### PR TITLE
feat(api): add failed-payment credential cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@ When documentation is needed, always use the official latest documentation.
 - Do not modify auto-generated `package.json` dependency versions from framework scaffolds (Nest/Next generators).
 - Use `@latest`/`latest` only when manually adding a new dependency or explicitly updating dependencies by hand.
 
+## Prisma migration rule for AI agents
+- Do not hand-write standalone SQL migration files by default.
+- When a Prisma schema change requires a migration, update `schema.prisma` first and then ask the user to run `pnpm db:migrate:dev --name <migration_name>` manually.
+- If a generated migration needs review, inspect the produced `migration.sql` after generation instead of prewriting it by hand.
+
 ## Command execution rule for AI agents
 - Prefer `pnpx` instead of `pnpm dlx` for one-off CLI execution in general.
 - If execution is blocked by network/sandbox/permission issues, explicitly ask for human intervention and wait for guidance/approval before retrying repeatedly.

--- a/apps/api/src/modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case.spec.ts
@@ -1,0 +1,64 @@
+import type { OrderRepositoryPort } from '@modules/orders/application/ports/order-repository.port';
+import { ClearOrderCredentialsUseCase } from '@modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case';
+import { Order } from '@modules/orders/domain/order.entity';
+import { OrderNotFoundError } from '@modules/orders/domain/order.errors';
+
+class InMemoryOrderRepository implements OrderRepositoryPort {
+	private readonly orders = new Map<string, Order>();
+
+	async findById(id: string): Promise<Order | null> {
+		return this.orders.get(id) ?? null;
+	}
+
+	async save(order: Order): Promise<void> {
+		this.orders.set(order.id, order);
+	}
+
+	insert(order: Order): void {
+		this.orders.set(order.id, order);
+	}
+}
+
+describe('ClearOrderCredentialsUseCase', () => {
+	it('removes stored credentials from an order', async () => {
+		const repository = new InMemoryOrderRepository();
+		const order = Order.create('order-1');
+		order.confirmPayment();
+		order.setCredentials({
+			login: 'login',
+			summonerName: 'summoner',
+			password: 'secret',
+		});
+		repository.insert(order);
+
+		const useCase = new ClearOrderCredentialsUseCase(repository);
+		await useCase.execute({ orderId: 'order-1' });
+
+		const savedOrder = await repository.findById('order-1');
+		expect(savedOrder?.credentials).toBeNull();
+	});
+
+	it('is idempotent when credentials are already absent', async () => {
+		const repository = new InMemoryOrderRepository();
+		const order = Order.create('order-2');
+		order.confirmPayment();
+		repository.insert(order);
+
+		const useCase = new ClearOrderCredentialsUseCase(repository);
+		await expect(
+			useCase.execute({ orderId: 'order-2' }),
+		).resolves.toBeUndefined();
+
+		const savedOrder = await repository.findById('order-2');
+		expect(savedOrder?.credentials).toBeNull();
+	});
+
+	it('throws when order does not exist', async () => {
+		const repository = new InMemoryOrderRepository();
+		const useCase = new ClearOrderCredentialsUseCase(repository);
+
+		await expect(useCase.execute({ orderId: 'missing-order' })).rejects.toThrow(
+			OrderNotFoundError,
+		);
+	});
+});

--- a/apps/api/src/modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case.ts
@@ -1,0 +1,26 @@
+import {
+	ORDER_REPOSITORY_KEY,
+	type OrderRepositoryPort,
+} from '@modules/orders/application/ports/order-repository.port';
+import { OrderNotFoundError } from '@modules/orders/domain/order.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+type ClearOrderCredentialsInput = {
+	orderId: string;
+};
+
+@Injectable()
+export class ClearOrderCredentialsUseCase {
+	constructor(
+		@Inject(ORDER_REPOSITORY_KEY)
+		private readonly orderRepository: OrderRepositoryPort,
+	) {}
+
+	async execute(input: ClearOrderCredentialsInput): Promise<void> {
+		const order = await this.orderRepository.findById(input.orderId);
+		if (!order) throw new OrderNotFoundError();
+
+		order.clearCredentials();
+		await this.orderRepository.save(order);
+	}
+}

