### PR TITLE
test(api): harden Mercado Pago methods & payment coverage

### DIFF
--- a/.agent/CHANGELOG.md
+++ b/.agent/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+- Hardened the Mercado Pago Checkout Pro adapter against unsupported runtime payment methods and added explicit backend coverage proving `credit_card`, `pix`, and `boleto` are intentionally supported through adapter configuration and payment e2e flows without introducing frontend scope.
 - Removed the remaining webhook dedupe redundancy by keying processed Mercado Pago notifications only by provider notification resource id, then added alias-replay regressions proving the same notification cannot be reprocessed by switching between `payment` and `payment.updated`.
 - Hardened the Mercado Pago webhook path by rejecting unsupported topics before provider reconciliation and switching replay/idempotency tracking from the unsigned body event id to a provider-bound key derived from topic plus notification resource id, with unit, integration, e2e, and DB-backed verification rerun afterward.
 - Completed issue `#22` verification by regenerating Prisma Client after the gateway-field migration, then rerunning the DB-backed payments lane so Mercado Pago checkout creation, webhook reconciliation, and persisted gateway metadata are now covered across unit, integration, e2e, and DB tests.

--- a/.agent/CONTINUITY.md
+++ b/.agent/CONTINUITY.md
@@ -3,6 +3,8 @@
 ## [PLANS]
 - 2026-03-21T08:08:03-04:00 [USER] Keep `AGENTS.md` concise, preserve key repo rules, reduce overlap, and reorder issue execution so issue review and planning happen before branch creation.
 - 2026-03-21T08:46:08-04:00 [USER] Implement issue `#22` for real Mercado Pago initiation and verified webhook reconciliation after the planning pass.
+- 2026-03-25T13:27:46-04:00 [USER] Request an implementation plan for `FR-025` and `FR-026` based on the current `docs/requirements.md` scope and existing Mercado Pago integration progress.
+- 2026-03-25T13:27:46-04:00 [USER] Implement the backend-only `FR-025` and `FR-026` completion plan in the direction established by merged PR `#43`, with frontend explicitly deferred.
 
 ## [DECISIONS]
 - 2026-03-21T08:08:03-04:00 [CODE] `AGENTS.md` now uses a consolidated structure with a global operating baseline first and repo-specific rules second.
@@ -11,6 +13,7 @@
 - 2026-03-21T08:08:03-04:00 [CODE] `AGENTS.md` now explicitly distinguishes `.agent/CONTINUITY.md` as current-state handoff context and `.agent/CHANGELOG.md` as durable project history.
 - 2026-03-21T08:46:08-04:00 [CODE] Issue `#22` implementation uses Checkout Pro preference creation, a provider-specific Mercado Pago webhook route, and approved-first reconciliation while still persisting non-approved provider statuses.
 - 2026-03-21T08:46:08-04:00 [CODE] `packages/integrations` is now being formalized as `@packages/integrations` with the official Mercado Pago SDK instead of continuing the old alias-only pattern.
+- 2026-03-25T13:27:46-04:00 [CODE] `FR-025` and `FR-026` follow PR `#43`'s backend-only Checkout Pro direction; remaining work should harden the existing adapter and cover the supported methods rather than introduce frontend flows or broaden webhook state transitions.
 
 ## [PROGRESS]
 - 2026-03-21T08:08:03-04:00 [TOOL] Rewrote `AGENTS.md` to merge the requested baseline with existing repo-specific rules and added this continuity file scaffold.
@@ -23,6 +26,8 @@
 - 2026-03-21T09:16:13-04:00 [TOOL] Installed the external `nestjs-doctor` skill from `RoloBits/nestjs-doctor` path `packages/nestjs-doctor/skill` into `~/.codex/skills/nestjs-doctor`.
 - 2026-03-21T13:03Z [TOOL] Hardened the Mercado Pago webhook path against replay-by-body-id and unsupported topics, then reran webhook-focused unit/integration/e2e coverage plus `pnpm biome:fix:all`, API typecheck, and the DB-backed payments lane.
 - 2026-03-21T13:07Z [TOOL] Closed the remaining alias-replay gap by removing topic from the processed webhook key, added alias-replay regressions, and reran the webhook-focused, e2e, formatting, typecheck, and DB-backed payments verification lanes.
