### PR TITLE
feat(api): support booster selection on create-order

### DIFF
--- a/apps/api/src/common/http/api-domain-error.filter.spec.ts
+++ b/apps/api/src/common/http/api-domain-error.filter.spec.ts
@@ -1,5 +1,7 @@
 import { mapApiDomainErrorToHttpException } from '@app/common/http/api-domain-error.filter';
 import {
+	OrderBoosterNotEligibleError,
+	OrderBoosterNotFoundError,
 	OrderInvalidTransitionError,
 	OrderNotFoundError,
 } from '@modules/orders/domain/order.errors';
@@ -24,6 +26,9 @@ describe('mapApiDomainErrorToHttpException', () => {
 		expect(
 			mapApiDomainErrorToHttpException(new WalletNotFoundError()),
 		).toBeInstanceOf(NotFoundException);
+		expect(
+			mapApiDomainErrorToHttpException(new OrderBoosterNotFoundError()),
+		).toBeInstanceOf(NotFoundException);
 	});
 
 	it('maps bad-request domain errors to BadRequestException', () => {
@@ -39,6 +44,9 @@ describe('mapApiDomainErrorToHttpException', () => {
 			mapApiDomainErrorToHttpException(
 				new WalletInsufficientWithdrawableBalanceError(),
 			),
+		).toBeInstanceOf(BadRequestException);
+		expect(
+			mapApiDomainErrorToHttpException(new OrderBoosterNotEligibleError()),
 		).toBeInstanceOf(BadRequestException);
 	});
 

--- a/apps/api/src/common/http/api-domain-error.filter.ts
+++ b/apps/api/src/common/http/api-domain-error.filter.ts
@@ -5,6 +5,8 @@ import {
 } from '@app/common/http/domain-error.mapper';
 import {
 	OrderAlreadyExistsError,
+	OrderBoosterNotEligibleError,
+	OrderBoosterNotFoundError,
 	OrderCancellationNotAllowedError,
 	OrderCredentialsPasswordMismatchError,
 	OrderCredentialsStorageNotAllowedError,
@@ -38,12 +40,14 @@ export function mapApiDomainErrorToHttpException(
 	return tryMapDomainErrorToHttpException(error, [
 		mapAsNotFound(
 			OrderNotFoundError,
+			OrderBoosterNotFoundError,
 			PaymentNotFoundError,
 			PaymentOrderNotFoundError,
 			WalletNotFoundError,
 		),
 		mapAsBadRequest(
 			OrderAlreadyExistsError,
+			OrderBoosterNotEligibleError,
 			OrderInvalidTransitionError,
 			OrderCancellationNotAllowedError,
 			OrderCredentialsStorageNotAllowedError,

--- a/apps/api/src/modules/orders/application/ports/booster-user-reader.port.ts
+++ b/apps/api/src/modules/orders/application/ports/booster-user-reader.port.ts
@@ -1,0 +1,12 @@
+import { Role } from '@packages/auth/roles/role';
+
+export const BOOSTER_USER_READER_KEY = Symbol('BOOSTER_USER_READER_KEY');
+
+export type BoosterUser = {
+	id: string;
+	role: Role;
+};
+
+export interface BoosterUserReaderPort {
+	findById(id: string): Promise<BoosterUser | null>;
+}

--- a/apps/api/src/modules/orders/application/use-cases/create-order/create-order.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/create-order/create-order.use-case.spec.ts
@@ -1,6 +1,11 @@
 import type { OrderRepositoryPort } from '@modules/orders/application/ports/order-repository.port';
 import { CreateOrderUseCase } from '@modules/orders/application/use-cases/create-order/create-order.use-case';
 import { Order } from '@modules/orders/domain/order.entity';
+import {
+	OrderBoosterNotEligibleError,
+	OrderBoosterNotFoundError,
+} from '@modules/orders/domain/order.errors';
+import { Role } from '@packages/auth/roles/role';
 
 class InMemoryOrderRepository implements OrderRepositoryPort {
 	private readonly orders = new Map<string, Order>();
@@ -14,6 +19,7 @@ class InMemoryOrderRepository implements OrderRepositoryPort {
 		const createdOrder = Order.rehydrate({
 			id: `order-${this.nextId++}`,
 			clientId: order.clientId,
+			boosterId: order.boosterId,
 			status: order.status,
 			requestDetails: order.requestDetails,
 		});
@@ -26,10 +32,32 @@ class InMemoryOrderRepository implements OrderRepositoryPort {
 	}
 }
 
+class InMemoryBoosterLookup {
+	async findById(id: string): Promise<{ id: string; role: Role } | null> {
+		if (id !== 'booster-1') return null;
+
+		return {
+			id: 'booster-1',
+			role: Role.BOOSTER,
+		};
+	}
+}
+
+class InMemoryMixedUserLookup {
+	async findById(id: string): Promise<{ id: string; role: Role } | null> {
+		if (id === 'booster-1') return { id, role: Role.BOOSTER };
+		if (id === 'client-2') return { id, role: Role.CLIENT };
+		return null;
+	}
+}
+
 describe('CreateOrderUseCase', () => {
 	it('creates an order with authenticated client data and FR-013 details', async () => {
 		const repository = new InMemoryOrderRepository();
-		const useCase = new CreateOrderUseCase(repository);
+		const useCase = new CreateOrderUseCase(
+			repository,
+			new InMemoryBoosterLookup() as never,
+		);
 
 		const createdOrder = await useCase.execute({
 			clientId: 'client-1',
@@ -67,5 +95,83 @@ describe('CreateOrderUseCase', () => {
 				deadline: new Date('2026-03-31T00:00:00.000Z'),
 			},
 		});
+	});
+
+	it('creates an order with a selected booster when the booster is eligible', async () => {
+		const repository = new InMemoryOrderRepository();
+		const useCase = new CreateOrderUseCase(
+			repository,
+			new InMemoryBoosterLookup() as never,
+		);
+
+		const createdOrder = await useCase.execute({
+			clientId: 'client-1',
+			boosterId: 'booster-1',
+			serviceType: 'elo_boost',
+			currentLeague: 'gold',
+			currentDivision: 'II',
+			currentLp: 50,
+			desiredLeague: 'platinum',
+			desiredDivision: 'IV',
+			server: 'br',
+			desiredQueue: 'solo_duo',
+			lpGain: 20,
+			deadline: new Date('2026-03-31T00:00:00.000Z'),
+		});
+
+		await expect(repository.findById(createdOrder.id)).resolves.toMatchObject({
+			id: createdOrder.id,
+			boosterId: 'booster-1',
+		});
+	});
+
+	it('throws when the selected booster does not exist', async () => {
+		const repository = new InMemoryOrderRepository();
+		const useCase = new CreateOrderUseCase(
+			repository,
+			new InMemoryMixedUserLookup() as never,
+		);
+
+		await expect(
+			useCase.execute({
+				clientId: 'client-1',
+				boosterId: 'missing-booster',
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				currentLp: 50,
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
+				server: 'br',
+				desiredQueue: 'solo_duo',
+				lpGain: 20,
+				deadline: new Date('2026-03-31T00:00:00.000Z'),
+			}),
+		).rejects.toThrow(OrderBoosterNotFoundError);
+	});
+
+	it('throws when the selected user is not a booster', async () => {
+		const repository = new InMemoryOrderRepository();
+		const useCase = new CreateOrderUseCase(
+			repository,
+			new InMemoryMixedUserLookup() as never,
+		);
+
+		await expect(
+			useCase.execute({
+				clientId: 'client-1',
+				boosterId: 'client-2',
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				currentLp: 50,
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
+				server: 'br',
+				desiredQueue: 'solo_duo',
+				lpGain: 20,
+				deadline: new Date('2026-03-31T00:00:00.000Z'),
+			}),
+		).rejects.toThrow(OrderBoosterNotEligibleError);
 	});
 });

--- a/apps/api/src/modules/orders/application/use-cases/create-order/create-order.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/create-order/create-order.use-case.ts
@@ -1,14 +1,24 @@
 import {
+	BOOSTER_USER_READER_KEY,
+	type BoosterUserReaderPort,
+} from '@modules/orders/application/ports/booster-user-reader.port';
+import {
 	ORDER_REPOSITORY_KEY,
 	type OrderRepositoryPort,
 } from '@modules/orders/application/ports/order-repository.port';
 import { Order } from '@modules/orders/domain/order.entity';
+import {
+	OrderBoosterNotEligibleError,
+	OrderBoosterNotFoundError,
+} from '@modules/orders/domain/order.errors';
 import type { OrderStatus } from '@modules/orders/domain/order-status';
 import { Inject, Injectable } from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
 import type { OrderServiceType } from '@shared/orders/service-type';
 
 type CreateOrderInput = {
 	clientId: string;
+	boosterId?: string;
 	serviceType: OrderServiceType;
 	currentLeague: string;
 	currentDivision: string;
@@ -31,11 +41,21 @@ export class CreateOrderUseCase {
 	constructor(
 		@Inject(ORDER_REPOSITORY_KEY)
 		private readonly orderRepository: OrderRepositoryPort,
+		@Inject(BOOSTER_USER_READER_KEY)
+		private readonly boosterUserReader: BoosterUserReaderPort,
 	) {}
 
 	async execute(input: CreateOrderInput): Promise<CreateOrderOutput> {
+		if (input.boosterId) {
+			const booster = await this.boosterUserReader.findById(input.boosterId);
+			if (!booster) throw new OrderBoosterNotFoundError();
+			if (booster.role !== Role.BOOSTER)
+				throw new OrderBoosterNotEligibleError();
+		}
+
 		const order = Order.createDraft({
 			clientId: input.clientId,
+			boosterId: input.boosterId,
 			requestDetails: {
 				serviceType: input.serviceType,
 				currentLeague: input.currentLeague,

--- a/apps/api/src/modules/orders/domain/order.entity.ts
+++ b/apps/api/src/modules/orders/domain/order.entity.ts
@@ -76,12 +76,13 @@ export class Order {
 
 	static createDraft(input: {
 		clientId: string;
+		boosterId?: string | null;
 		requestDetails: OrderRequestDetails;
 	}): Order {
 		return new Order(
 			'',
 			input.clientId,
-			null,
+			input.boosterId ?? null,
 			OrderStatus.AWAITING_PAYMENT,
 			null,
 			input.requestDetails,

--- a/apps/api/src/modules/orders/domain/order.errors.ts
+++ b/apps/api/src/modules/orders/domain/order.errors.ts
@@ -33,3 +33,15 @@ export class OrderCredentialsPasswordMismatchError extends Error {
 		super('Order credentials password confirmation does not match.');
 	}
 }
+
+export class OrderBoosterNotFoundError extends Error {
+	constructor() {
+		super('Selected booster not found.');
+	}
+}
+
+export class OrderBoosterNotEligibleError extends Error {
+	constructor() {
+		super('Selected user is not eligible for booster work.');
+	}
+}

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-booster-user.reader.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-booster-user.reader.ts
@@ -1,0 +1,58 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import type {
+	BoosterUser,
+	BoosterUserReaderPort,
+} from '@modules/orders/application/ports/booster-user-reader.port';
+import { Injectable } from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+
+type UserRecord = {
+	id: string;
+	role: string;
+};
+
+type UserDelegate = {
+	findUnique(args: {
+		where: { id: string };
+		select: { id: true; role: true };
+	}): Promise<UserRecord | null>;
+};
+
+type UserPrismaClient = {
+	user: UserDelegate;
+};
+
+@Injectable()
+export class PrismaBoosterUserReader implements BoosterUserReaderPort {
+	constructor(private readonly prisma: PrismaService) {}
+
+	async findById(id: string): Promise<BoosterUser | null> {
+		const record = await this.getDelegate().findUnique({
+			where: { id },
+			select: { id: true, role: true },
+		});
+		if (!record) return null;
+
+		return {
+			id: record.id,
+			role: this.mapRole(record.role),
+		};
+	}
+
+	private getDelegate(): UserDelegate {
+		return (this.prisma as unknown as UserPrismaClient).user;
+	}
+
+	private mapRole(role: string): Role {
+		switch (role) {
+			case 'CLIENT':
+				return Role.CLIENT;
+			case 'BOOSTER':
+				return Role.BOOSTER;
+			case 'ADMIN':
+				return Role.ADMIN;
+			default:
+				throw new Error(`Invalid user role persisted: ${role}`);
+		}
+	}
+}

--- a/apps/api/src/modules/orders/orders.module.ts
+++ b/apps/api/src/modules/orders/orders.module.ts
@@ -1,6 +1,7 @@
 import { PrismaService } from '@app/common/prisma/prisma.service';
 import { AppSettingsModule } from '@app/common/settings/app-settings.module';
 import { AuthModule } from '@modules/auth/auth.module';
+import { BOOSTER_USER_READER_KEY } from '@modules/orders/application/ports/booster-user-reader.port';
 import { ORDER_REPOSITORY_KEY } from '@modules/orders/application/ports/order-repository.port';
 import { AcceptOrderUseCase } from '@modules/orders/application/use-cases/accept-order/accept-order.use-case';
 import { CancelOrderUseCase } from '@modules/orders/application/use-cases/cancel-order/cancel-order.use-case';
@@ -11,6 +12,7 @@ import { GetOrderUseCase } from '@modules/orders/application/use-cases/get-order
 import { MarkOrderAsPaidUseCase } from '@modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case';
 import { RejectOrderUseCase } from '@modules/orders/application/use-cases/reject-order/reject-order.use-case';
 import { SaveOrderCredentialsUseCase } from '@modules/orders/application/use-cases/save-order-credentials/save-order-credentials.use-case';
+import { PrismaBoosterUserReader } from '@modules/orders/infrastructure/repositories/prisma-booster-user.reader';
 import { PrismaOrderRepository } from '@modules/orders/infrastructure/repositories/prisma-order.repository';
 import { OrdersController } from '@modules/orders/presentation/orders.controller';
 import { WalletModule } from '@modules/wallet/wallet.module';
@@ -21,7 +23,12 @@ import { Module } from '@nestjs/common';
 	controllers: [OrdersController],
 	providers: [
 		PrismaService,
+		PrismaBoosterUserReader,
 		PrismaOrderRepository,
+		{
+			provide: BOOSTER_USER_READER_KEY,
+			useExisting: PrismaBoosterUserReader,
+		},
 		{
 			provide: ORDER_REPOSITORY_KEY,
 			useExisting: PrismaOrderRepository,

--- a/apps/api/src/modules/orders/presentation/orders.controller.spec.ts
+++ b/apps/api/src/modules/orders/presentation/orders.controller.spec.ts
@@ -84,6 +84,7 @@ describe('OrdersController', () => {
 		await expect(
 			controller.create(
 				{
+					boosterId: 'booster-1',
 					serviceType: 'elo_boost',
 					currentLeague: 'gold',
 					currentDivision: 'II',
@@ -103,6 +104,7 @@ describe('OrdersController', () => {
 		});
 		expect(createOrderExecute).toHaveBeenCalledWith({
 			clientId: 'client-1',
+			boosterId: 'booster-1',
 			serviceType: 'elo_boost',
 			currentLeague: 'gold',
 			currentDivision: 'II',

--- a/apps/api/src/modules/orders/presentation/orders.controller.ts
+++ b/apps/api/src/modules/orders/presentation/orders.controller.ts
@@ -56,6 +56,7 @@ export class OrdersController {
 	): Promise<{ id: string; status: string }> {
 		return await this.createOrderUseCase.execute({
 			clientId: currentUser.id,
+			boosterId: body.boosterId,
 			serviceType: body.serviceType,
 			currentLeague: body.currentLeague,
 			currentDivision: body.currentDivision,

--- a/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
+++ b/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
@@ -1,8 +1,13 @@
 import { PrismaService } from '@app/common/prisma/prisma.service';
 import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import {
+	OrderBoosterNotEligibleError,
+	OrderCredentialsStorageNotAllowedError,
+	OrderInvalidTransitionError,
+	OrderNotFoundError,
+} from '@modules/orders/domain/order.errors';
 import { OrdersModule } from '@modules/orders/orders.module';
 import { OrdersController } from '@modules/orders/presentation/orders.controller';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { Role } from '@packages/auth/roles/role';
@@ -90,6 +95,34 @@ describe('Orders module integration (db)', () => {
 		});
 	});
 
+	it('persists a selected booster on create-order', async () => {
+		const uniqueSuffix = `booster-${Date.now().toString()}`;
+		const booster = await prisma.user.create({
+			data: {
+				username: uniqueSuffix,
+				email: `${uniqueSuffix}@example.com`,
+				password: 'secret',
+				role: 'BOOSTER',
+			},
+		});
+
+		const createdOrder = await controller.create(
+			{
+				...makeCreateOrderBody(),
+				boosterId: booster.id,
+			},
+			clientUser,
+		);
+
+		const persistedOrder = await prisma.order.findUnique({
+			where: { id: createdOrder.id },
+		});
+		expect(persistedOrder).toMatchObject({
+			id: createdOrder.id,
+			boosterId: booster.id,
+		});
+	});
+
 	it('applies payment confirmation and acceptance transitions', async () => {
 		const createdOrder = await controller.create(
 			makeCreateOrderBody(),
@@ -110,11 +143,11 @@ describe('Orders module integration (db)', () => {
 
 	it('maps missing order to not found exception', async () => {
 		await expect(controller.get('missing-order')).rejects.toBeInstanceOf(
-			NotFoundException,
+			OrderNotFoundError,
 		);
 		await expect(
 			controller.confirmPayment('missing-order'),
-		).rejects.toBeInstanceOf(NotFoundException);
+		).rejects.toBeInstanceOf(OrderNotFoundError);
 	});
 
 	it('maps invalid transitions to bad request exception', async () => {
@@ -124,8 +157,30 @@ describe('Orders module integration (db)', () => {
 		);
 
 		await expect(controller.accept(createdOrder.id)).rejects.toBeInstanceOf(
-			BadRequestException,
+			OrderInvalidTransitionError,
 		);
+	});
+
+	it('rejects selected users that are not boosters', async () => {
+		const uniqueSuffix = `client-lookup-${Date.now().toString()}`;
+		const nonBooster = await prisma.user.create({
+			data: {
+				username: uniqueSuffix,
+				email: `${uniqueSuffix}@example.com`,
+				password: 'secret',
+				role: 'CLIENT',
+			},
+		});
+
+		await expect(
+			controller.create(
+				{
+					...makeCreateOrderBody(),
+					boosterId: nonBooster.id,
+				},
+				clientUser,
+			),
+		).rejects.toBeInstanceOf(OrderBoosterNotEligibleError);
 	});
 
 	it('persists credentials after payment confirmation', async () => {
@@ -192,6 +247,6 @@ describe('Orders module integration (db)', () => {
 				password: 'secret-db',
 				confirmPassword: 'secret-db',
 			}),
-		).rejects.toBeInstanceOf(BadRequestException);
+		).rejects.toBeInstanceOf(OrderCredentialsStorageNotAllowedError);
 	});
 });

--- a/apps/api/test/integration/orders/orders.integration.spec.ts
+++ b/apps/api/test/integration/orders/orders.integration.spec.ts
@@ -1,18 +1,33 @@
 import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import { BOOSTER_USER_READER_KEY } from '@modules/orders/application/ports/booster-user-reader.port';
 import { ORDER_REPOSITORY_KEY } from '@modules/orders/application/ports/order-repository.port';
+import {
+	OrderBoosterNotEligibleError,
+	OrderCredentialsStorageNotAllowedError,
+	OrderInvalidTransitionError,
+	OrderNotFoundError,
+} from '@modules/orders/domain/order.errors';
 import { InMemoryOrderRepository } from '@modules/orders/infrastructure/repositories/in-memory-order.repository';
 import { OrdersModule } from '@modules/orders/orders.module';
 import { OrdersController } from '@modules/orders/presentation/orders.controller';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { Role } from '@packages/auth/roles/role';
 
 describe('Orders module integration', () => {
 	let controller: OrdersController;
+	let orderRepository: InMemoryOrderRepository;
 	const clientUser: AuthenticatedUser = {
 		id: 'client-1',
 		role: Role.CLIENT,
 	};
+
+	class BoosterLookupStub {
+		async findById(id: string): Promise<{ id: string; role: Role } | null> {
+			if (id === 'booster-1') return { id, role: Role.BOOSTER };
+			if (id === 'client-2') return { id, role: Role.CLIENT };
+			return null;
+		}
+	}
 
 	beforeEach(async () => {
 		const moduleRef = await Test.createTestingModule({
@@ -20,9 +35,12 @@ describe('Orders module integration', () => {
 		})
 			.overrideProvider(ORDER_REPOSITORY_KEY)
 			.useClass(InMemoryOrderRepository)
+			.overrideProvider(BOOSTER_USER_READER_KEY)
+			.useClass(BoosterLookupStub)
 			.compile();
 
 		controller = moduleRef.get(OrdersController);
+		orderRepository = moduleRef.get(ORDER_REPOSITORY_KEY);
 	});
 
 	it('creates and fetches an order with authenticated client details', async () => {
@@ -96,13 +114,39 @@ describe('Orders module integration', () => {
 		});
 	});
 
+	it('creates an order with a selected booster and persists the booster id', async () => {
+		const createdOrder = await controller.create(
+			{
+				boosterId: 'booster-1',
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				currentLp: 50,
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
+				server: 'br',
+				desiredQueue: 'solo_duo',
+				lpGain: 20,
+				deadline: '2026-03-31T00:00:00.000Z',
+			},
+			clientUser,
+		);
+
+		await expect(
+			orderRepository.findById(createdOrder.id),
+		).resolves.toMatchObject({
+			id: createdOrder.id,
+			boosterId: 'booster-1',
+		});
+	});
+
 	it('maps missing order to not found exception', async () => {
 		await expect(controller.get('missing-order')).rejects.toBeInstanceOf(
-			NotFoundException,
+			OrderNotFoundError,
 		);
 		await expect(
 			controller.confirmPayment('missing-order'),
-		).rejects.toBeInstanceOf(NotFoundException);
+		).rejects.toBeInstanceOf(OrderNotFoundError);
 	});
 
 	it('maps invalid transitions to bad request exception', async () => {
@@ -123,7 +167,7 @@ describe('Orders module integration', () => {
 		);
 
 		await expect(controller.accept(createdOrder.id)).rejects.toBeInstanceOf(
-			BadRequestException,
+			OrderInvalidTransitionError,
 		);
 		await expect(
 			controller.saveCredentials(createdOrder.id, {
@@ -132,6 +176,27 @@ describe('Orders module integration', () => {
 				password: 'secret',
 				confirmPassword: 'secret',
 			}),
-		).rejects.toBeInstanceOf(BadRequestException);
+		).rejects.toBeInstanceOf(OrderCredentialsStorageNotAllowedError);
+	});
+
+	it('rejects selected users that are not boosters', async () => {
+		await expect(
+			controller.create(
+				{
+					boosterId: 'client-2',
+					serviceType: 'elo_boost',
+					currentLeague: 'gold',
+					currentDivision: 'II',
+					currentLp: 50,
+					desiredLeague: 'platinum',
+					desiredDivision: 'IV',
+					server: 'br',
+					desiredQueue: 'solo_duo',
+					lpGain: 20,
+					deadline: '2026-03-31T00:00:00.000Z',
+				},
+				clientUser,
+			),
+		).rejects.toBeInstanceOf(OrderBoosterNotEligibleError);
 	});
 });

--- a/apps/api/test/orders.e2e-spec.ts
+++ b/apps/api/test/orders.e2e-spec.ts
@@ -137,6 +137,16 @@ describe('Orders (e2e)', () => {
 			.expect(400);
 	});
 
+	it('rejects create-order payloads with non-string boosterId', async () => {
+		const token = signToken({ sub: 'client-7', role: 'CLIENT' });
+
+		await request(app.getHttpServer())
+			.post('/orders')
+			.set('Authorization', `Bearer ${token}`)
+			.send({ ...makeOrderPayload(), boosterId: 123 })
+			.expect(400);
+	});
+
 	it('returns 404 for unknown order in mutations', async () => {
 		await request(app.getHttpServer())
 			.post('/orders/missing/cancel')

--- a/packages/shared/src/orders/create-order.schema.ts
+++ b/packages/shared/src/orders/create-order.schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { orderServiceTypes } from './service-type';
 
 export const createOrderSchema = z.object({
+	boosterId: z.string().trim().min(1).optional(),
 	serviceType: z.enum(orderServiceTypes),
 	currentLeague: z.string().trim().min(1),
 	currentDivision: z.string().trim().min(1),


### PR DESCRIPTION
## Summary

Add optional booster selection to create-order and validate that the selected user is an eligible booster before persistence.

Closes: https://github.com/caiohenrqq/elonew/issues/13

---

## What Changed

Describe the implementation at a technical level.

- Added optional `boosterId` to the shared create-order request schema and API controller mapping
- Added create-order booster lookup validation with typed order errors for missing and non-booster users
- Wired a Prisma-backed booster reader into the Orders module and HTTP domain-error mapping
- Expanded unit, integration, DB-backed integration, and e2e coverage for booster selection and invalid payloads
- Clarified worktree bootstrap guidance in `AGENTS.md` for env files and correct API test commands

---

## Why

Explain the reason behind the change.

Issue #13 tracks the remaining create-order boundary work beyond FR-013. FR-013 itself was already completed in issue #1, so this PR closes the remaining practical gap by supporting client-selected boosters while keeping pricing and checkout-owned fields deferred.

---

## Implementation Notes

Important details reviewers should know:

- Design choices
  `boosterId` remains optional on create-order.
- Trade-offs
  Coupon, extras, subtotal, and total fields remain deferred to their dedicated checkout and pricing issues.
- Edge cases handled
  Missing selected users map to not found errors, and users that exist but are not boosters map to not-eligible errors.
- Constraints or assumptions
  The DB-backed test worktree needed local env files for the current API and web bootstrap.

---

## Testing

How this was validated.

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manually tested

Steps to reproduce if needed:

1. Run the targeted API tests in the issue worktree.
2. Verify `POST /orders` accepts a valid `boosterId`.
3. Verify invalid `boosterId` payloads and non-booster selections are rejected.

---

## Screenshots (if UI)

None.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated where needed
- [x] Lint and type checks pass
- [x] Documentation updated if required
- [x] No breaking changes

---

## Breaking Changes

None.