--- a/apps/api/src/modules/orders/domain/order.entity.ts
+++ b/apps/api/src/modules/orders/domain/order.entity.ts
@@ -117,6 +117,10 @@ export class Order {
 		this.currentCredentials = credentials;
 	}
 
+	clearCredentials(): void {
+		this.currentCredentials = null;
+	}
+
 	private transitionTo(nextStatus: OrderStatus): void {
 		const allowed = ALLOWED_TRANSITIONS[this.currentStatus];
 		if (!allowed.includes(nextStatus))

--- a/apps/api/src/modules/orders/orders.module.ts
+++ b/apps/api/src/modules/orders/orders.module.ts
@@ -3,6 +3,7 @@ import { AppSettingsModule } from '@app/common/settings/app-settings.module';
 import { ORDER_REPOSITORY_KEY } from '@modules/orders/application/ports/order-repository.port';
 import { AcceptOrderUseCase } from '@modules/orders/application/use-cases/accept-order/accept-order.use-case';
 import { CancelOrderUseCase } from '@modules/orders/application/use-cases/cancel-order/cancel-order.use-case';
+import { ClearOrderCredentialsUseCase } from '@modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case';
 import { CompleteOrderUseCase } from '@modules/orders/application/use-cases/complete-order/complete-order.use-case';
 import { CreateOrderUseCase } from '@modules/orders/application/use-cases/create-order/create-order.use-case';
 import { GetOrderUseCase } from '@modules/orders/application/use-cases/get-order/get-order.use-case';
@@ -30,9 +31,14 @@ import { Module } from '@nestjs/common';
 		AcceptOrderUseCase,
 		RejectOrderUseCase,
 		CancelOrderUseCase,
+		ClearOrderCredentialsUseCase,
 		CompleteOrderUseCase,
 		SaveOrderCredentialsUseCase,
 	],
-	exports: [ORDER_REPOSITORY_KEY, MarkOrderAsPaidUseCase],
+	exports: [
+		ORDER_REPOSITORY_KEY,
+		MarkOrderAsPaidUseCase,
+		ClearOrderCredentialsUseCase,
+	],
 })
 export class OrdersModule {}

--- a/apps/api/src/modules/payments/application/ports/order-credential-cleanup.port.ts
+++ b/apps/api/src/modules/payments/application/ports/order-credential-cleanup.port.ts
@@ -1,0 +1,7 @@
+export const ORDER_CREDENTIAL_CLEANUP_PORT_KEY = Symbol(
+	'ORDER_CREDENTIAL_CLEANUP_PORT_KEY',
+);
+
+export interface OrderCredentialCleanupPort {
+	clearCredentials(orderId: string): Promise<void>;
+}