+- 2026-03-25T13:27:46-04:00 [TOOL] Added Mercado Pago adapter coverage for `credit_card`, `pix`, and `boleto` Checkout Pro preference exclusions plus a runtime guard against unsupported payment methods, then added API e2e coverage for `credit_card` and `boleto` payment creation.
+- 2026-03-25T13:27:46-04:00 [TOOL] Reran `pnpm biome:fix:all`, `pnpm --filter api exec tsc --noEmit -p tsconfig.json`, `pnpm --filter api exec jest --runInBand test/integration/payments/mercadopago-sdk.integration.spec.ts`, `pnpm --filter api exec jest --runInBand test/integration/payments/payments.integration.spec.ts`, and `pnpm --filter api test:e2e -- payments.e2e-spec.ts`.
 
 ## [DISCOVERIES]
 - 2026-03-21T08:08:03-04:00 [TOOL] `.agent/CONTINUITY.md` did not exist before this change.
@@ -32,6 +37,7 @@
 - 2026-03-21T12:50Z [TOOL] Applying the migration was not sufficient for DB verification; Prisma Client also had to be regenerated locally before the repository/test code recognized `gatewayReferenceId` and `gatewayStatusDetail`.
 - 2026-03-21T13:03Z [CODE] Using Mercado Pago body `id` as the dedupe key was unsafe because the signature manifest does not cover that field; replay protection is now keyed from provider-bound `topic + notificationResourceId` instead.
 - 2026-03-21T13:07Z [CODE] Including topic in the processed webhook key was still redundant and unsafe because Mercado Pago signature verification does not bind topic; the canonical replay key is now only the provider notification resource id.
+- 2026-03-25T13:27:46-04:00 [TOOL] After PR `#43`, the backend already handled Mercado Pago Checkout Pro initiation and approved-first webhook reconciliation; the practical remaining `FR-025`/`FR-026` gap was explicit method hardening and coverage, not new payment flow wiring.
 
 ## [OUTCOMES]
 - 2026-03-21T08:08:03-04:00 [CODE] Workspace guidance now has an explicit continuity mechanism and a less overlapping issue-start workflow.
@@ -42,3 +48,4 @@
 - 2026-03-21T09:16:13-04:00 [TOOL] `nestjs-doctor` is now available as a local Codex skill for future turns after client restart.
 - 2026-03-21T13:03Z [CODE] The webhook route now rejects unsupported Mercado Pago topics before provider fetch and ignores replayed deliveries even when the unsigned body event id changes.
 - 2026-03-21T13:07Z [CODE] The webhook route now also ignores alias-based replays where the same Mercado Pago notification is delivered once as `payment` and once as `payment.updated`.
+- 2026-03-25T13:27:46-04:00 [CODE] The backend now fails fast if an unsupported payment method reaches the Mercado Pago adapter at runtime, and automated coverage now proves intentional support for `credit_card`, `pix`, and `boleto` without adding frontend scope.

--- a/apps/api/test/integration/payments/mercadopago-sdk.integration.spec.ts
+++ b/apps/api/test/integration/payments/mercadopago-sdk.integration.spec.ts
@@ -32,6 +32,144 @@ describe('MercadoPagoSdkAdapter', () => {
 		});
 	});
 
