### PR TITLE
test(api): add same-quote checkout concurrency coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Official docs to use:
 - [ ] Add or expand controller/integration coverage for accepted payloads and invalid-request `BadRequestException` mapping wherever boundary validation is introduced.
 
 ## Changelog
+- Added DB-backed concurrency coverage proving same-quote double-submit creates exactly one order, consumes the quote once, and fails the loser with the expected quote-used error without requiring checkout implementation changes.
 - Added a dedicated order-checkout boundary so quote consumption and order creation are linked transactionally in Prisma, while tests now cover quote rollback on create failure and cross-client payment reads with ownership-aware in-memory payment lookup.
 - Replaced stateless order quote tokens with persisted one-time client-owned quotes, enforced client ownership on order/payment reads and payment creation, and added security regression coverage for quote reuse and cross-client checkout access.
 - Added quote-driven subtotal calculation for orders, persisted quote-derived pricing on created orders, and changed payment creation to derive the charge amount from the persisted order total so checkout pays the amount the user saw.

--- a/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
+++ b/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
@@ -6,6 +6,7 @@ import {
 	OrderInvalidTransitionError,
 	OrderNotFoundError,
 } from '@modules/orders/domain/order.errors';
+import { OrderQuoteAlreadyUsedError } from '@modules/orders/domain/order-pricing.errors';
 import { OrdersModule } from '@modules/orders/orders.module';
 import { OrdersController } from '@modules/orders/presentation/orders.controller';
 import type { TestingModule } from '@nestjs/testing';
@@ -140,6 +141,72 @@ describe('Orders module integration (db)', () => {
 			id: createdOrder.id,
 			boosterId: booster.id,
 		});
+	});
+
+	it('creates exactly one order when the same quote is submitted concurrently', async () => {
+		const quote = await controller.quote(
+			{
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				currentLp: 50,
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
+				server: 'br',
+				desiredQueue: 'solo_duo',
+				lpGain: 20,
+				deadline: '2026-03-31T00:00:00.000Z',
+			},
+			clientUser,
+		);
+
+		const results = await Promise.allSettled([
+			controller.create({ quoteId: quote.quoteId }, clientUser),
+			controller.create({ quoteId: quote.quoteId }, clientUser),
+		]);
+
+		const successfulResults = results.filter(
+			(
+				result,
+			): result is PromiseFulfilledResult<{
+				id: string;
+				status: string;
+				subtotal: number | null;
+				totalAmount: number | null;
+				discountAmount: number;
+			}> => result.status === 'fulfilled',
+		);
+		const failedResults = results.filter(
+			(result): result is PromiseRejectedResult => result.status === 'rejected',
+		);
+
+		expect(successfulResults).toHaveLength(1);
+		expect(failedResults).toHaveLength(1);
+		expect(successfulResults[0]?.value).toMatchObject({
+			id: expect.any(String),
+			status: 'awaiting_payment',
+			subtotal: 25.2,
+			totalAmount: 25.2,
+			discountAmount: 0,
+		});
+		expect(failedResults[0]?.reason).toBeInstanceOf(OrderQuoteAlreadyUsedError);
+
+		const persistedOrders = await prisma.order.findMany({
+			where: { clientId: clientUser.id },
+			orderBy: { createdAt: 'asc' },
+		});
+		expect(persistedOrders).toHaveLength(1);
+		expect(persistedOrders[0]?.id).toBe(successfulResults[0]?.value.id);
+
+		const persistedQuote = await prisma.orderQuote.findUnique({
+			where: { id: quote.quoteId },
+		});
+		expect(persistedQuote).toMatchObject({
+			id: quote.quoteId,
+			clientId: clientUser.id,
+			orderId: successfulResults[0]?.value.id,
+		});
+		expect(persistedQuote?.consumedAt).toBeInstanceOf(Date);
 	});
 
 	it('applies payment confirmation and acceptance transitions', async () => {


### PR DESCRIPTION
## Summary

Add DB-backed regression coverage proving same-quote concurrent checkout creates only one order and cleanly rejects the losing request.

Closes: https://github.com/caiohenrqq/elonew/issues/35

---

## What Changed

Describe the implementation at a technical level.

- Added an orders DB integration test that submits the same `quoteId` concurrently through the real checkout path
- Asserted the winning and losing request contract, including `OrderQuoteAlreadyUsedError` for the loser
- Verified the final persisted state contains exactly one consumed quote and one linked order
- Documented the completed issue work in `AGENTS.md`

---

## Why

Explain the reason behind the change.

Issue #35 required proof that quote consumption is safe under concurrent same-quote submission. The existing checkout transaction already behaved correctly, so the issue closed with regression coverage instead of production code hardening.

---

## Implementation Notes

Important details reviewers should know:

- Design choices
  Coverage stays at the controller plus OrdersModule DB integration layer so the real Prisma transaction and repository wiring are exercised.
- Trade-offs
  No production code changed because the race condition did not reproduce under the real checkout transaction.
- Edge cases handled
  The test verifies no orphan second order row is created and that the consumed quote points at the winning order.
- Constraints or assumptions
  Controlled failure for the losing request is asserted at the domain-error level, not through HTTP transport mapping.

---

## Testing

How this was validated.

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manually tested

Steps to reproduce if needed:

1. Run `pnpm --filter api test:integration:db -- orders.db.integration.spec.ts`.
2. Run `pnpm biome:fix:all`.
3. Run `pnpm --filter api exec tsc --noEmit -p tsconfig.json`.

---

## Screenshots (if UI)

None.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated where needed
- [x] Lint and type checks pass
- [x] Documentation updated if required
- [x] No breaking changes

---

## Breaking Changes

None.