--- a/apps/api/src/modules/payments/application/use-cases/fail-payment/fail-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/fail-payment/fail-payment.use-case.spec.ts
@@ -1,0 +1,97 @@
+import type { OrderCredentialCleanupPort } from '@modules/payments/application/ports/order-credential-cleanup.port';
+import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
+import { FailPaymentUseCase } from '@modules/payments/application/use-cases/fail-payment/fail-payment.use-case';
+import { Payment } from '@modules/payments/domain/payment.entity';
+import { PaymentNotFoundError } from '@modules/payments/domain/payment.errors';
+
+class InMemoryPaymentRepository implements PaymentRepositoryPort {
+	private readonly payments = new Map<string, Payment>();
+
+	async findById(id: string): Promise<Payment | null> {
+		return this.payments.get(id) ?? null;
+	}
+
+	async findByOrderId(orderId: string): Promise<Payment | null> {
+		for (const payment of this.payments.values()) {
+			if (payment.orderId === orderId) return payment;
+		}
+
+		return null;
+	}
+
+	async save(payment: Payment): Promise<void> {
+		this.payments.set(payment.id, payment);
+	}
+
+	insert(payment: Payment): void {
+		this.payments.set(payment.id, payment);
+	}
+}
+
+class InMemoryOrderCredentialCleanupPort implements OrderCredentialCleanupPort {
+	readonly orderIds: string[] = [];
+
+	async clearCredentials(orderId: string): Promise<void> {
+		this.orderIds.push(orderId);
+	}
+}
+
+describe('FailPaymentUseCase', () => {
+	it('fails a payment and clears related order credentials', async () => {
+		const paymentRepository = new InMemoryPaymentRepository();
+		const orderCredentialCleanupPort = new InMemoryOrderCredentialCleanupPort();
+		paymentRepository.insert(
+			Payment.create({
+				id: 'payment-1',
+				orderId: 'order-1',
+				grossAmount: 100,
+			}),
+		);
+
+		const useCase = new FailPaymentUseCase(
+			paymentRepository,
+			orderCredentialCleanupPort,
+		);
+		await useCase.execute({ paymentId: 'payment-1' });
+
+		const savedPayment = await paymentRepository.findById('payment-1');
+		expect(savedPayment?.status).toBe('failed');
+		expect(orderCredentialCleanupPort.orderIds).toEqual(['order-1']);
+	});
+
+	it('is idempotent when payment is already failed', async () => {
+		const paymentRepository = new InMemoryPaymentRepository();
+		const orderCredentialCleanupPort = new InMemoryOrderCredentialCleanupPort();
+		const payment = Payment.create({
+			id: 'payment-2',
+			orderId: 'order-2',
+			grossAmount: 100,
+		});
+		payment.fail();
+		paymentRepository.insert(payment);
+
+		const useCase = new FailPaymentUseCase(
+			paymentRepository,
+			orderCredentialCleanupPort,
+		);
+		await useCase.execute({ paymentId: 'payment-2' });
+
+		const savedPayment = await paymentRepository.findById('payment-2');
+		expect(savedPayment?.status).toBe('failed');
+		expect(orderCredentialCleanupPort.orderIds).toEqual(['order-2']);
+	});
+
+	it('throws when payment does not exist', async () => {
+		const paymentRepository = new InMemoryPaymentRepository();
+		const orderCredentialCleanupPort = new InMemoryOrderCredentialCleanupPort();
+		const useCase = new FailPaymentUseCase(
+			paymentRepository,
+			orderCredentialCleanupPort,
+		);
+
+		await expect(
+			useCase.execute({ paymentId: 'missing-payment' }),
+		).rejects.toThrow(PaymentNotFoundError);
+		expect(orderCredentialCleanupPort.orderIds).toEqual([]);
+	});
+});

--- a/apps/api/src/modules/payments/application/use-cases/fail-payment/fail-payment.use-case.ts
+++ b/apps/api/src/modules/payments/application/use-cases/fail-payment/fail-payment.use-case.ts
@@ -1,0 +1,33 @@
+import {
+	ORDER_CREDENTIAL_CLEANUP_PORT_KEY,
+	type OrderCredentialCleanupPort,
+} from '@modules/payments/application/ports/order-credential-cleanup.port';
+import {
+	PAYMENT_REPOSITORY_KEY,
+	type PaymentRepositoryPort,
+} from '@modules/payments/application/ports/payment-repository.port';
+import { PaymentNotFoundError } from '@modules/payments/domain/payment.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+type FailPaymentInput = {
+	paymentId: string;
+};
+
+@Injectable()
+export class FailPaymentUseCase {
+	constructor(
+		@Inject(PAYMENT_REPOSITORY_KEY)
+		private readonly paymentRepository: PaymentRepositoryPort,
+		@Inject(ORDER_CREDENTIAL_CLEANUP_PORT_KEY)
+		private readonly orderCredentialCleanupPort: OrderCredentialCleanupPort,
+	) {}
+
+	async execute(input: FailPaymentInput): Promise<void> {
+		const payment = await this.paymentRepository.findById(input.paymentId);
+		if (!payment) throw new PaymentNotFoundError();
+
+		payment.fail();
+		await this.paymentRepository.save(payment);
+		await this.orderCredentialCleanupPort.clearCredentials(payment.orderId);
+	}
+}