+	it('creates a credit-card checkout preference with only card-compatible payment types enabled', async () => {
+		const create = jest.fn().mockResolvedValue({
+			id: 'pref-credit-card',
+			init_point: 'https://mercadopago.test/checkout/pref-credit-card',
+		});
+		const adapter = new MercadoPagoSdkAdapter({
+			accessToken: 'mp-access-token',
+			webhookSecret: 'webhook-secret',
+			webhookUrl: 'https://example.com/payments/webhooks/mercadopago',
+			preferenceClient: {
+				create,
+			},
+			paymentClient: {
+				get: jest.fn(),
+			},
+		});
+
+		await adapter.createPayment({
+			paymentId: 'payment-credit-card',
+			orderId: 'order-credit-card',
+			amount: 100,
+			paymentMethod: 'credit_card',
+		});
+
+		expect(create).toHaveBeenCalledWith({
+			body: expect.objectContaining({
+				payment_methods: {
+					excluded_payment_types: [
+						{ id: 'ticket' },
+						{ id: 'bank_transfer' },
+						{ id: 'atm' },
+					],
+				},
+			}),
+		});
+	});
+
+	it('creates a pix checkout preference with only pix-compatible payment types enabled', async () => {
+		const create = jest.fn().mockResolvedValue({
+			id: 'pref-pix',
+			init_point: 'https://mercadopago.test/checkout/pref-pix',
+		});
+		const adapter = new MercadoPagoSdkAdapter({
+			accessToken: 'mp-access-token',
+			webhookSecret: 'webhook-secret',
+			webhookUrl: 'https://example.com/payments/webhooks/mercadopago',
+			preferenceClient: {
+				create,
+			},
+			paymentClient: {
+				get: jest.fn(),
+			},
+		});
+
+		await adapter.createPayment({
+			paymentId: 'payment-pix',
+			orderId: 'order-pix',
+			amount: 100,
+			paymentMethod: 'pix',
+		});
+
+		expect(create).toHaveBeenCalledWith({
+			body: expect.objectContaining({
+				payment_methods: {
+					excluded_payment_types: [
+						{ id: 'credit_card' },
+						{ id: 'debit_card' },
+						{ id: 'ticket' },
+						{ id: 'atm' },
+					],
+				},
+			}),
+		});
+	});
+
+	it('creates a boleto checkout preference with only boleto-compatible payment types enabled', async () => {
+		const create = jest.fn().mockResolvedValue({
+			id: 'pref-boleto',
+			init_point: 'https://mercadopago.test/checkout/pref-boleto',
+		});
+		const adapter = new MercadoPagoSdkAdapter({
+			accessToken: 'mp-access-token',
+			webhookSecret: 'webhook-secret',
+			webhookUrl: 'https://example.com/payments/webhooks/mercadopago',
+			preferenceClient: {
+				create,
+			},
+			paymentClient: {
+				get: jest.fn(),
+			},
+		});
+
+		await adapter.createPayment({
+			paymentId: 'payment-boleto',
+			orderId: 'order-boleto',
+			amount: 100,
+			paymentMethod: 'boleto',
+		});
+
+		expect(create).toHaveBeenCalledWith({
+			body: expect.objectContaining({
+				payment_methods: {
+					excluded_payment_types: [
+						{ id: 'credit_card' },
+						{ id: 'debit_card' },
+						{ id: 'bank_transfer' },
+						{ id: 'atm' },
+					],
+				},
+			}),
+		});
+	});
+
+	it('rejects unsupported payment methods before calling Mercado Pago', async () => {
+		const create = jest.fn();
+		const adapter = new MercadoPagoSdkAdapter({
+			accessToken: 'mp-access-token',
+			webhookSecret: 'webhook-secret',
+			webhookUrl: 'https://example.com/payments/webhooks/mercadopago',
+			preferenceClient: {
+				create,
+			},
+			paymentClient: {
+				get: jest.fn(),
+			},
+		});
+
+		await expect(
+			adapter.createPayment({
+				paymentId: 'payment-invalid',
+				orderId: 'order-invalid',
+				amount: 100,
+				paymentMethod: 'cash' as 'pix',
+			}),
+		).rejects.toThrow('Unsupported Mercado Pago payment method: cash');
+		expect(create).not.toHaveBeenCalled();
+	});
+
 	it('fetches a payment notification and maps provider fields to the internal contract', async () => {
 		const adapter = new MercadoPagoSdkAdapter({
 			accessToken: 'mp-access-token',

--- a/apps/api/test/payments.e2e-spec.ts
+++ b/apps/api/test/payments.e2e-spec.ts
@@ -190,6 +190,52 @@ describe('Payments (e2e)', () => {
 			.execute();
 	});
 
+	it('creates a Mercado Pago checkout for credit-card payments', async () => {
+		const token = signToken({ sub: 'client-credit-card', role: 'CLIENT' });
+		const createdOrder = await createQuotedOrder(token);
+
+		await requestHttp(app)
+			.post('/payments')
+			.set('Authorization', `Bearer ${token}`)
+			.send({
+				orderId: createdOrder.id,
+				paymentMethod: 'credit_card',
+			})
+			.expect(201)
+			.expect(({ body }) => {
+				expect(body).toMatchObject({
+					orderId: createdOrder.id,
+					status: 'awaiting_confirmation',
+					paymentMethod: 'credit_card',
+					checkoutUrl: expect.stringContaining('/checkout/'),
+				});
+			})
+			.execute();
+	});
+
+	it('creates a Mercado Pago checkout for boleto payments', async () => {
+		const token = signToken({ sub: 'client-boleto', role: 'CLIENT' });
+		const createdOrder = await createQuotedOrder(token);
+
+		await requestHttp(app)
+			.post('/payments')
+			.set('Authorization', `Bearer ${token}`)
+			.send({
+				orderId: createdOrder.id,
+				paymentMethod: 'boleto',
+			})
+			.expect(201)
+			.expect(({ body }) => {
+				expect(body).toMatchObject({
+					orderId: createdOrder.id,
+					status: 'awaiting_confirmation',
+					paymentMethod: 'boleto',
+					checkoutUrl: expect.stringContaining('/checkout/'),
+				});
+			})
+			.execute();
+	});
+
 	it('rejects creating a second payment for the same order', async () => {
 		const token = signToken({
 			sub: 'client-duplicate-payment',

--- a/packages/integrations/src/mercadopago/mercadopago-sdk.adapter.ts
+++ b/packages/integrations/src/mercadopago/mercadopago-sdk.adapter.ts
@@ -55,6 +55,10 @@ function buildExcludedPaymentTypes(
 				{ id: 'bank_transfer' },
 				{ id: 'atm' },
 			];
+		default:
+			throw new Error(
+				`Unsupported Mercado Pago payment method: ${input.paymentMethod}`,
+			);
 	}
 }
 


### PR DESCRIPTION
## Summary

Harden Mercado Pago payment-method handling and expand backend payment coverage for the supported Checkout Pro methods.

Closes: #45

---

## What Changed

Describe the implementation at a technical level.

- Modified the Mercado Pago SDK adapter to fail fast if an unsupported payment method reaches the runtime boundary
- Added integration coverage for Checkout Pro preference configuration across `credit_card`, `pix`, and `boleto`
- Added e2e coverage proving the payments API creates Mercado Pago checkout flows for `credit_card` and `boleto`

---

## Why

Explain the reason behind the change.

The Mercado Pago backend flow was already in place after the previous payment integration work, but the supported method behavior was not explicitly protected by tests across all required methods. This PR keeps the issue backend-only and aligns the implementation with the current Mercado Pago Checkout Pro direction already established in the codebase.

---

## Implementation Notes

Important details reviewers should know:

- The change does not introduce any frontend/payment UX scope
- The adapter guard is defensive only; request-boundary validation already rejects unsupported methods before runtime
- The new tests focus on intentional support for the three required methods instead of expanding the payment state machine

---

## Testing

How this was validated.

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manually tested

Steps to reproduce if needed:

1. `pnpm biome:fix:all`
2. `pnpm --filter api exec tsc --noEmit -p tsconfig.json`
3. `pnpm --filter api exec jest --runInBand test/integration/payments/mercadopago-sdk.integration.spec.ts`
4. `pnpm --filter api exec jest --runInBand test/integration/payments/payments.integration.spec.ts`
5. `pnpm --filter api test:e2e -- payments.e2e-spec.ts`

---

## Screenshots (if UI)

Before / After.

None.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated where needed
- [x] Lint and type checks pass
- [x] Documentation updated if required
- [x] No breaking changes

---

## Breaking Changes

Describe any breaking behavior changes.

If none:

None.