--- a/apps/api/src/modules/payments/domain/payment-status.ts
+++ b/apps/api/src/modules/payments/domain/payment-status.ts
@@ -2,4 +2,5 @@ export enum PaymentStatus {
 	AWAITING_CONFIRMATION = 'awaiting_confirmation',
 	HELD = 'held',
 	RELEASED = 'released',
+	FAILED = 'failed',
 }

--- a/apps/api/src/modules/payments/domain/payment.entity.spec.ts
+++ b/apps/api/src/modules/payments/domain/payment.entity.spec.ts
@@ -3,6 +3,7 @@ import { Payment } from '@modules/payments/domain/payment.entity';
 import {
 	PaymentAmountInvalidError,
 	PaymentHoldReleaseNotAllowedError,
+	PaymentInvalidTransitionError,
 } from '@modules/payments/domain/payment.errors';
 
 describe('Payment', () => {
@@ -87,5 +88,42 @@ describe('Payment', () => {
 
 		expect(() => payment.releaseHold(OrderStatus.COMPLETED)).not.toThrow();
 		expect(payment.status).toBe('released');
+	});
+
+	it('fails a payment before confirmation', () => {
+		const payment = Payment.create({
+			id: 'payment-6',
+			orderId: 'order-6',
+			grossAmount: 100,
+		});
+
+		payment.fail();
+
+		expect(payment.status).toBe('failed');
+	});
+
+	it('treats repeated failure as idempotent', () => {
+		const payment = Payment.create({
+			id: 'payment-7',
+			orderId: 'order-7',
+			grossAmount: 100,
+		});
+
+		payment.fail();
+
+		expect(() => payment.fail()).not.toThrow();
+		expect(payment.status).toBe('failed');
+	});
+
+	it('blocks failing a released payment', () => {
+		const payment = Payment.create({
+			id: 'payment-8',
+			orderId: 'order-8',
+			grossAmount: 100,
+		});
+		payment.confirm();
+		payment.releaseHold(OrderStatus.COMPLETED);
+
+		expect(() => payment.fail()).toThrow(PaymentInvalidTransitionError);
 	});
 });

--- a/apps/api/src/modules/payments/domain/payment.entity.ts
+++ b/apps/api/src/modules/payments/domain/payment.entity.ts
@@ -9,9 +9,13 @@ import { PaymentStatus } from '@modules/payments/domain/payment-status';
 type AllowedTransitionMap = Record<PaymentStatus, readonly PaymentStatus[]>;
 
 const ALLOWED_TRANSITIONS: AllowedTransitionMap = {
-	[PaymentStatus.AWAITING_CONFIRMATION]: [PaymentStatus.HELD],
+	[PaymentStatus.AWAITING_CONFIRMATION]: [
+		PaymentStatus.HELD,
+		PaymentStatus.FAILED,
+	],
 	[PaymentStatus.HELD]: [PaymentStatus.RELEASED],
 	[PaymentStatus.RELEASED]: [],
+	[PaymentStatus.FAILED]: [],
 };
 
 export class Payment {
@@ -69,6 +73,12 @@ export class Payment {
 			return;
 
 		this.transitionTo(PaymentStatus.HELD);
+	}
+
+	fail(): void {
+		if (this.currentStatus === PaymentStatus.FAILED) return;
+
+		this.transitionTo(PaymentStatus.FAILED);
 	}
 
 	releaseHold(orderStatus: OrderStatus): void {

--- a/apps/api/src/modules/payments/infrastructure/adapters/order-credential-cleanup-from-orders.adapter.ts
+++ b/apps/api/src/modules/payments/infrastructure/adapters/order-credential-cleanup-from-orders.adapter.ts
@@ -1,0 +1,16 @@
+import { ClearOrderCredentialsUseCase } from '@modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case';
+import type { OrderCredentialCleanupPort } from '@modules/payments/application/ports/order-credential-cleanup.port';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class OrderCredentialCleanupFromOrdersAdapter
+	implements OrderCredentialCleanupPort
+{
+	constructor(
+		private readonly clearOrderCredentialsUseCase: ClearOrderCredentialsUseCase,
+	) {}
+
+	async clearCredentials(orderId: string): Promise<void> {
+		await this.clearOrderCredentialsUseCase.execute({ orderId });
+	}
+}

--- a/apps/api/src/modules/payments/infrastructure/repositories/prisma-payment.repository.spec.ts
+++ b/apps/api/src/modules/payments/infrastructure/repositories/prisma-payment.repository.spec.ts
@@ -14,6 +14,7 @@ describe('PrismaPaymentRepository', () => {
 		const prisma = {
 			payment: {
 				findUnique,
+				findFirst: jest.fn(),
 				upsert,
 			},
 		};
@@ -55,6 +56,7 @@ describe('PrismaPaymentRepository', () => {
 		const prisma = {
 			payment: {
 				findUnique: jest.fn().mockResolvedValue(null),
+				findFirst: jest.fn(),
 				upsert: jest.fn(),
 			},
 		};
@@ -73,6 +75,7 @@ describe('PrismaPaymentRepository', () => {
 					grossAmount: 100,
 					boosterAmount: 70,
 				}),
+				findFirst: jest.fn(),
 				upsert: jest.fn(),
 			},
 		};
@@ -81,5 +84,29 @@ describe('PrismaPaymentRepository', () => {
 		await expect(repository.findById('payment-1')).rejects.toThrow(
 			'Invalid payment status persisted: invalid_status',
 		);
+	});
+
+	it('rehydrates failed payment status', async () => {
+		const prisma = {
+			payment: {
+				findUnique: jest.fn().mockResolvedValue({
+					id: 'payment-failed-1',
+					orderId: 'order-failed-1',
+					status: 'failed',
+					grossAmount: 100,
+					boosterAmount: 70,
+				}),
+				findFirst: jest.fn(),
+				upsert: jest.fn(),
+			},
+		};
+		const repository = new PrismaPaymentRepository(prisma as never);
+
+		await expect(
+			repository.findById('payment-failed-1'),
+		).resolves.toMatchObject({
+			id: 'payment-failed-1',
+			status: 'failed',
+		});
 	});
 });

--- a/apps/api/src/modules/payments/payments.module.ts
+++ b/apps/api/src/modules/payments/payments.module.ts
@@ -1,15 +1,18 @@
 import { PrismaService } from '@app/common/prisma/prisma.service';
 import { AppSettingsModule } from '@app/common/settings/app-settings.module';
 import { OrdersModule } from '@modules/orders/orders.module';
+import { ORDER_CREDENTIAL_CLEANUP_PORT_KEY } from '@modules/payments/application/ports/order-credential-cleanup.port';
 import { ORDER_PAYMENT_CONFIRMATION_PORT_KEY } from '@modules/payments/application/ports/order-payment-confirmation.port';
 import { ORDER_STATUS_PORT_KEY } from '@modules/payments/application/ports/order-status.port';
 import { PAYMENT_REPOSITORY_KEY } from '@modules/payments/application/ports/payment-repository.port';
 import { PROCESSED_WEBHOOK_EVENT_PORT_KEY } from '@modules/payments/application/ports/processed-webhook-event.port';
 import { ConfirmPaymentUseCase } from '@modules/payments/application/use-cases/confirm-payment/confirm-payment.use-case';
 import { CreatePaymentUseCase } from '@modules/payments/application/use-cases/create-payment/create-payment.use-case';
+import { FailPaymentUseCase } from '@modules/payments/application/use-cases/fail-payment/fail-payment.use-case';
 import { GetPaymentUseCase } from '@modules/payments/application/use-cases/get-payment/get-payment.use-case';
 import { HandlePaymentConfirmedWebhookUseCase } from '@modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case';
 import { ReleasePaymentHoldUseCase } from '@modules/payments/application/use-cases/release-payment-hold/release-payment-hold.use-case';
+import { OrderCredentialCleanupFromOrdersAdapter } from '@modules/payments/infrastructure/adapters/order-credential-cleanup-from-orders.adapter';
 import { OrderPaymentConfirmationFromOrdersAdapter } from '@modules/payments/infrastructure/adapters/order-payment-confirmation-from-orders.adapter';
 import { OrderStatusFromPrismaAdapter } from '@modules/payments/infrastructure/adapters/order-status-from-prisma.adapter';
 import { PrismaPaymentRepository } from '@modules/payments/infrastructure/repositories/prisma-payment.repository';
@@ -42,9 +45,15 @@ import { Module } from '@nestjs/common';
 			provide: ORDER_PAYMENT_CONFIRMATION_PORT_KEY,
 			useExisting: OrderPaymentConfirmationFromOrdersAdapter,
 		},
+		OrderCredentialCleanupFromOrdersAdapter,
+		{
+			provide: ORDER_CREDENTIAL_CLEANUP_PORT_KEY,
+			useExisting: OrderCredentialCleanupFromOrdersAdapter,
+		},
 		CreatePaymentUseCase,
 		GetPaymentUseCase,
 		ConfirmPaymentUseCase,
+		FailPaymentUseCase,
 		HandlePaymentConfirmedWebhookUseCase,
 		ReleasePaymentHoldUseCase,
 	],

--- a/apps/api/src/modules/payments/presentation/payments.controller.ts
+++ b/apps/api/src/modules/payments/presentation/payments.controller.ts
@@ -5,6 +5,7 @@ import {
 } from '@app/common/http/domain-error.mapper';
 import { ConfirmPaymentUseCase } from '@modules/payments/application/use-cases/confirm-payment/confirm-payment.use-case';
 import { CreatePaymentUseCase } from '@modules/payments/application/use-cases/create-payment/create-payment.use-case';
+import { FailPaymentUseCase } from '@modules/payments/application/use-cases/fail-payment/fail-payment.use-case';
 import { GetPaymentUseCase } from '@modules/payments/application/use-cases/get-payment/get-payment.use-case';
 import { HandlePaymentConfirmedWebhookUseCase } from '@modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case';
 import { ReleasePaymentHoldUseCase } from '@modules/payments/application/use-cases/release-payment-hold/release-payment-hold.use-case';
@@ -44,6 +45,7 @@ export class PaymentsController {
 		private readonly createPaymentUseCase: CreatePaymentUseCase,
 		private readonly getPaymentUseCase: GetPaymentUseCase,
 		private readonly confirmPaymentUseCase: ConfirmPaymentUseCase,
+		private readonly failPaymentUseCase: FailPaymentUseCase,
 		private readonly handlePaymentConfirmedWebhookUseCase: HandlePaymentConfirmedWebhookUseCase,
 		private readonly releasePaymentHoldUseCase: ReleasePaymentHoldUseCase,
 	) {}
@@ -84,6 +86,16 @@ export class PaymentsController {
 	): Promise<{ success: true }> {
 		return this.executeMutation(() =>
 			this.confirmPaymentUseCase.execute({ paymentId }),
+		);
+	}
+
+	@Post(':paymentId/fail')
+	@HttpCode(200)
+	async fail(
+		@Param('paymentId') paymentId: string,
+	): Promise<{ success: true }> {
+		return this.executeMutation(() =>
+			this.failPaymentUseCase.execute({ paymentId }),
 		);
 	}
 

--- a/apps/api/test/integration-db/payments/payments.db.integration.spec.ts
+++ b/apps/api/test/integration-db/payments/payments.db.integration.spec.ts
@@ -113,4 +113,39 @@ describe('Payments module integration (db)', () => {
 			},
 		);
 	});
+
+	it('fails a payment, clears credentials, and keeps the negative state idempotent', async () => {
+		await ordersController.create({ orderId: 'order-db-5' });
+		await paymentsController.create({
+			paymentId: 'payment-db-5',
+			orderId: 'order-db-5',
+			grossAmount: 100,
+		});
+		await ordersController.confirmPayment('order-db-5');
+		await ordersController.saveCredentials('order-db-5', {
+			login: 'login-db',
+			summonerName: 'summoner-db',
+			password: 'secret-db',
+			confirmPassword: 'secret-db',
+		});
+
+		await expect(paymentsController.fail('payment-db-5')).resolves.toEqual({
+			success: true,
+		});
+		await expect(paymentsController.fail('payment-db-5')).resolves.toEqual({
+			success: true,
+		});
+
+		await expect(paymentsController.get('payment-db-5')).resolves.toMatchObject(
+			{
+				id: 'payment-db-5',
+				status: 'failed',
+			},
+		);
+		await expect(
+			prisma.orderCredentials.findUnique({
+				where: { orderId: 'order-db-5' },
+			}),
+		).resolves.toBeNull();
+	});
 });

--- a/apps/api/test/integration/payments/payments.integration.spec.ts
+++ b/apps/api/test/integration/payments/payments.integration.spec.ts
@@ -124,4 +124,25 @@ describe('Payments module integration', () => {
 			status: 'held',
 		});
 	});
+
+	it('fails a payment and keeps the negative state idempotent', async () => {
+		await ordersController.create({ orderId: 'order-5' });
+		await paymentsController.create({
+			paymentId: 'payment-5',
+			orderId: 'order-5',
+			grossAmount: 100,
+		});
+
+		await expect(paymentsController.fail('payment-5')).resolves.toEqual({
+			success: true,
+		});
+		await expect(paymentsController.fail('payment-5')).resolves.toEqual({
+			success: true,
+		});
+
+		await expect(paymentsController.get('payment-5')).resolves.toMatchObject({
+			id: 'payment-5',
+			status: 'failed',
+		});
+	});
 });

--- a/packages/database/prisma/migrations/20260309205601_add_failed_payment_status/migration.sql
+++ b/packages/database/prisma/migrations/20260309205601_add_failed_payment_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "PaymentStatus" ADD VALUE 'failed';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -24,6 +24,7 @@ enum PaymentStatus {
   awaiting_confirmation
   held
   released
+  failed
 }
 
 enum ServiceType {
@@ -83,7 +84,6 @@ model Order {
   status           OrderStatus  @default(awaiting_payment)
   serviceType      ServiceType?
   
-  // FR-013 fields
   currentLeague    String?
   currentDivision  String?
   currentLp        Int?


### PR DESCRIPTION
## Summary

Adds an explicit negative payment finalization path that clears stored order credentials and persists the resulting failed payment state, covering the least-retention requirement for sensitive credentials.

Closes: https://github.com/caiohenrqq/elonew/issues/8

---

## What Changed

Describe the implementation at a technical level.

- Added a failed payment lifecycle path plus a dedicated fail-payment use-case
- Modified orders/payments integration so negative payment finalization clears stored order credentials through an explicit cleanup boundary
- Added integration, DB integration, and domain/use-case coverage for failed-payment cleanup and idempotent retry behavior

---

## Why

Explain the reason behind the change.

Issue #8 requires explicit credential cleanup when payment is not confirmed or fails or rolls back, and NFR-007 requires least-retention for sensitive data. The existing flow blocked pre-confirm credential storage but did not provide an explicit negative-finalization cleanup path after credentials had been stored.

---

## Implementation Notes

Important details reviewers should know:

- Design choices
  The persisted negative payment state is `failed`, and payments trigger credential cleanup through an orders-side cleanup use-case exposed behind a payments port adapter.
- Trade-offs
  The API currently exposes the negative-finalization path as `fail`, which is concrete and simple but narrower in wording than a more generic negative-finalization name.
- Edge cases handled
  Failing a payment is idempotent, credential cleanup is idempotent, and DB-backed verification confirms credentials are removed after repeated failure calls.
- Constraints or assumptions
  This issue does not add queue-based timeout orchestration; it implements the failure path and cleanup behavior needed by the issue scope.

---

## Testing

How this was validated.

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manually tested

Steps to reproduce if needed:

1. Create a payment and confirm or store order credentials.
2. Call the payment failure path.
3. Verify the payment status becomes `failed` and stored order credentials are removed.

---

## Screenshots (if UI)

None.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated where needed
- [x] Lint and type checks pass
- [x] Documentation updated if required
- [x] No breaking changes

---

## Breaking Changes

None.
