### PR TITLE
feat(notifications): add in-platform dashboard notifications

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { AdminModule } from '@modules/admin/admin.module';
 import { AuthModule } from '@modules/auth/auth.module';
 import { ChatModule } from '@modules/chat/chat.module';
+import { NotificationsModule } from '@modules/notifications/notifications.module';
 import { OrdersModule } from '@modules/orders/orders.module';
 import { PaymentsModule } from '@modules/payments/payments.module';
 import { SystemModule } from '@modules/system/system.module';
@@ -19,6 +20,7 @@ import { AppSettingsModule } from './common/settings/app-settings.module';
 		AdminModule,
 		AuthModule,
 		ChatModule,
+		NotificationsModule,
 		OrdersModule,
 		PaymentsModule,
 		SystemModule,

--- a/apps/api/src/common/http/api-domain-error.filter.ts
+++ b/apps/api/src/common/http/api-domain-error.filter.ts
@@ -31,6 +31,10 @@ import {
 	ChatOrderNotFoundError,
 } from '@modules/chat/domain/chat.errors';
 import {
+	NotificationNotFoundError,
+	NotificationReadConflictError,
+} from '@modules/notifications/domain/notification.errors';
+import {
 	OrderAlreadyExistsError,
 	OrderBoosterNotEligibleError,
 	OrderBoosterNotFoundError,
@@ -143,6 +147,7 @@ export function mapApiDomainErrorToHttpException(
 			PaymentNotFoundError,
 			PaymentOrderNotFoundError,
 			WalletNotFoundError,
+			NotificationNotFoundError,
 		),
 		mapAsBadRequest(
 			OrderAlreadyExistsError,
@@ -171,6 +176,7 @@ export function mapApiDomainErrorToHttpException(
 			AdminGovernanceReasonRequiredError,
 		),
 		mapAsConflict(OrderPricingVersionActiveConflictError, ChatNotWritableError),
+		mapAsConflict(NotificationReadConflictError),
 	]);
 }
 

--- a/apps/api/src/modules/chat/application/ports/chat-repository.port.ts
+++ b/apps/api/src/modules/chat/application/ports/chat-repository.port.ts
@@ -1,4 +1,5 @@
 import type { Role } from '@packages/auth/roles/role';
+import type { NotificationOutput } from '@packages/shared/notifications/notification.schema';
 
 export const CHAT_REPOSITORY_KEY = Symbol('CHAT_REPOSITORY_KEY');
 
@@ -23,6 +24,18 @@ export type ChatMessageRecord = {
 	createdAt: Date;
 };
 
+export type ChatNotificationWriteInput = {
+	recipientId: string;
+};
+
+export type ChatMessageWriteResult = {
+	message: ChatMessageRecord;
+	notification?: {
+		notification: NotificationOutput;
+		unreadCount: number;
+	};
+};
+
 export type ListChatMessagesInput = {
 	chatId: string;
 	limit: number;
@@ -42,5 +55,11 @@ export interface ChatRepositoryPort {
 		senderId: string;
 		content: string;
 	}): Promise<ChatMessageRecord>;
+	createMessageWithNotification(input: {
+		chatId: string;
+		senderId: string;
+		content: string;
+		notification?: ChatNotificationWriteInput;
+	}): Promise<ChatMessageWriteResult>;
 	listMessages(input: ListChatMessagesInput): Promise<ListChatMessagesOutput>;
 }

--- a/apps/api/src/modules/chat/application/use-cases/list-chat-messages/list-chat-messages.use-case.spec.ts
+++ b/apps/api/src/modules/chat/application/use-cases/list-chat-messages/list-chat-messages.use-case.spec.ts
@@ -1,5 +1,6 @@
 import type {
 	ChatMessageRecord,
+	ChatMessageWriteResult,
 	ChatOrderRecord,
 	ChatRepositoryPort,
 	ListChatMessagesInput,
@@ -29,6 +30,15 @@ class InMemoryChatRepository implements ChatRepositoryPort {
 		senderId: string;
 		content: string;
 	}): Promise<ChatMessageRecord> {
+		throw new Error('Not implemented.');
+	}
+
+	async createMessageWithNotification(_input: {
+		chatId: string;
+		senderId: string;
+		content: string;
+		notification?: { recipientId: string };
+	}): Promise<ChatMessageWriteResult> {
 		throw new Error('Not implemented.');
 	}
 

--- a/apps/api/src/modules/chat/application/use-cases/send-chat-message/send-chat-message.use-case.spec.ts
+++ b/apps/api/src/modules/chat/application/use-cases/send-chat-message/send-chat-message.use-case.spec.ts
@@ -1,5 +1,6 @@
 import type {
 	ChatMessageRecord,
+	ChatMessageWriteResult,
 	ChatOrderRecord,
 	ChatRepositoryPort,
 	ListChatMessagesInput,
@@ -11,11 +12,13 @@ import {
 	ChatNotWritableError,
 	ChatOrderNotFoundError,
 } from '@modules/chat/domain/chat.errors';
+import type { NotificationEventsPort } from '@modules/notifications/application/ports/notification-events.port';
 import { Role } from '@packages/auth/roles/role';
 
 class InMemoryChatRepository implements ChatRepositoryPort {
 	order: ChatOrderRecord | null = null;
 	readonly messages: ChatMessageRecord[] = [];
+	failNotificationPersistence = false;
 
 	async findOrderChat(_orderId: string): Promise<ChatOrderRecord | null> {
 		return this.order;
@@ -39,6 +42,18 @@ class InMemoryChatRepository implements ChatRepositoryPort {
 		senderId: string;
 		content: string;
 	}): Promise<ChatMessageRecord> {
+		return (await this.createMessageWithNotification(input)).message;
+	}
+
+	async createMessageWithNotification(input: {
+		chatId: string;
+		senderId: string;
+		content: string;
+		notification?: { recipientId: string };
+	}): Promise<ChatMessageWriteResult> {
+		if (input.notification && this.failNotificationPersistence)
+			throw new Error('notification persistence failed');
+
 		const message: ChatMessageRecord = {
 			id: `message-${this.messages.length + 1}`,
 			orderId: this.order?.orderId ?? 'order-1',
@@ -52,13 +67,75 @@ class InMemoryChatRepository implements ChatRepositoryPort {
 			createdAt: new Date('2026-05-08T12:00:00.000Z'),
 		};
 		this.messages.push(message);
-		return message;
+		return {
+			message,
+			...(input.notification
+				? {
+						notification: {
+							notification: {
+								id: `notification-${message.id}`,
+								type: 'CHAT_MESSAGE_CREATED' as const,
+								payload: {
+									type: 'CHAT_MESSAGE_CREATED' as const,
+									metadata: {
+										orderId: message.orderId,
+										chatMessageId: message.id,
+										senderId: message.sender.id,
+										senderUsername: message.sender.username,
+									},
+								},
+								readAt: null,
+								activityAt: message.createdAt.toISOString(),
+								createdAt: message.createdAt.toISOString(),
+								updatedAt: message.createdAt.toISOString(),
+							},
+							unreadCount: 1,
+						},
+					}
+				: {}),
+		};
 	}
 
 	async listMessages(
 		_input: ListChatMessagesInput,
 	): Promise<ListChatMessagesOutput> {
 		return { items: this.messages, nextCursor: null };
+	}
+}
+
+type NotificationUpdatedSpyEvent = {
+	notification: { id: string };
+	unreadCount: number;
+};
+
+type NotificationsReadAllSpyEvent = {
+	unreadCount: number;
+};
+
+class NotificationEventsSpy implements NotificationEventsPort {
+	readonly updated: Array<{
+		recipientId: string;
+		notificationId: string;
+		unreadCount: number;
+	}> = [];
+	readonly readAll: Array<{ recipientId: string; unreadCount: number }> = [];
+
+	emitNotificationUpdated(
+		recipientId: string,
+		event: NotificationUpdatedSpyEvent,
+	): void {
+		this.updated.push({
+			recipientId,
+			notificationId: event.notification.id,
+			unreadCount: event.unreadCount,
+		});
+	}
+
+	emitNotificationsReadAll(
+		recipientId: string,
+		event: NotificationsReadAllSpyEvent,
+	): void {
+		this.readAll.push({ recipientId, unreadCount: event.unreadCount });
 	}
 }
 
@@ -74,7 +151,8 @@ describe('SendChatMessageUseCase', () => {
 	it('persists a client message for an in-progress participant order', async () => {
 		const repository = new InMemoryChatRepository();
 		repository.order = makeWritableOrder();
-		const useCase = new SendChatMessageUseCase(repository);
+		const notifications = new NotificationEventsSpy();
+		const useCase = new SendChatMessageUseCase(repository, notifications);
 
 		const message = await useCase.execute({
 			orderId: 'order-1',
@@ -88,12 +166,20 @@ describe('SendChatMessageUseCase', () => {
 			chatId: 'chat-1',
 			content: 'Olá booster',
 		});
+		expect(notifications.updated).toEqual([
+			{
+				recipientId: 'booster-1',
+				notificationId: 'notification-message-1',
+				unreadCount: 1,
+			},
+		]);
 	});
 
 	it('persists a booster message for an assigned in-progress order', async () => {
 		const repository = new InMemoryChatRepository();
 		repository.order = makeWritableOrder();
-		const useCase = new SendChatMessageUseCase(repository);
+		const notifications = new NotificationEventsSpy();
+		const useCase = new SendChatMessageUseCase(repository, notifications);
 
 		await expect(
 			useCase.execute({
@@ -105,12 +191,59 @@ describe('SendChatMessageUseCase', () => {
 		).resolves.toMatchObject({
 			content: 'Começando agora',
 		});
+		expect(notifications.updated).toEqual([
+			expect.objectContaining({
+				recipientId: 'client-1',
+			}),
+		]);
+	});
+
+	it('does not create a notification when the opposite participant is missing', async () => {
+		const repository = new InMemoryChatRepository();
+		repository.order = {
+			...makeWritableOrder(),
+			boosterId: null,
+		};
+		const notifications = new NotificationEventsSpy();
+		const useCase = new SendChatMessageUseCase(repository, notifications);
+
+		await useCase.execute({
+			orderId: 'order-1',
+			userId: 'client-1',
+			role: Role.CLIENT,
+			content: 'sem booster',
+		});
+
+		expect(notifications.updated).toEqual([]);
+	});
+
+	it('does not leave a persisted message when notification persistence fails', async () => {
+		const repository = new InMemoryChatRepository();
+		repository.order = makeWritableOrder();
+		repository.failNotificationPersistence = true;
+		const useCase = new SendChatMessageUseCase(
+			repository,
+			new NotificationEventsSpy(),
+		);
+
+		await expect(
+			useCase.execute({
+				orderId: 'order-1',
+				userId: 'client-1',
+				role: Role.CLIENT,
+				content: 'Olá booster',
+			}),
+		).rejects.toThrow('notification persistence failed');
+		expect(repository.messages).toEqual([]);
 	});
 
 	it('hides orders from unrelated participants', async () => {
 		const repository = new InMemoryChatRepository();
 		repository.order = makeWritableOrder();
-		const useCase = new SendChatMessageUseCase(repository);
+		const useCase = new SendChatMessageUseCase(
+			repository,
+			new NotificationEventsSpy(),
+		);
 
 		await expect(
 			useCase.execute({
@@ -125,7 +258,10 @@ describe('SendChatMessageUseCase', () => {
 	it('rejects admin writes', async () => {
 		const repository = new InMemoryChatRepository();
 		repository.order = makeWritableOrder();
-		const useCase = new SendChatMessageUseCase(repository);
+		const useCase = new SendChatMessageUseCase(
+			repository,
+			new NotificationEventsSpy(),
+		);
 
 		await expect(
 			useCase.execute({
@@ -143,7 +279,10 @@ describe('SendChatMessageUseCase', () => {
 			...makeWritableOrder(),
 			status: 'completed',
 		};
-		const useCase = new SendChatMessageUseCase(repository);
+		const useCase = new SendChatMessageUseCase(
+			repository,
+			new NotificationEventsSpy(),
+		);
 
 		await expect(
 			useCase.execute({

--- a/apps/api/src/modules/chat/application/use-cases/send-chat-message/send-chat-message.use-case.ts
+++ b/apps/api/src/modules/chat/application/use-cases/send-chat-message/send-chat-message.use-case.ts
@@ -11,6 +11,10 @@ import {
 	ChatNotWritableError,
 	ChatOrderNotFoundError,
 } from '@modules/chat/domain/chat.errors';
+import {
+	NOTIFICATION_EVENTS_KEY,
+	type NotificationEventsPort,
+} from '@modules/notifications/application/ports/notification-events.port';
 import { Inject, Injectable } from '@nestjs/common';
 import { Role } from '@packages/auth/roles/role';
 
@@ -28,6 +32,8 @@ export class SendChatMessageUseCase {
 	constructor(
 		@Inject(CHAT_REPOSITORY_KEY)
 		private readonly chatRepository: ChatRepositoryPort,
+		@Inject(NOTIFICATION_EVENTS_KEY)
+		private readonly notificationEvents: NotificationEventsPort,
 	) {}
 
 	async execute(input: SendChatMessageInput): Promise<ChatMessageResponse> {
@@ -38,13 +44,43 @@ export class SendChatMessageUseCase {
 			throw new ChatNotWritableError();
 		if (!order.chatId) throw new ChatOrderNotFoundError();
 
-		return mapChatMessageResponse(
-			await this.chatRepository.createMessage({
-				chatId: order.chatId,
-				senderId: input.userId,
-				content: input.content,
-			}),
-		);
+		const recipientId = this.getRecipientId(input, order);
+		const result = await this.chatRepository.createMessageWithNotification({
+			chatId: order.chatId,
+			senderId: input.userId,
+			content: input.content,
+			...(recipientId
+				? {
+						notification: {
+							recipientId,
+						},
+					}
+				: {}),
+		});
+		const { message } = result;
+		if (recipientId && result.notification) {
+			this.notificationEvents.emitNotificationUpdated(recipientId, {
+				notification: result.notification.notification,
+				unreadCount: result.notification.unreadCount,
+			});
+		}
+
+		return mapChatMessageResponse(message);
+	}
+
+	private getRecipientId(
+		input: Pick<SendChatMessageInput, 'role' | 'userId'>,
+		order: {
+			clientId: string | null;
+			boosterId: string | null;
+		},
+	): string | null {
+		if (input.role === Role.CLIENT && order.clientId === input.userId)
+			return order.boosterId;
+		if (input.role === Role.BOOSTER && order.boosterId === input.userId)
+			return order.clientId;
+
+		return null;
 	}
 
 	private canWrite(

--- a/apps/api/src/modules/chat/chat.module.ts
+++ b/apps/api/src/modules/chat/chat.module.ts
@@ -8,10 +8,11 @@ import { PrismaChatRepository } from '@modules/chat/infrastructure/repositories/
 import { AdminChatController } from '@modules/chat/presentation/admin-chat.controller';
 import { ChatController } from '@modules/chat/presentation/chat.controller';
 import { ChatGateway } from '@modules/chat/presentation/chat.gateway';
+import { NotificationsModule } from '@modules/notifications/notifications.module';
 import { Module } from '@nestjs/common';
 
 @Module({
-	imports: [PrismaModule, AuthModule],
+	imports: [PrismaModule, AuthModule, NotificationsModule],
 	controllers: [AdminChatController, ChatController],
 	providers: [
 		PrismaChatRepository,

--- a/apps/api/src/modules/chat/infrastructure/repositories/prisma-chat.repository.ts
+++ b/apps/api/src/modules/chat/infrastructure/repositories/prisma-chat.repository.ts
@@ -1,6 +1,7 @@
 import { PrismaService } from '@app/common/prisma/prisma.service';
 import type {
 	ChatMessageRecord,
+	ChatMessageWriteResult,
 	ChatOrderRecord,
 	ChatRepositoryPort,
 	ListChatMessagesInput,
@@ -9,6 +10,11 @@ import type {
 import { ChatMessageNotFoundError } from '@modules/chat/domain/chat.errors';
 import { Injectable } from '@nestjs/common';
 import { Role } from '@packages/auth/roles/role';
+import {
+	notificationPayloadSchema,
+	notificationTypeSchema,
+} from '@packages/shared/notifications/notification.schema';
+import type { Prisma } from '@prisma/client';
 
 @Injectable()
 export class PrismaChatRepository implements ChatRepositoryPort {
@@ -59,29 +65,56 @@ export class PrismaChatRepository implements ChatRepositoryPort {
 		senderId: string;
 		content: string;
 	}): Promise<ChatMessageRecord> {
-		const message = await this.prisma.chatMessage.create({
-			data: {
-				chatId: input.chatId,
-				senderId: input.senderId,
-				content: input.content,
-			},
-			include: {
-				chat: {
-					select: {
-						orderId: true,
-					},
-				},
-				sender: {
-					select: {
-						id: true,
-						username: true,
-						role: true,
-					},
-				},
-			},
-		});
+		return (await this.createMessageWithNotification(input)).message;
+	}
 
-		return this.mapMessage(message);
+	async createMessageWithNotification(input: {
+		chatId: string;
+		senderId: string;
+		content: string;
+		notification?: {
+			recipientId: string;
+		};
+	}): Promise<ChatMessageWriteResult> {
+		return await this.prisma.$transaction(async (transaction) => {
+			const message = await this.createMessageRecord(transaction, input);
+			if (!input.notification) return { message: this.mapMessage(message) };
+
+			const notification = await transaction.notification.upsert({
+				where: {
+					recipientId_type_aggregateKey: {
+						recipientId: input.notification.recipientId,
+						type: 'CHAT_MESSAGE_CREATED',
+						aggregateKey: message.chat.orderId,
+					},
+				},
+				create: {
+					recipientId: input.notification.recipientId,
+					type: 'CHAT_MESSAGE_CREATED',
+					aggregateKey: message.chat.orderId,
+					payload: this.buildChatNotificationPayload(message),
+				},
+				update: {
+					payload: this.buildChatNotificationPayload(message),
+					readAt: null,
+					activityAt: new Date(),
+				},
+			});
+			const unreadCount = await transaction.notification.count({
+				where: {
+					recipientId: input.notification.recipientId,
+					readAt: null,
+				},
+			});
+
+			return {
+				message: this.mapMessage(message),
+				notification: {
+					notification: this.mapNotification(notification),
+					unreadCount,
+				},
+			};
+		});
 	}
 
 	async listMessages(
@@ -156,6 +189,78 @@ export class PrismaChatRepository implements ChatRepositoryPort {
 				role: message.sender.role as Role,
 			},
 			createdAt: message.createdAt,
+		};
+	}
+
+	private async createMessageRecord(
+		prisma: Prisma.TransactionClient,
+		input: {
+			chatId: string;
+			senderId: string;
+			content: string;
+		},
+	) {
+		return await prisma.chatMessage.create({
+			data: {
+				chatId: input.chatId,
+				senderId: input.senderId,
+				content: input.content,
+			},
+			include: {
+				chat: {
+					select: {
+						orderId: true,
+					},
+				},
+				sender: {
+					select: {
+						id: true,
+						username: true,
+						role: true,
+					},
+				},
+			},
+		});
+	}
+
+	private buildChatNotificationPayload(message: {
+		id: string;
+		chat: {
+			orderId: string;
+		};
+		sender: {
+			id: string;
+			username: string;
+		};
+	}) {
+		return {
+			type: 'CHAT_MESSAGE_CREATED' as const,
+			metadata: {
+				orderId: message.chat.orderId,
+				chatMessageId: message.id,
+				senderId: message.sender.id,
+				senderUsername: message.sender.username,
+			},
+		};
+	}
+
+	private mapNotification(notification: {
+		id: string;
+		type: string;
+		payload: unknown;
+		readAt: Date | null;
+		activityAt: Date;
+		createdAt: Date;
+		updatedAt: Date;
+	}) {
+		return {
+			id: notification.id,
+			type: notificationTypeSchema.parse(notification.type),
+			payload: notificationPayloadSchema.parse(notification.payload),
+			readAt: notification.readAt?.toISOString() ?? null,
+			activityAt: notification.activityAt.toISOString(),
+			createdAt: notification.createdAt.toISOString(),
+			updatedAt: notification.updatedAt.toISOString(),
 		};
 	}
 }

--- a/apps/api/src/modules/notifications/application/ports/notification-events.port.ts
+++ b/apps/api/src/modules/notifications/application/ports/notification-events.port.ts
@@ -1,0 +1,17 @@
+import type {
+	NotificationsReadAllEventResponse,
+	NotificationUpdatedEventResponse,
+} from '@modules/notifications/application/use-cases/notification-response';
+
+export const NOTIFICATION_EVENTS_KEY = Symbol('NOTIFICATION_EVENTS_KEY');
+
+export interface NotificationEventsPort {
+	emitNotificationUpdated(
+		recipientId: string,
+		event: NotificationUpdatedEventResponse,
+	): void;
+	emitNotificationsReadAll(
+		recipientId: string,
+		event: NotificationsReadAllEventResponse,
+	): void;
+}

--- a/apps/api/src/modules/notifications/application/ports/notification-repository.port.ts
+++ b/apps/api/src/modules/notifications/application/ports/notification-repository.port.ts
@@ -1,0 +1,56 @@
+import type {
+	NotificationPayload,
+	NotificationType,
+} from '@packages/shared/notifications/notification.schema';
+
+export const NOTIFICATION_REPOSITORY_KEY = Symbol(
+	'NOTIFICATION_REPOSITORY_KEY',
+);
+
+export type NotificationRecord = {
+	id: string;
+	recipientId: string;
+	type: NotificationType;
+	aggregateKey: string;
+	payload: NotificationPayload;
+	readAt: Date | null;
+	activityAt: Date;
+	createdAt: Date;
+	updatedAt: Date;
+};
+
+export type ListNotificationsInput = {
+	recipientId: string;
+	limit: number;
+	cursor?: string;
+};
+
+export type ListNotificationsOutput = {
+	items: NotificationRecord[];
+	nextCursor: string | null;
+	unreadCount: number;
+};
+
+export type UpsertNotificationInput = {
+	recipientId: string;
+	type: NotificationType;
+	aggregateKey: string;
+	payload: NotificationPayload;
+};
+
+export interface NotificationRepositoryPort {
+	countUnread(recipientId: string): Promise<number>;
+	list(input: ListNotificationsInput): Promise<ListNotificationsOutput>;
+	markRead(input: {
+		notificationId: string;
+		recipientId: string;
+		readAt: Date;
+		expectedActivityAt?: Date;
+	}): Promise<NotificationRecord | 'changed' | null>;
+	markAllRead(input: {
+		recipientId: string;
+		readAt: Date;
+		cutoffActivityAt: Date;
+	}): Promise<number>;
+	upsert(input: UpsertNotificationInput): Promise<NotificationRecord>;
+}

--- a/apps/api/src/modules/notifications/application/use-cases/list-notifications/list-notifications.use-case.ts
+++ b/apps/api/src/modules/notifications/application/use-cases/list-notifications/list-notifications.use-case.ts
@@ -1,0 +1,29 @@
+import {
+	NOTIFICATION_REPOSITORY_KEY,
+	type NotificationRepositoryPort,
+} from '@modules/notifications/application/ports/notification-repository.port';
+import { mapListNotificationsResponse } from '@modules/notifications/application/use-cases/notification-response';
+import { Inject, Injectable } from '@nestjs/common';
+import type { ListNotificationsResponse } from '@packages/shared/notifications/notification.schema';
+
+type ListNotificationsInput = {
+	recipientId: string;
+	limit: number;
+	cursor?: string;
+};
+
+@Injectable()
+export class ListNotificationsUseCase {
+	constructor(
+		@Inject(NOTIFICATION_REPOSITORY_KEY)
+		private readonly notificationRepository: NotificationRepositoryPort,
+	) {}
+
+	async execute(
+		input: ListNotificationsInput,
+	): Promise<ListNotificationsResponse> {
+		return mapListNotificationsResponse(
+			await this.notificationRepository.list(input),
+		);
+	}
+}

--- a/apps/api/src/modules/notifications/application/use-cases/mark-all-notifications-read/mark-all-notifications-read.use-case.ts
+++ b/apps/api/src/modules/notifications/application/use-cases/mark-all-notifications-read/mark-all-notifications-read.use-case.ts
@@ -1,0 +1,53 @@
+import {
+	NOTIFICATION_EVENTS_KEY,
+	type NotificationEventsPort,
+} from '@modules/notifications/application/ports/notification-events.port';
+import {
+	NOTIFICATION_REPOSITORY_KEY,
+	type NotificationRepositoryPort,
+} from '@modules/notifications/application/ports/notification-repository.port';
+import { mapNotificationsReadAllEventResponse } from '@modules/notifications/application/use-cases/notification-response';
+import { Inject, Injectable } from '@nestjs/common';
+import type { MarkAllNotificationsReadResponse } from '@packages/shared/notifications/notification.schema';
+
+type MarkAllNotificationsReadInput = {
+	recipientId: string;
+	readAt: Date;
+};
+
+@Injectable()
+export class MarkAllNotificationsReadUseCase {
+	constructor(
+		@Inject(NOTIFICATION_REPOSITORY_KEY)
+		private readonly notificationRepository: NotificationRepositoryPort,
+		@Inject(NOTIFICATION_EVENTS_KEY)
+		private readonly notificationEvents: NotificationEventsPort,
+	) {}
+
+	async execute(
+		input: MarkAllNotificationsReadInput,
+	): Promise<MarkAllNotificationsReadResponse> {
+		const cutoffActivityAt = input.readAt;
+		const updatedCount = await this.notificationRepository.markAllRead({
+			...input,
+			cutoffActivityAt,
+		});
+		const unreadCount = await this.notificationRepository.countUnread(
+			input.recipientId,
+		);
+		this.notificationEvents.emitNotificationsReadAll(
+			input.recipientId,
+			mapNotificationsReadAllEventResponse(
+				input.readAt,
+				cutoffActivityAt,
+				unreadCount,
+			),
+		);
+
+		return {
+			cutoffActivityAt: cutoffActivityAt.toISOString(),
+			unreadCount,
+			updatedCount,
+		};
+	}
+}

--- a/apps/api/src/modules/notifications/application/use-cases/mark-notification-read/mark-notification-read.use-case.ts
+++ b/apps/api/src/modules/notifications/application/use-cases/mark-notification-read/mark-notification-read.use-case.ts
@@ -1,0 +1,53 @@
+import {
+	NOTIFICATION_EVENTS_KEY,
+	type NotificationEventsPort,
+} from '@modules/notifications/application/ports/notification-events.port';
+import {
+	NOTIFICATION_REPOSITORY_KEY,
+	type NotificationRepositoryPort,
+} from '@modules/notifications/application/ports/notification-repository.port';
+import {
+	mapNotificationResponse,
+	mapNotificationUpdatedEventResponse,
+	type NotificationResponse,
+} from '@modules/notifications/application/use-cases/notification-response';
+import {
+	NotificationNotFoundError,
+	NotificationReadConflictError,
+} from '@modules/notifications/domain/notification.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+type MarkNotificationReadInput = {
+	notificationId: string;
+	recipientId: string;
+	readAt: Date;
+	expectedActivityAt?: Date;
+};
+
+@Injectable()
+export class MarkNotificationReadUseCase {
+	constructor(
+		@Inject(NOTIFICATION_REPOSITORY_KEY)
+		private readonly notificationRepository: NotificationRepositoryPort,
+		@Inject(NOTIFICATION_EVENTS_KEY)
+		private readonly notificationEvents: NotificationEventsPort,
+	) {}
+
+	async execute(
+		input: MarkNotificationReadInput,
+	): Promise<NotificationResponse> {
+		const notification = await this.notificationRepository.markRead(input);
+		if (notification === 'changed') throw new NotificationReadConflictError();
+		if (!notification) throw new NotificationNotFoundError();
+
+		const unreadCount = await this.notificationRepository.countUnread(
+			input.recipientId,
+		);
+		this.notificationEvents.emitNotificationUpdated(
+			input.recipientId,
+			mapNotificationUpdatedEventResponse(notification, unreadCount),
+		);
+
+		return mapNotificationResponse(notification);
+	}
+}

--- a/apps/api/src/modules/notifications/application/use-cases/notification-response.ts
+++ b/apps/api/src/modules/notifications/application/use-cases/notification-response.ts
@@ -1,0 +1,52 @@
+import type {
+	ListNotificationsResponse,
+	NotificationOutput,
+	NotificationsReadAllEvent,
+	NotificationUpdatedEvent,
+} from '@packages/shared/notifications/notification.schema';
+import type {
+	ListNotificationsOutput,
+	NotificationRecord,
+} from '../ports/notification-repository.port';
+
+export type NotificationResponse = NotificationOutput;
+export type NotificationUpdatedEventResponse = NotificationUpdatedEvent;
+export type NotificationsReadAllEventResponse = NotificationsReadAllEvent;
+
+export const mapNotificationResponse = (
+	record: NotificationRecord,
+): NotificationResponse => ({
+	id: record.id,
+	type: record.type,
+	payload: record.payload,
+	readAt: record.readAt?.toISOString() ?? null,
+	activityAt: record.activityAt.toISOString(),
+	createdAt: record.createdAt.toISOString(),
+	updatedAt: record.updatedAt.toISOString(),
+});
+
+export const mapListNotificationsResponse = (
+	output: ListNotificationsOutput,
+): ListNotificationsResponse => ({
+	items: output.items.map(mapNotificationResponse),
+	nextCursor: output.nextCursor,
+	unreadCount: output.unreadCount,
+});
+
+export const mapNotificationUpdatedEventResponse = (
+	notification: NotificationRecord,
+	unreadCount: number,
+): NotificationUpdatedEventResponse => ({
+	notification: mapNotificationResponse(notification),
+	unreadCount,
+});
+
+export const mapNotificationsReadAllEventResponse = (
+	readAt: Date,
+	cutoffActivityAt: Date,
+	unreadCount: number,
+): NotificationsReadAllEventResponse => ({
+	readAt: readAt.toISOString(),
+	cutoffActivityAt: cutoffActivityAt.toISOString(),
+	unreadCount,
+});

--- a/apps/api/src/modules/notifications/application/use-cases/notifications.use-cases.spec.ts
+++ b/apps/api/src/modules/notifications/application/use-cases/notifications.use-cases.spec.ts
@@ -1,0 +1,414 @@
+import type { NotificationEventsPort } from '@modules/notifications/application/ports/notification-events.port';
+import type {
+	ListNotificationsInput,
+	ListNotificationsOutput,
+	NotificationRecord,
+	NotificationRepositoryPort,
+	UpsertNotificationInput,
+} from '@modules/notifications/application/ports/notification-repository.port';
+import { ListNotificationsUseCase } from '@modules/notifications/application/use-cases/list-notifications/list-notifications.use-case';
+import { MarkAllNotificationsReadUseCase } from '@modules/notifications/application/use-cases/mark-all-notifications-read/mark-all-notifications-read.use-case';
+import { MarkNotificationReadUseCase } from '@modules/notifications/application/use-cases/mark-notification-read/mark-notification-read.use-case';
+import { UpsertChatNotificationUseCase } from '@modules/notifications/application/use-cases/upsert-chat-notification/upsert-chat-notification.use-case';
+import {
+	NotificationNotFoundError,
+	NotificationReadConflictError,
+} from '@modules/notifications/domain/notification.errors';
+
+class InMemoryNotificationRepository implements NotificationRepositoryPort {
+	private readonly notifications = new Map<string, NotificationRecord>();
+
+	async countUnread(recipientId: string): Promise<number> {
+		return [...this.notifications.values()].filter(
+			(notification) =>
+				notification.recipientId === recipientId && !notification.readAt,
+		).length;
+	}
+
+	async list(input: ListNotificationsInput): Promise<ListNotificationsOutput> {
+		const items = [...this.notifications.values()]
+			.filter((notification) => notification.recipientId === input.recipientId)
+			.sort(
+				(left, right) => right.activityAt.getTime() - left.activityAt.getTime(),
+			);
+		const page = items.slice(0, input.limit);
+
+		return {
+			items: page,
+			nextCursor: items.length > input.limit ? (page.at(-1)?.id ?? null) : null,
+			unreadCount: items.filter((notification) => !notification.readAt).length,
+		};
+	}
+
+	async markRead(input: {
+		notificationId: string;
+		recipientId: string;
+		readAt: Date;
+		expectedActivityAt?: Date;
+	}): Promise<NotificationRecord | 'changed' | null> {
+		const notification = this.notifications.get(input.notificationId);
+		if (!notification || notification.recipientId !== input.recipientId)
+			return null;
+		if (
+			input.expectedActivityAt &&
+			notification.activityAt.getTime() !== input.expectedActivityAt.getTime()
+		)
+			return 'changed';
+
+		const updated = {
+			...notification,
+			readAt: notification.readAt ?? input.readAt,
+		};
+		this.notifications.set(updated.id, updated);
+		return updated;
+	}
+
+	async markAllRead(input: {
+		recipientId: string;
+		readAt: Date;
+		cutoffActivityAt: Date;
+	}): Promise<number> {
+		let count = 0;
+		for (const notification of this.notifications.values()) {
+			if (notification.recipientId !== input.recipientId || notification.readAt)
+				continue;
+			if (notification.activityAt > input.cutoffActivityAt) continue;
+
+			this.notifications.set(notification.id, {
+				...notification,
+				readAt: input.readAt,
+			});
+			count++;
+		}
+
+		return count;
+	}
+
+	async upsert(input: UpsertNotificationInput): Promise<NotificationRecord> {
+		const existing = [...this.notifications.values()].find(
+			(notification) =>
+				notification.recipientId === input.recipientId &&
+				notification.type === input.type &&
+				notification.aggregateKey === input.aggregateKey,
+		);
+		const now = new Date('2026-05-18T12:00:00.000Z');
+		const notification: NotificationRecord = {
+			id: existing?.id ?? `notification-${this.notifications.size + 1}`,
+			recipientId: input.recipientId,
+			type: input.type,
+			aggregateKey: input.aggregateKey,
+			payload: input.payload,
+			readAt: null,
+			createdAt: existing?.createdAt ?? now,
+			activityAt: now,
+			updatedAt: now,
+		};
+		this.notifications.set(notification.id, notification);
+		return notification;
+	}
+}
+
+class NotificationEventsSpy implements NotificationEventsPort {
+	readonly updated: Array<{
+		recipientId: string;
+		notificationId: string;
+		unreadCount: number;
+	}> = [];
+	readonly readAll: Array<{
+		recipientId: string;
+		cutoffActivityAt?: string;
+		unreadCount: number;
+	}> = [];
+
+	emitNotificationUpdated(
+		recipientId: string,
+		event: { notification: { id: string }; unreadCount: number },
+	): void {
+		this.updated.push({
+			recipientId,
+			notificationId: event.notification.id,
+			unreadCount: event.unreadCount,
+		});
+	}
+
+	emitNotificationsReadAll(
+		recipientId: string,
+		event: { cutoffActivityAt?: string; unreadCount: number },
+	): void {
+		this.readAll.push({
+			recipientId,
+			cutoffActivityAt: event.cutoffActivityAt,
+			unreadCount: event.unreadCount,
+		});
+	}
+}
+
+describe('notification use-cases', () => {
+	it('coalesces chat notifications per recipient and order and emits recipient-scoped updates', async () => {
+		const repository = new InMemoryNotificationRepository();
+		const events = new NotificationEventsSpy();
+		const useCase = new UpsertChatNotificationUseCase(repository, events);
+
+		const first = await useCase.execute({
+			recipientId: 'booster-1',
+			orderId: 'order-1',
+			chatMessageId: 'message-1',
+			senderId: 'client-1',
+			senderUsername: 'Client',
+		});
+		const second = await useCase.execute({
+			recipientId: 'booster-1',
+			orderId: 'order-1',
+			chatMessageId: 'message-2',
+			senderId: 'client-1',
+			senderUsername: 'Client',
+		});
+
+		expect(second.id).toBe(first.id);
+		expect(second.readAt).toBeNull();
+		expect(second.payload.metadata.chatMessageId).toBe('message-2');
+		expect(events.updated).toEqual([
+			{ recipientId: 'booster-1', notificationId: first.id, unreadCount: 1 },
+			{ recipientId: 'booster-1', notificationId: second.id, unreadCount: 1 },
+		]);
+	});
+
+	it('lists only recipient-owned notifications with unread count', async () => {
+		const repository = new InMemoryNotificationRepository();
+		await repository.upsert({
+			recipientId: 'client-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-1',
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: 'order-1',
+					chatMessageId: 'message-1',
+					senderId: 'booster-1',
+					senderUsername: 'Booster',
+				},
+			},
+		});
+		await repository.upsert({
+			recipientId: 'client-2',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-2',
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: 'order-2',
+					chatMessageId: 'message-2',
+					senderId: 'booster-1',
+					senderUsername: 'Booster',
+				},
+			},
+		});
+		const useCase = new ListNotificationsUseCase(repository);
+
+		await expect(
+			useCase.execute({ recipientId: 'client-1', limit: 10 }),
+		).resolves.toMatchObject({
+			items: [expect.objectContaining({ id: 'notification-1' })],
+			nextCursor: null,
+			unreadCount: 1,
+		});
+	});
+
+	it('marks one owned notification read idempotently and hides foreign ids', async () => {
+		const repository = new InMemoryNotificationRepository();
+		const notification = await repository.upsert({
+			recipientId: 'client-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-1',
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: 'order-1',
+					chatMessageId: 'message-1',
+					senderId: 'booster-1',
+					senderUsername: 'Booster',
+				},
+			},
+		});
+		const events = new NotificationEventsSpy();
+		const useCase = new MarkNotificationReadUseCase(repository, events);
+
+		const first = await useCase.execute({
+			notificationId: notification.id,
+			recipientId: 'client-1',
+			readAt: new Date('2026-05-18T12:00:00.000Z'),
+		});
+		const second = await useCase.execute({
+			notificationId: notification.id,
+			recipientId: 'client-1',
+			readAt: new Date('2026-05-18T13:00:00.000Z'),
+		});
+
+		expect(second.readAt).toBe(first.readAt);
+		expect(events.updated[0]).toMatchObject({ unreadCount: 0 });
+		await expect(
+			useCase.execute({
+				notificationId: notification.id,
+				recipientId: 'client-2',
+				readAt: new Date('2026-05-18T14:00:00.000Z'),
+				expectedActivityAt: new Date(notification.activityAt),
+			}),
+		).rejects.toThrow(NotificationNotFoundError);
+	});
+
+	it('rejects stale read attempts without clearing a newer notification', async () => {
+		const repository = new InMemoryNotificationRepository();
+		const notification = await repository.upsert({
+			recipientId: 'client-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-1',
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: 'order-1',
+					chatMessageId: 'message-1',
+					senderId: 'booster-1',
+					senderUsername: 'Booster',
+				},
+			},
+		});
+		const useCase = new MarkNotificationReadUseCase(
+			repository,
+			new NotificationEventsSpy(),
+		);
+
+		await expect(
+			useCase.execute({
+				notificationId: notification.id,
+				recipientId: 'client-1',
+				readAt: new Date('2026-05-18T13:00:00.000Z'),
+				expectedActivityAt: new Date('2026-05-18T11:00:00.000Z'),
+			}),
+		).rejects.toThrow(NotificationReadConflictError);
+	});
+
+	it('marks all unread recipient notifications read idempotently', async () => {
+		const repository = new InMemoryNotificationRepository();
+		await repository.upsert({
+			recipientId: 'client-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-1',
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: 'order-1',
+					chatMessageId: 'message-1',
+					senderId: 'booster-1',
+					senderUsername: 'Booster',
+				},
+			},
+		});
+		const events = new NotificationEventsSpy();
+		const useCase = new MarkAllNotificationsReadUseCase(repository, events);
+
+		await expect(
+			useCase.execute({
+				recipientId: 'client-1',
+				readAt: new Date('2026-05-18T12:00:00.000Z'),
+			}),
+		).resolves.toEqual({
+			cutoffActivityAt: '2026-05-18T12:00:00.000Z',
+			unreadCount: 0,
+			updatedCount: 1,
+		});
+		await expect(
+			useCase.execute({
+				recipientId: 'client-1',
+				readAt: new Date('2026-05-18T13:00:00.000Z'),
+			}),
+		).resolves.toEqual({
+			cutoffActivityAt: '2026-05-18T13:00:00.000Z',
+			unreadCount: 0,
+			updatedCount: 0,
+		});
+		expect(events.readAll).toEqual([
+			{
+				recipientId: 'client-1',
+				cutoffActivityAt: '2026-05-18T12:00:00.000Z',
+				unreadCount: 0,
+			},
+			{
+				recipientId: 'client-1',
+				cutoffActivityAt: '2026-05-18T13:00:00.000Z',
+				unreadCount: 0,
+			},
+		]);
+	});
+
+	it('emits the remaining unread count after a cutoff-limited bulk read', async () => {
+		const repository = new InMemoryNotificationRepository();
+		const oldNotification = await repository.upsert({
+			recipientId: 'client-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-1',
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: 'order-1',
+					chatMessageId: 'message-1',
+					senderId: 'booster-1',
+					senderUsername: 'Booster',
+				},
+			},
+		});
+		const newNotification = await repository.upsert({
+			recipientId: 'client-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-2',
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: 'order-2',
+					chatMessageId: 'message-2',
+					senderId: 'booster-1',
+					senderUsername: 'Booster',
+				},
+			},
+		});
+		(
+			repository as unknown as {
+				notifications: Map<string, NotificationRecord>;
+			}
+		).notifications.set(newNotification.id, {
+			...newNotification,
+			activityAt: new Date('2026-05-18T13:00:00.000Z'),
+		});
+		await repository.markRead({
+			notificationId: oldNotification.id,
+			recipientId: 'client-1',
+			readAt: new Date('2026-05-18T12:00:00.000Z'),
+		});
+		const events = new NotificationEventsSpy();
+		const useCase = new MarkAllNotificationsReadUseCase(repository, events);
+
+		await expect(
+			useCase.execute({
+				recipientId: 'client-1',
+				readAt: new Date('2026-05-18T12:00:00.000Z'),
+			}),
+		).resolves.toEqual({
+			cutoffActivityAt: '2026-05-18T12:00:00.000Z',
+			unreadCount: 1,
+			updatedCount: 0,
+		});
+		expect(events.readAll).toEqual([
+			{
+				recipientId: 'client-1',
+				cutoffActivityAt: '2026-05-18T12:00:00.000Z',
+				unreadCount: 1,
+			},
+		]);
+		await expect(
+			repository.markRead({
+				notificationId: newNotification.id,
+				recipientId: 'client-1',
+				readAt: new Date('2026-05-18T13:00:00.000Z'),
+			}),
+		).resolves.toMatchObject({ readAt: new Date('2026-05-18T13:00:00.000Z') });
+	});
+});

--- a/apps/api/src/modules/notifications/application/use-cases/upsert-chat-notification/upsert-chat-notification.use-case.ts
+++ b/apps/api/src/modules/notifications/application/use-cases/upsert-chat-notification/upsert-chat-notification.use-case.ts
@@ -1,0 +1,62 @@
+import {
+	NOTIFICATION_EVENTS_KEY,
+	type NotificationEventsPort,
+} from '@modules/notifications/application/ports/notification-events.port';
+import {
+	NOTIFICATION_REPOSITORY_KEY,
+	type NotificationRepositoryPort,
+} from '@modules/notifications/application/ports/notification-repository.port';
+import {
+	mapNotificationResponse,
+	mapNotificationUpdatedEventResponse,
+	type NotificationResponse,
+} from '@modules/notifications/application/use-cases/notification-response';
+import { Inject, Injectable } from '@nestjs/common';
+
+type UpsertChatNotificationInput = {
+	recipientId: string;
+	orderId: string;
+	chatMessageId: string;
+	senderId: string;
+	senderUsername: string;
+};
+
+@Injectable()
+export class UpsertChatNotificationUseCase {
+	constructor(
+		@Inject(NOTIFICATION_REPOSITORY_KEY)
+		private readonly notificationRepository: NotificationRepositoryPort,
+		@Inject(NOTIFICATION_EVENTS_KEY)
+		private readonly notificationEvents: NotificationEventsPort,
+	) {}
+
+	async execute(
+		input: UpsertChatNotificationInput,
+	): Promise<NotificationResponse> {
+		const notificationRecord = await this.notificationRepository.upsert({
+			recipientId: input.recipientId,
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: input.orderId,
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: input.orderId,
+					chatMessageId: input.chatMessageId,
+					senderId: input.senderId,
+					senderUsername: input.senderUsername,
+				},
+			},
+		});
+		const unreadCount = await this.notificationRepository.countUnread(
+			input.recipientId,
+		);
+		const notification = mapNotificationResponse(notificationRecord);
+
+		this.notificationEvents.emitNotificationUpdated(
+			input.recipientId,
+			mapNotificationUpdatedEventResponse(notificationRecord, unreadCount),
+		);
+
+		return notification;
+	}
+}

--- a/apps/api/src/modules/notifications/domain/notification.errors.ts
+++ b/apps/api/src/modules/notifications/domain/notification.errors.ts
@@ -1,0 +1,13 @@
+export class NotificationNotFoundError extends Error {
+	constructor() {
+		super('Notification not found.');
+		this.name = 'NotificationNotFoundError';
+	}
+}
+
+export class NotificationReadConflictError extends Error {
+	constructor() {
+		super('Notification changed before it could be marked read.');
+		this.name = 'NotificationReadConflictError';
+	}
+}

--- a/apps/api/src/modules/notifications/infrastructure/repositories/prisma-notification.repository.ts
+++ b/apps/api/src/modules/notifications/infrastructure/repositories/prisma-notification.repository.ts
@@ -1,0 +1,178 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import type {
+	ListNotificationsInput,
+	ListNotificationsOutput,
+	NotificationRecord,
+	NotificationRepositoryPort,
+	UpsertNotificationInput,
+} from '@modules/notifications/application/ports/notification-repository.port';
+import { Injectable } from '@nestjs/common';
+import {
+	notificationPayloadSchema,
+	notificationTypeSchema,
+} from '@packages/shared/notifications/notification.schema';
+
+type PersistedNotification = {
+	id: string;
+	recipientId: string;
+	type: string;
+	aggregateKey: string;
+	payload: unknown;
+	readAt: Date | null;
+	activityAt: Date;
+	createdAt: Date;
+	updatedAt: Date;
+};
+
+@Injectable()
+export class PrismaNotificationRepository
+	implements NotificationRepositoryPort
+{
+	constructor(private readonly prisma: PrismaService) {}
+
+	async countUnread(recipientId: string): Promise<number> {
+		return await this.prisma.notification.count({
+			where: {
+				recipientId,
+				readAt: null,
+			},
+		});
+	}
+
+	async list(input: ListNotificationsInput): Promise<ListNotificationsOutput> {
+		const notifications = await this.prisma.notification.findMany({
+			where: { recipientId: input.recipientId },
+			cursor: input.cursor ? { id: input.cursor } : undefined,
+			skip: input.cursor ? 1 : 0,
+			take: input.limit + 1,
+			orderBy: [{ activityAt: 'desc' }, { id: 'desc' }],
+		});
+		const page = notifications.slice(0, input.limit);
+		const unreadCount = await this.countUnread(input.recipientId);
+
+		return {
+			items: page.map((notification) =>
+				this.mapNotification(notification as PersistedNotification),
+			),
+			nextCursor:
+				notifications.length > input.limit
+					? (page[page.length - 1]?.id ?? null)
+					: null,
+			unreadCount,
+		};
+	}
+
+	async markRead(input: {
+		notificationId: string;
+		recipientId: string;
+		readAt: Date;
+		expectedActivityAt?: Date;
+	}): Promise<NotificationRecord | 'changed' | null> {
+		if (input.expectedActivityAt) {
+			const result = await this.prisma.notification.updateMany({
+				where: {
+					id: input.notificationId,
+					recipientId: input.recipientId,
+					activityAt: input.expectedActivityAt,
+				},
+				data: { readAt: input.readAt },
+			});
+			if (result.count === 0) {
+				const existing = await this.prisma.notification.findFirst({
+					where: {
+						id: input.notificationId,
+						recipientId: input.recipientId,
+					},
+					select: { id: true },
+				});
+				return existing ? 'changed' : null;
+			}
+
+			const updated = await this.prisma.notification.findUnique({
+				where: { id: input.notificationId },
+			});
+			return updated
+				? this.mapNotification(updated as PersistedNotification)
+				: null;
+		}
+
+		const notification = await this.prisma.notification.findFirst({
+			where: {
+				id: input.notificationId,
+				recipientId: input.recipientId,
+			},
+		});
+		if (!notification) return null;
+
+		return this.mapNotification(
+			(await this.prisma.notification.update({
+				where: { id: notification.id },
+				data: {
+					readAt: notification.readAt ?? input.readAt,
+				},
+			})) as PersistedNotification,
+		);
+	}
+
+	async markAllRead(input: {
+		recipientId: string;
+		readAt: Date;
+		cutoffActivityAt: Date;
+	}): Promise<number> {
+		const result = await this.prisma.notification.updateMany({
+			where: {
+				recipientId: input.recipientId,
+				readAt: null,
+				activityAt: {
+					lte: input.cutoffActivityAt,
+				},
+			},
+			data: {
+				readAt: input.readAt,
+			},
+		});
+
+		return result.count;
+	}
+
+	async upsert(input: UpsertNotificationInput): Promise<NotificationRecord> {
+		return this.mapNotification(
+			(await this.prisma.notification.upsert({
+				where: {
+					recipientId_type_aggregateKey: {
+						recipientId: input.recipientId,
+						type: input.type,
+						aggregateKey: input.aggregateKey,
+					},
+				},
+				create: {
+					recipientId: input.recipientId,
+					type: input.type,
+					aggregateKey: input.aggregateKey,
+					payload: input.payload,
+				},
+				update: {
+					payload: input.payload,
+					readAt: null,
+					activityAt: new Date(),
+				},
+			})) as PersistedNotification,
+		);
+	}
+
+	private mapNotification(
+		notification: PersistedNotification,
+	): NotificationRecord {
+		return {
+			id: notification.id,
+			recipientId: notification.recipientId,
+			type: notificationTypeSchema.parse(notification.type),
+			aggregateKey: notification.aggregateKey,
+			payload: notificationPayloadSchema.parse(notification.payload),
+			readAt: notification.readAt,
+			activityAt: notification.activityAt,
+			createdAt: notification.createdAt,
+			updatedAt: notification.updatedAt,
+		};
+	}
+}

--- a/apps/api/src/modules/notifications/notifications.module.ts
+++ b/apps/api/src/modules/notifications/notifications.module.ts
@@ -1,0 +1,41 @@
+import { PrismaModule } from '@app/common/prisma/prisma.module';
+import { AuthModule } from '@modules/auth/auth.module';
+import { NOTIFICATION_EVENTS_KEY } from '@modules/notifications/application/ports/notification-events.port';
+import { NOTIFICATION_REPOSITORY_KEY } from '@modules/notifications/application/ports/notification-repository.port';
+import { ListNotificationsUseCase } from '@modules/notifications/application/use-cases/list-notifications/list-notifications.use-case';
+import { MarkAllNotificationsReadUseCase } from '@modules/notifications/application/use-cases/mark-all-notifications-read/mark-all-notifications-read.use-case';
+import { MarkNotificationReadUseCase } from '@modules/notifications/application/use-cases/mark-notification-read/mark-notification-read.use-case';
+import { UpsertChatNotificationUseCase } from '@modules/notifications/application/use-cases/upsert-chat-notification/upsert-chat-notification.use-case';
+import { PrismaNotificationRepository } from '@modules/notifications/infrastructure/repositories/prisma-notification.repository';
+import { NotificationsController } from '@modules/notifications/presentation/notifications.controller';
+import { NotificationsGateway } from '@modules/notifications/presentation/notifications.gateway';
+import { Module } from '@nestjs/common';
+
+@Module({
+	imports: [PrismaModule, AuthModule],
+	controllers: [NotificationsController],
+	providers: [
+		PrismaNotificationRepository,
+		{
+			provide: NOTIFICATION_REPOSITORY_KEY,
+			useFactory: (
+				notificationRepository: PrismaNotificationRepository,
+			): PrismaNotificationRepository => notificationRepository,
+			inject: [PrismaNotificationRepository],
+		},
+		NotificationsGateway,
+		{
+			provide: NOTIFICATION_EVENTS_KEY,
+			useFactory: (
+				notificationsGateway: NotificationsGateway,
+			): NotificationsGateway => notificationsGateway,
+			inject: [NotificationsGateway],
+		},
+		ListNotificationsUseCase,
+		MarkNotificationReadUseCase,
+		MarkAllNotificationsReadUseCase,
+		UpsertChatNotificationUseCase,
+	],
+	exports: [NOTIFICATION_EVENTS_KEY, UpsertChatNotificationUseCase],
+})
+export class NotificationsModule {}

--- a/apps/api/src/modules/notifications/presentation/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/presentation/notifications.controller.ts
@@ -1,0 +1,87 @@
+import { ZodValidationPipe } from '@app/common/http/zod-validation.pipe';
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import { CurrentUser } from '@modules/auth/presentation/decorators/current-user.decorator';
+import { Roles } from '@modules/auth/presentation/decorators/roles.decorator';
+import { JwtAuthGuard } from '@modules/auth/presentation/guards/jwt-auth.guard';
+import { RolesGuard } from '@modules/auth/presentation/guards/roles.guard';
+import { ListNotificationsUseCase } from '@modules/notifications/application/use-cases/list-notifications/list-notifications.use-case';
+import { MarkAllNotificationsReadUseCase } from '@modules/notifications/application/use-cases/mark-all-notifications-read/mark-all-notifications-read.use-case';
+import { MarkNotificationReadUseCase } from '@modules/notifications/application/use-cases/mark-notification-read/mark-notification-read.use-case';
+import type { NotificationResponse } from '@modules/notifications/application/use-cases/notification-response';
+import {
+	Body,
+	Controller,
+	Get,
+	HttpCode,
+	Param,
+	Patch,
+	Query,
+	UseGuards,
+} from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+import type {
+	ListNotificationsResponse,
+	MarkAllNotificationsReadResponse,
+} from '@packages/shared/notifications/notification.schema';
+import {
+	type ListNotificationsQuery,
+	listNotificationsQuerySchema,
+	type MarkNotificationReadInput,
+	markNotificationReadSchema,
+	type NotificationIdParamSchemaInput,
+	notificationIdParamSchema,
+} from './notifications.request-schemas';
+
+@Controller('notifications')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.CLIENT, Role.BOOSTER, Role.ADMIN)
+export class NotificationsController {
+	constructor(
+		private readonly listNotificationsUseCase: ListNotificationsUseCase,
+		private readonly markNotificationReadUseCase: MarkNotificationReadUseCase,
+		private readonly markAllNotificationsReadUseCase: MarkAllNotificationsReadUseCase,
+	) {}
+
+	@Get()
+	async list(
+		@Query(new ZodValidationPipe(listNotificationsQuerySchema))
+		query: ListNotificationsQuery,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	): Promise<ListNotificationsResponse> {
+		return await this.listNotificationsUseCase.execute({
+			recipientId: currentUser.id,
+			limit: query.limit,
+			cursor: query.cursor,
+		});
+	}
+
+	@Patch(':notificationId/read')
+	@HttpCode(200)
+	async markRead(
+		@Param('notificationId', new ZodValidationPipe(notificationIdParamSchema))
+		notificationId: NotificationIdParamSchemaInput,
+		@Body(new ZodValidationPipe(markNotificationReadSchema))
+		body: MarkNotificationReadInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	): Promise<NotificationResponse> {
+		return await this.markNotificationReadUseCase.execute({
+			notificationId,
+			recipientId: currentUser.id,
+			readAt: new Date(),
+			...(body.expectedActivityAt
+				? { expectedActivityAt: new Date(body.expectedActivityAt) }
+				: {}),
+		});
+	}
+
+	@Patch('read-all')
+	@HttpCode(200)
+	async markAllRead(
+		@CurrentUser() currentUser: AuthenticatedUser,
+	): Promise<MarkAllNotificationsReadResponse> {
+		return await this.markAllNotificationsReadUseCase.execute({
+			recipientId: currentUser.id,
+			readAt: new Date(),
+		});
+	}
+}

--- a/apps/api/src/modules/notifications/presentation/notifications.gateway.spec.ts
+++ b/apps/api/src/modules/notifications/presentation/notifications.gateway.spec.ts
@@ -1,0 +1,195 @@
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import type { AccessTokenServicePort } from '@modules/auth/application/ports/token-service.port';
+import { InvalidAccessTokenError } from '@modules/auth/domain/auth.errors';
+import type { WebSessionCookieService } from '@modules/auth/infrastructure/security/web-session-cookie.service';
+import type { NotificationResponse } from '@modules/notifications/application/use-cases/notification-response';
+import { NotificationsGateway } from '@modules/notifications/presentation/notifications.gateway';
+import { Role } from '@packages/auth/roles/role';
+
+class AccessTokenVerifierStub implements AccessTokenServicePort {
+	constructor(private readonly user: AuthenticatedUser | Error) {}
+
+	sign(): { token: string; expiresInSeconds: number } {
+		return { token: 'token', expiresInSeconds: 900 };
+	}
+
+	verify(): AuthenticatedUser {
+		if (this.user instanceof Error) throw this.user;
+		return this.user;
+	}
+}
+
+class WebSessionCookieServiceStub {
+	user: AuthenticatedUser | null = null;
+
+	verifyCookieHeader(): AuthenticatedUser | null {
+		return this.user;
+	}
+}
+
+class NotificationSocketStub {
+	readonly data: Record<string, unknown> = {};
+	readonly emitted: Array<{ event: string; payload: unknown }> = [];
+	readonly joinedRooms: string[] = [];
+	disconnectCalled = false;
+	handshake = {
+		auth: {} as Record<string, unknown>,
+		headers: {} as Record<string, string | undefined>,
+	};
+
+	emit(event: string, payload: unknown): void {
+		this.emitted.push({ event, payload });
+	}
+
+	async join(room: string): Promise<void> {
+		this.joinedRooms.push(room);
+	}
+
+	disconnect(): void {
+		this.disconnectCalled = true;
+	}
+}
+
+const makeGateway = (
+	user: AuthenticatedUser | Error = { id: 'client-1', role: Role.CLIENT },
+) => {
+	const webSessionCookieService = new WebSessionCookieServiceStub();
+	const emittedToRooms: Array<{
+		room: string;
+		event: string;
+		payload: unknown;
+	}> = [];
+	const gateway = new NotificationsGateway(
+		new AccessTokenVerifierStub(user),
+		webSessionCookieService as unknown as WebSessionCookieService,
+	);
+	(
+		gateway as unknown as {
+			server: {
+				to(room: string): { emit(event: string, payload: unknown): void };
+			};
+		}
+	).server = {
+		to(room: string) {
+			return {
+				emit(event: string, payload: unknown) {
+					emittedToRooms.push({ room, event, payload });
+				},
+			};
+		},
+	};
+
+	return { emittedToRooms, gateway, webSessionCookieService };
+};
+
+describe('NotificationsGateway', () => {
+	it.each([
+		Role.CLIENT,
+		Role.BOOSTER,
+		Role.ADMIN,
+	])('authenticates %s connections and joins a recipient room', (role) => {
+		const { gateway } = makeGateway({ id: 'user-1', role });
+		const socket = new NotificationSocketStub();
+		socket.handshake.auth.token = 'Bearer valid-token';
+
+		gateway.handleConnection(socket as never);
+
+		expect(socket.data.user).toEqual({ id: 'user-1', role });
+		expect(socket.joinedRooms).toEqual(['user:user-1:notifications']);
+		expect(socket.emitted).toContainEqual({
+			event: 'notifications:connected',
+			payload: { userId: 'user-1' },
+		});
+	});
+
+	it('disconnects unauthenticated connections', () => {
+		const { gateway } = makeGateway(new InvalidAccessTokenError());
+		const socket = new NotificationSocketStub();
+		socket.handshake.auth.token = 'invalid-token';
+
+		gateway.handleConnection(socket as never);
+
+		expect(socket.disconnectCalled).toBe(true);
+		expect(socket.emitted).toContainEqual({
+			event: 'notifications:error',
+			payload: {
+				code: 'INVALID_ACCESS_TOKEN',
+				message: 'Invalid access token.',
+			},
+		});
+	});
+
+	it('authenticates browser connections with the web session cookie', () => {
+		const { gateway, webSessionCookieService } = makeGateway(
+			new InvalidAccessTokenError(),
+		);
+		const socket = new NotificationSocketStub();
+		socket.handshake.headers.cookie = 'elonew.session=sealed-session';
+		webSessionCookieService.user = { id: 'client-cookie', role: Role.CLIENT };
+
+		gateway.handleConnection(socket as never);
+
+		expect(socket.data.user).toEqual({
+			id: 'client-cookie',
+			role: Role.CLIENT,
+		});
+		expect(socket.joinedRooms).toEqual(['user:client-cookie:notifications']);
+		expect(socket.disconnectCalled).toBe(false);
+	});
+
+	it('emits notification updates only to the recipient room', () => {
+		const { emittedToRooms, gateway } = makeGateway();
+		const notification: NotificationResponse = {
+			id: 'notification-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: 'order-1',
+					chatMessageId: 'message-1',
+					senderId: 'client-1',
+					senderUsername: 'Client',
+				},
+			},
+			readAt: null,
+			activityAt: '2026-05-18T12:00:00.000Z',
+			createdAt: '2026-05-18T12:00:00.000Z',
+			updatedAt: '2026-05-18T12:00:00.000Z',
+		};
+
+		gateway.emitNotificationUpdated('booster-1', {
+			notification,
+			unreadCount: 1,
+		});
+
+		expect(emittedToRooms).toEqual([
+			{
+				room: 'user:booster-1:notifications',
+				event: 'notifications:updated',
+				payload: { notification, unreadCount: 1 },
+			},
+		]);
+	});
+
+	it('emits read-all updates only to the recipient room', () => {
+		const { emittedToRooms, gateway } = makeGateway();
+
+		gateway.emitNotificationsReadAll('client-1', {
+			cutoffActivityAt: '2026-05-18T12:00:00.000Z',
+			readAt: '2026-05-18T12:00:00.000Z',
+			unreadCount: 0,
+		});
+
+		expect(emittedToRooms).toEqual([
+			{
+				room: 'user:client-1:notifications',
+				event: 'notifications:read-all',
+				payload: {
+					cutoffActivityAt: '2026-05-18T12:00:00.000Z',
+					readAt: '2026-05-18T12:00:00.000Z',
+					unreadCount: 0,
+				},
+			},
+		]);
+	});
+});

--- a/apps/api/src/modules/notifications/presentation/notifications.gateway.ts
+++ b/apps/api/src/modules/notifications/presentation/notifications.gateway.ts
@@ -1,0 +1,153 @@
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import {
+	ACCESS_TOKEN_SERVICE_KEY,
+	type AccessTokenServicePort,
+} from '@modules/auth/application/ports/token-service.port';
+import {
+	AuthenticationRequiredError,
+	InsufficientPermissionsError,
+	InvalidAccessTokenError,
+} from '@modules/auth/domain/auth.errors';
+import { WebSessionCookieService } from '@modules/auth/infrastructure/security/web-session-cookie.service';
+import type { NotificationEventsPort } from '@modules/notifications/application/ports/notification-events.port';
+import type {
+	NotificationsReadAllEventResponse,
+	NotificationUpdatedEventResponse,
+} from '@modules/notifications/application/use-cases/notification-response';
+import { Inject } from '@nestjs/common';
+import {
+	OnGatewayConnection,
+	WebSocketGateway,
+	WebSocketServer,
+} from '@nestjs/websockets';
+import { Role } from '@packages/auth/roles/role';
+import { Server, Socket } from 'socket.io';
+
+type NotificationSocket = Socket & {
+	data: {
+		user?: AuthenticatedUser;
+	};
+};
+
+type NotificationErrorCode =
+	| 'AUTHENTICATION_REQUIRED'
+	| 'INVALID_ACCESS_TOKEN'
+	| 'INSUFFICIENT_PERMISSIONS'
+	| 'INTERNAL_ERROR';
+
+@WebSocketGateway({
+	namespace: 'notifications',
+})
+export class NotificationsGateway
+	implements OnGatewayConnection<NotificationSocket>, NotificationEventsPort
+{
+	@WebSocketServer()
+	private server?: Server;
+
+	constructor(
+		@Inject(ACCESS_TOKEN_SERVICE_KEY)
+		private readonly accessTokenService: AccessTokenServicePort,
+		private readonly webSessionCookieService: WebSessionCookieService,
+	) {}
+
+	handleConnection(client: NotificationSocket): void {
+		try {
+			const user = this.getAuthenticatedUser(client);
+			if (
+				user.role !== Role.CLIENT &&
+				user.role !== Role.BOOSTER &&
+				user.role !== Role.ADMIN
+			)
+				throw new InsufficientPermissionsError();
+
+			client.data.user = user;
+			void client.join(this.getUserRoom(user.id));
+			client.emit('notifications:connected', { userId: user.id });
+		} catch (error) {
+			this.emitError(client, error);
+			client.disconnect(true);
+		}
+	}
+
+	emitNotificationUpdated(
+		recipientId: string,
+		event: NotificationUpdatedEventResponse,
+	): void {
+		this.server
+			?.to(this.getUserRoom(recipientId))
+			.emit('notifications:updated', event);
+	}
+
+	emitNotificationsReadAll(
+		recipientId: string,
+		event: NotificationsReadAllEventResponse,
+	): void {
+		this.server
+			?.to(this.getUserRoom(recipientId))
+			.emit('notifications:read-all', event);
+	}
+
+	private getAuthenticatedUser(client: NotificationSocket): AuthenticatedUser {
+		const token = this.getToken(client);
+		if (token) return this.accessTokenService.verify(token);
+
+		const user = this.webSessionCookieService.verifyCookieHeader(
+			client.handshake.headers.cookie,
+		);
+		if (!user) throw new AuthenticationRequiredError();
+
+		return user;
+	}
+
+	private getToken(client: NotificationSocket): string | null {
+		const authToken = client.handshake.auth.token;
+		if (typeof authToken === 'string' && authToken.trim())
+			return this.normalizeToken(authToken);
+
+		const authorization = client.handshake.headers.authorization;
+		if (typeof authorization === 'string')
+			return this.normalizeToken(authorization);
+
+		return null;
+	}
+
+	private normalizeToken(value: string): string {
+		if (value.startsWith('Bearer '))
+			return value.slice('Bearer '.length).trim();
+		if (value.trim()) return value.trim();
+		throw new AuthenticationRequiredError();
+	}
+
+	private getUserRoom(userId: string): string {
+		return `user:${userId}:notifications`;
+	}
+
+	private emitError(client: NotificationSocket, error: unknown): void {
+		const code = this.getErrorCode(error);
+		client.emit('notifications:error', {
+			code,
+			message: this.getErrorMessage(code),
+		});
+	}
+
+	private getErrorCode(error: unknown): NotificationErrorCode {
+		if (error instanceof AuthenticationRequiredError)
+			return 'AUTHENTICATION_REQUIRED';
+		if (error instanceof InvalidAccessTokenError) return 'INVALID_ACCESS_TOKEN';
+		if (error instanceof InsufficientPermissionsError)
+			return 'INSUFFICIENT_PERMISSIONS';
+
+		return 'INTERNAL_ERROR';
+	}
+
+	private getErrorMessage(code: NotificationErrorCode): string {
+		const messages: Record<NotificationErrorCode, string> = {
+			AUTHENTICATION_REQUIRED: 'Authentication required.',
+			INVALID_ACCESS_TOKEN: 'Invalid access token.',
+			INSUFFICIENT_PERMISSIONS: 'Insufficient permissions.',
+			INTERNAL_ERROR: 'Unable to process notification event.',
+		};
+
+		return messages[code];
+	}
+}

--- a/apps/api/src/modules/notifications/presentation/notifications.request-schemas.ts
+++ b/apps/api/src/modules/notifications/presentation/notifications.request-schemas.ts
@@ -1,0 +1,14 @@
+import { notificationIdParamSchema } from '@packages/shared/notifications/notification.schema';
+import type { z } from 'zod';
+
+export {
+	type ListNotificationsQuery,
+	listNotificationsQuerySchema,
+	type MarkNotificationReadInput,
+	markNotificationReadSchema,
+	notificationIdParamSchema,
+} from '@packages/shared/notifications/notification.schema';
+
+export type NotificationIdParamSchemaInput = z.infer<
+	typeof notificationIdParamSchema
+>;

--- a/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
+++ b/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
@@ -108,6 +108,9 @@ describe('Orders module integration (db)', () => {
 		orderRepository = moduleRef.get(ORDER_REPOSITORY_KEY);
 		pricingVersions = moduleRef.get(ORDER_PRICING_VERSION_REPOSITORY_KEY);
 		markOrderAsPaidUseCase = moduleRef.get(MarkOrderAsPaidUseCase);
+		await prisma.notification.deleteMany();
+		await prisma.chatMessage.deleteMany();
+		await prisma.chat.deleteMany();
 		await prisma.payment.deleteMany();
 		await prisma.orderQuote.deleteMany();
 		await prisma.order.deleteMany();

--- a/apps/api/test/integration-db/payments/payments.db.integration.spec.ts
+++ b/apps/api/test/integration-db/payments/payments.db.integration.spec.ts
@@ -111,6 +111,9 @@ describe('Payments module integration (db)', () => {
 		markOrderAsPaidUseCase = moduleRef.get(MarkOrderAsPaidUseCase);
 		prisma = moduleRef.get(PrismaService);
 		await prisma.processedWebhookEvent.deleteMany();
+		await prisma.notification.deleteMany();
+		await prisma.chatMessage.deleteMany();
+		await prisma.chat.deleteMany();
 		await prisma.payment.deleteMany();
 		await prisma.orderQuote.deleteMany();
 		await prisma.order.deleteMany();

--- a/apps/api/test/integration-db/users/users.db.integration.spec.ts
+++ b/apps/api/test/integration-db/users/users.db.integration.spec.ts
@@ -18,6 +18,9 @@ describe('Users module integration (db)', () => {
 		controller = moduleRef.get(UsersController);
 		prisma = moduleRef.get(PrismaService);
 		await prisma.processedWebhookEvent.deleteMany();
+		await prisma.notification.deleteMany();
+		await prisma.chatMessage.deleteMany();
+		await prisma.chat.deleteMany();
 		await prisma.walletTransaction.deleteMany();
 		await prisma.payment.deleteMany();
 		await prisma.orderCredentials.deleteMany();

--- a/apps/api/test/integration/notifications/notifications.integration.spec.ts
+++ b/apps/api/test/integration/notifications/notifications.integration.spec.ts
@@ -1,0 +1,225 @@
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import type { NotificationEventsPort } from '@modules/notifications/application/ports/notification-events.port';
+import { NOTIFICATION_EVENTS_KEY } from '@modules/notifications/application/ports/notification-events.port';
+import type {
+	ListNotificationsInput,
+	ListNotificationsOutput,
+	NotificationRecord,
+	NotificationRepositoryPort,
+	UpsertNotificationInput,
+} from '@modules/notifications/application/ports/notification-repository.port';
+import { NOTIFICATION_REPOSITORY_KEY } from '@modules/notifications/application/ports/notification-repository.port';
+import { NotificationNotFoundError } from '@modules/notifications/domain/notification.errors';
+import { NotificationsModule } from '@modules/notifications/notifications.module';
+import { NotificationsController } from '@modules/notifications/presentation/notifications.controller';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Role } from '@packages/auth/roles/role';
+
+class InMemoryNotificationRepository implements NotificationRepositoryPort {
+	private readonly notifications = new Map<string, NotificationRecord>();
+
+	async countUnread(recipientId: string): Promise<number> {
+		return [...this.notifications.values()].filter(
+			(notification) =>
+				notification.recipientId === recipientId && !notification.readAt,
+		).length;
+	}
+
+	async list(input: ListNotificationsInput): Promise<ListNotificationsOutput> {
+		const items = [...this.notifications.values()]
+			.filter((notification) => notification.recipientId === input.recipientId)
+			.sort(
+				(left, right) => right.activityAt.getTime() - left.activityAt.getTime(),
+			);
+		const page = items.slice(0, input.limit);
+
+		return {
+			items: page,
+			nextCursor: items.length > input.limit ? (page.at(-1)?.id ?? null) : null,
+			unreadCount: items.filter((notification) => !notification.readAt).length,
+		};
+	}
+
+	async markRead(input: {
+		notificationId: string;
+		recipientId: string;
+		readAt: Date;
+		expectedActivityAt?: Date;
+	}): Promise<NotificationRecord | 'changed' | null> {
+		const notification = this.notifications.get(input.notificationId);
+		if (!notification || notification.recipientId !== input.recipientId)
+			return null;
+		if (
+			input.expectedActivityAt &&
+			notification.activityAt.getTime() !== input.expectedActivityAt.getTime()
+		)
+			return 'changed';
+
+		const updated = {
+			...notification,
+			readAt: notification.readAt ?? input.readAt,
+		};
+		this.notifications.set(updated.id, updated);
+		return updated;
+	}
+
+	async markAllRead(input: {
+		recipientId: string;
+		readAt: Date;
+		cutoffActivityAt: Date;
+	}): Promise<number> {
+		let updatedCount = 0;
+		for (const notification of this.notifications.values()) {
+			if (
+				notification.recipientId !== input.recipientId ||
+				notification.readAt ||
+				notification.activityAt > input.cutoffActivityAt
+			)
+				continue;
+
+			this.notifications.set(notification.id, {
+				...notification,
+				readAt: input.readAt,
+			});
+			updatedCount++;
+		}
+
+		return updatedCount;
+	}
+
+	async upsert(input: UpsertNotificationInput): Promise<NotificationRecord> {
+		const existing = [...this.notifications.values()].find(
+			(notification) =>
+				notification.recipientId === input.recipientId &&
+				notification.type === input.type &&
+				notification.aggregateKey === input.aggregateKey,
+		);
+		const now = new Date('2026-05-18T12:00:00.000Z');
+		const notification: NotificationRecord = {
+			id: existing?.id ?? `notification-${this.notifications.size + 1}`,
+			recipientId: input.recipientId,
+			type: input.type,
+			aggregateKey: input.aggregateKey,
+			payload: input.payload,
+			readAt: null,
+			activityAt: now,
+			createdAt: existing?.createdAt ?? now,
+			updatedAt: now,
+		};
+		this.notifications.set(notification.id, notification);
+		return notification;
+	}
+}
+
+class NotificationEventsSpy implements NotificationEventsPort {
+	readonly updated: unknown[] = [];
+	readonly readAll: Array<{ recipientId: string; unreadCount: number }> = [];
+
+	emitNotificationUpdated(_recipientId: string, event: unknown): void {
+		this.updated.push(event);
+	}
+
+	emitNotificationsReadAll(
+		recipientId: string,
+		event: { unreadCount: number },
+	): void {
+		this.readAll.push({ recipientId, unreadCount: event.unreadCount });
+	}
+}
+
+const makePayload = (orderId: string, chatMessageId: string) => ({
+	type: 'CHAT_MESSAGE_CREATED' as const,
+	metadata: {
+		orderId,
+		chatMessageId,
+		senderId: 'booster-1',
+		senderUsername: 'Booster',
+	},
+});
+
+describe('Notifications module integration', () => {
+	let controller: NotificationsController;
+	let events: NotificationEventsSpy;
+	let moduleRef: TestingModule;
+	let repository: InMemoryNotificationRepository;
+	const clientUser: AuthenticatedUser = { id: 'client-1', role: Role.CLIENT };
+	const otherClientUser: AuthenticatedUser = {
+		id: 'client-2',
+		role: Role.CLIENT,
+	};
+
+	beforeEach(async () => {
+		events = new NotificationEventsSpy();
+		repository = new InMemoryNotificationRepository();
+		moduleRef = await Test.createTestingModule({
+			imports: [NotificationsModule],
+		})
+			.overrideProvider(NOTIFICATION_REPOSITORY_KEY)
+			.useValue(repository)
+			.overrideProvider(NOTIFICATION_EVENTS_KEY)
+			.useValue(events)
+			.compile();
+		controller = moduleRef.get(NotificationsController);
+	});
+
+	afterEach(async () => {
+		await moduleRef.close();
+	});
+
+	it('lists only notifications owned by the authenticated recipient', async () => {
+		await repository.upsert({
+			recipientId: 'client-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-1',
+			payload: makePayload('order-1', 'message-1'),
+		});
+		await repository.upsert({
+			recipientId: 'client-2',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-2',
+			payload: makePayload('order-2', 'message-2'),
+		});
+
+		await expect(
+			controller.list({ limit: 10 }, clientUser),
+		).resolves.toMatchObject({
+			items: [expect.objectContaining({ id: 'notification-1' })],
+			unreadCount: 1,
+		});
+	});
+
+	it('hides foreign notification ids when marking one read', async () => {
+		const notification = await repository.upsert({
+			recipientId: 'client-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-1',
+			payload: makePayload('order-1', 'message-1'),
+		});
+
+		await expect(
+			controller.markRead(
+				notification.id,
+				{ expectedActivityAt: notification.activityAt.toISOString() },
+				otherClientUser,
+			),
+		).rejects.toThrow(NotificationNotFoundError);
+	});
+
+	it('marks all owned notifications read and emits the remaining unread count', async () => {
+		await repository.upsert({
+			recipientId: 'client-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			aggregateKey: 'order-1',
+			payload: makePayload('order-1', 'message-1'),
+		});
+
+		await expect(controller.markAllRead(clientUser)).resolves.toMatchObject({
+			unreadCount: 0,
+			updatedCount: 1,
+		});
+		expect(events.readAll).toEqual([
+			{ recipientId: 'client-1', unreadCount: 0 },
+		]);
+	});
+});

--- a/apps/api/test/integration/orders/orders.integration.spec.ts
+++ b/apps/api/test/integration/orders/orders.integration.spec.ts
@@ -1,4 +1,6 @@
 import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import { CHAT_REPOSITORY_KEY } from '@modules/chat/application/ports/chat-repository.port';
+import { CHAT_THREAD_WRITER_KEY } from '@modules/chat/application/ports/chat-thread-writer.port';
 import { BOOSTER_USER_READER_KEY } from '@modules/orders/application/ports/booster-user-reader.port';
 import { ORDER_CHECKOUT_PORT_KEY } from '@modules/orders/application/ports/order-checkout.port';
 import { ORDER_COMPLETION_EARNINGS_PORT_KEY } from '@modules/orders/application/ports/order-completion-earnings.port';
@@ -22,6 +24,7 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { Role } from '@packages/auth/roles/role';
 import { makeDefaultOrderPricingVersionInput } from '../../order-pricing-version-test-data';
+import { InMemoryChatRepository } from '../../support/in-memory/chat/in-memory-chat.repository';
 import { InMemoryOrderRepository } from '../../support/in-memory/orders/in-memory-order.repository';
 import { InMemoryOrderCheckoutRepository } from '../../support/in-memory/orders/in-memory-order-checkout.repository';
 import { InMemoryOrderPricingVersionRepository } from '../../support/in-memory/orders/in-memory-order-pricing-version.repository';
@@ -32,6 +35,7 @@ describe('Orders module integration', () => {
 	let controller: OrdersController;
 	let pricingAdminController: OrdersPricingAdminController;
 	let orderRepository: InMemoryOrderRepository;
+	let chatRepository: InMemoryChatRepository;
 	let pricingVersions: OrderPricingVersionRepositoryPort;
 	let markOrderAsPaidUseCase: MarkOrderAsPaidUseCase;
 	const adminUser: AuthenticatedUser = {
@@ -102,11 +106,17 @@ describe('Orders module integration', () => {
 	}
 
 	beforeEach(async () => {
+		orderRepository = new InMemoryOrderRepository();
+		chatRepository = new InMemoryChatRepository(orderRepository);
 		moduleRef = await Test.createTestingModule({
 			imports: [OrdersModule],
 		})
 			.overrideProvider(ORDER_REPOSITORY_KEY)
-			.useClass(InMemoryOrderRepository)
+			.useValue(orderRepository)
+			.overrideProvider(CHAT_REPOSITORY_KEY)
+			.useValue(chatRepository)
+			.overrideProvider(CHAT_THREAD_WRITER_KEY)
+			.useValue(chatRepository)
 			.overrideProvider(ORDER_CHECKOUT_PORT_KEY)
 			.useClass(InMemoryOrderCheckoutRepository)
 			.overrideProvider(ORDER_QUOTE_REPOSITORY_KEY)
@@ -121,7 +131,6 @@ describe('Orders module integration', () => {
 
 		controller = moduleRef.get(OrdersController);
 		pricingAdminController = moduleRef.get(OrdersPricingAdminController);
-		orderRepository = moduleRef.get(ORDER_REPOSITORY_KEY);
 		pricingVersions = moduleRef.get(ORDER_PRICING_VERSION_REPOSITORY_KEY);
 		markOrderAsPaidUseCase = moduleRef.get(MarkOrderAsPaidUseCase);
 		const version = await pricingVersions.createDraft(

--- a/apps/api/test/support/in-memory/chat/in-memory-chat.repository.ts
+++ b/apps/api/test/support/in-memory/chat/in-memory-chat.repository.ts
@@ -1,5 +1,6 @@
 import type {
 	ChatMessageRecord,
+	ChatMessageWriteResult,
 	ChatOrderRecord,
 	ChatRepositoryPort,
 	ListChatMessagesInput,
@@ -48,6 +49,15 @@ export class InMemoryChatRepository implements ChatRepositoryPort {
 		senderId: string;
 		content: string;
 	}): Promise<ChatMessageRecord> {
+		return (await this.createMessageWithNotification(input)).message;
+	}
+
+	async createMessageWithNotification(input: {
+		chatId: string;
+		senderId: string;
+		content: string;
+		notification?: { recipientId: string };
+	}): Promise<ChatMessageWriteResult> {
 		const orderId = this.getOrderIdForChat(input.chatId);
 		const message: ChatMessageRecord = {
 			id: `message-${this.nextMessageId++}`,
@@ -67,7 +77,33 @@ export class InMemoryChatRepository implements ChatRepositoryPort {
 			message,
 		]);
 
-		return message;
+		return {
+			message,
+			...(input.notification
+				? {
+						notification: {
+							notification: {
+								id: `notification-${message.id}`,
+								type: 'CHAT_MESSAGE_CREATED' as const,
+								payload: {
+									type: 'CHAT_MESSAGE_CREATED' as const,
+									metadata: {
+										orderId,
+										chatMessageId: message.id,
+										senderId: message.sender.id,
+										senderUsername: message.sender.username,
+									},
+								},
+								readAt: null,
+								activityAt: message.createdAt.toISOString(),
+								createdAt: message.createdAt.toISOString(),
+								updatedAt: message.createdAt.toISOString(),
+							},
+							unreadCount: 1,
+						},
+					}
+				: {}),
+		};
 	}
 
 	async listMessages(

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,7 @@
 PORT=3001
 NEXT_PUBLIC_APP_URL=http://localhost:3001
 API_URL=http://localhost:3000
+NEXT_PUBLIC_API_URL=http://localhost:3000
 WEB_SESSION_SECRET=replace-with-at-least-32-characters
+# Set in production when the web and API run on sibling subdomains.
+# WEB_SESSION_COOKIE_DOMAIN=.example.com

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
 		"react": "19.2.3",
 		"react-dom": "19.2.3",
 		"react-hook-form": "^7.72.1",
+		"socket.io-client": "^4.8.3",
 		"tailwind-merge": "^3.5.0",
 		"zod": "^3.25.76"
 	},

--- a/apps/web/src/app/(dashboard)/booster/orders/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/booster/orders/[id]/page.tsx
@@ -1,0 +1,17 @@
+import { BoosterOrderDetailsPage } from '@/modules/booster-dashboard/presentation/order-details/booster-order-details-page';
+
+type BoosterOrderDetailsRouteProps = {
+	params: Promise<{
+		id: string;
+	}>;
+};
+
+const BoosterOrderDetailsRoute = async ({
+	params,
+}: BoosterOrderDetailsRouteProps) => {
+	const { id } = await params;
+
+	return <BoosterOrderDetailsPage orderId={id} />;
+};
+
+export default BoosterOrderDetailsRoute;

--- a/apps/web/src/app/api/notifications/route.spec.ts
+++ b/apps/web/src/app/api/notifications/route.spec.ts
@@ -1,0 +1,72 @@
+jest.mock('@/shared/api-client-management/api-client', () => ({
+	api: {
+		request: jest.fn(),
+	},
+}));
+
+import { api } from '@/shared/api-client-management/api-client';
+import { ApiRequestError } from '@/shared/api-client-management/http';
+
+const apiRequestMock = jest.mocked(api.request);
+const originalResponse = global.Response;
+let GET: typeof import('./route').GET;
+
+class TestResponse {
+	readonly body: string | null;
+	readonly status: number;
+
+	constructor(body?: string | null, init?: ResponseInit) {
+		this.body = body ?? null;
+		this.status = init?.status ?? 200;
+	}
+
+	async json(): Promise<unknown> {
+		return this.body ? JSON.parse(this.body) : null;
+	}
+
+	static json(body: unknown, init?: ResponseInit): TestResponse {
+		return new TestResponse(JSON.stringify(body), init);
+	}
+}
+
+const responsePayload = {
+	items: [],
+	nextCursor: null,
+	unreadCount: 0,
+};
+
+describe('notifications BFF route', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		global.Response = TestResponse as unknown as typeof global.Response;
+		({ GET } = require('./route') as typeof import('./route'));
+	});
+
+	afterEach(() => {
+		global.Response = originalResponse;
+	});
+
+	it('returns authenticated notification state without exposing tokens', async () => {
+		apiRequestMock.mockResolvedValue(responsePayload);
+
+		const response = await GET();
+
+		await expect(response.json()).resolves.toEqual(responsePayload);
+		expect(apiRequestMock).toHaveBeenCalledWith('/notifications?limit=10', {
+			auth: true,
+		});
+	});
+
+	it('maps API auth failures to the browser route status', async () => {
+		apiRequestMock.mockRejectedValue(
+			new ApiRequestError(401, { message: 'Entre novamente.' }),
+		);
+
+		const response = await GET();
+
+		expect(response.status).toBe(401);
+		await expect(response.json()).resolves.toEqual({
+			message: 'Entre novamente.',
+		});
+	});
+});

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -1,0 +1,27 @@
+import { api } from '@/shared/api-client-management/api-client';
+import { ApiRequestError } from '@/shared/api-client-management/http';
+import { listNotificationsResponseSchema } from '@/shared/notifications/notification-contracts';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export const GET = async () => {
+	try {
+		const response = await api.request<unknown>('/notifications?limit=10', {
+			auth: true,
+		});
+
+		return Response.json(listNotificationsResponseSchema.parse(response), {
+			headers: { 'cache-control': 'no-store' },
+		});
+	} catch (error) {
+		if (error instanceof ApiRequestError) {
+			return Response.json(
+				{ message: error.payload?.message ?? 'Unable to load notifications.' },
+				{ status: error.status, headers: { 'cache-control': 'no-store' } },
+			);
+		}
+
+		throw error;
+	}
+};

--- a/apps/web/src/modules/admin-dashboard/presentation/dashboard/admin-dashboard-shell.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/dashboard/admin-dashboard-shell.tsx
@@ -1,6 +1,8 @@
 import { Shield } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { logoutAction } from '@/modules/auth/actions/auth-actions';
+import { getDashboardNotifications } from '@/modules/notifications/actions/notification-actions';
+import { NotificationPopover } from '@/modules/notifications/presentation/notification-popover';
 import { DashboardShell as SharedDashboardShell } from '@/shared/dashboard/dashboard-shell';
 import { AdminNavigation } from './admin-navigation';
 
@@ -11,28 +13,38 @@ type AdminDashboardShellProps = {
 	};
 };
 
-export const AdminDashboardShell = ({
+export const AdminDashboardShell = async ({
 	children,
 	user,
-}: AdminDashboardShellProps) => (
-	<SharedDashboardShell
-		user={user}
-		roleLabel="ADMIN"
-		roleIcon={Shield}
-		portalLabel="Painel Admin"
-		navigation={<AdminNavigation />}
-		logoutAction={logoutAction}
-		headerAside={
-			<div className="text-right">
-				<p className="text-[8px] font-medium uppercase tracking-widest text-white/40">
-					Acesso
-				</p>
-				<p className="text-[9px] font-black uppercase tracking-widest text-emerald-400">
-					Restrito
-				</p>
-			</div>
-		}
-	>
-		{children}
-	</SharedDashboardShell>
-);
+}: AdminDashboardShellProps) => {
+	const notifications = await getDashboardNotifications();
+
+	return (
+		<SharedDashboardShell
+			user={user}
+			roleLabel="ADMIN"
+			roleIcon={Shield}
+			portalLabel="Painel Admin"
+			navigation={<AdminNavigation />}
+			logoutAction={logoutAction}
+			headerAside={
+				<div className="flex items-center gap-4">
+					<NotificationPopover
+						initialNotifications={notifications}
+						viewerRole="ADMIN"
+					/>
+					<div className="text-right">
+						<p className="text-[8px] font-medium uppercase tracking-widest text-white/40">
+							Acesso
+						</p>
+						<p className="text-[9px] font-black uppercase tracking-widest text-emerald-400">
+							Restrito
+						</p>
+					</div>
+				</div>
+			}
+		>
+			{children}
+		</SharedDashboardShell>
+	);
+};

--- a/apps/web/src/modules/booster-dashboard/actions/booster-actions.ts
+++ b/apps/web/src/modules/booster-dashboard/actions/booster-actions.ts
@@ -19,6 +19,7 @@ import {
 } from '@/shared/chat/chat-service';
 import { assertSameOriginRequest } from '@/shared/security/origin';
 import type {
+	BoosterOrderOutput,
 	BoosterQueueOutput,
 	BoosterWalletOutput,
 	BoosterWalletTransactionsOutput,
@@ -83,6 +84,17 @@ export const getBoosterWork = async (): Promise<BoosterWorkOutput> => {
 	} catch (error) {
 		return redirectOnAuthError(error);
 	}
+};
+
+export const getBoosterOrder = async (
+	orderId: string,
+): Promise<BoosterOrderOutput | null> => {
+	const work = await getBoosterWork();
+	return (
+		[...work.activeOrders, ...work.recentCompletedOrders].find(
+			(order) => order.id === orderId,
+		) ?? null
+	);
 };
 
 export const getBoosterWallet = async (): Promise<BoosterWalletOutput> => {

--- a/apps/web/src/modules/booster-dashboard/presentation/dashboard/booster-dashboard-shell.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/dashboard/booster-dashboard-shell.tsx
@@ -3,6 +3,8 @@ import { User, Wallet } from 'lucide-react';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { logoutAction } from '@/modules/auth/actions/auth-actions';
+import { getDashboardNotifications } from '@/modules/notifications/actions/notification-actions';
+import { NotificationPopover } from '@/modules/notifications/presentation/notification-popover';
 import { DashboardShell as SharedDashboardShell } from '@/shared/dashboard/dashboard-shell';
 import { BoosterNavigation } from './booster-navigation';
 
@@ -13,31 +15,41 @@ type BoosterDashboardShellProps = {
 	};
 };
 
-export const BoosterDashboardShell = ({
+export const BoosterDashboardShell = async ({
 	children,
 	user,
-}: BoosterDashboardShellProps) => (
-	<SharedDashboardShell
-		user={user}
-		roleLabel="BOOSTER"
-		roleIcon={User}
-		portalLabel="Portal do Booster"
-		navigation={<BoosterNavigation />}
-		logoutAction={logoutAction}
-		headerAside={
-			<Link
-				href="/booster"
-				className={getButtonClassName({
-					variant: 'outline',
-					size: 'sm',
-					className: 'gap-2',
-				})}
-			>
-				<Wallet className="h-3 w-3" />
-				Carteira
-			</Link>
-		}
-	>
-		{children}
-	</SharedDashboardShell>
-);
+}: BoosterDashboardShellProps) => {
+	const notifications = await getDashboardNotifications();
+
+	return (
+		<SharedDashboardShell
+			user={user}
+			roleLabel="BOOSTER"
+			roleIcon={User}
+			portalLabel="Portal do Booster"
+			navigation={<BoosterNavigation />}
+			logoutAction={logoutAction}
+			headerAside={
+				<div className="flex items-center gap-3">
+					<NotificationPopover
+						initialNotifications={notifications}
+						viewerRole="BOOSTER"
+					/>
+					<Link
+						href="/booster"
+						className={getButtonClassName({
+							variant: 'outline',
+							size: 'sm',
+							className: 'gap-2',
+						})}
+					>
+						<Wallet className="h-3 w-3" />
+						Carteira
+					</Link>
+				</div>
+			}
+		>
+			{children}
+		</SharedDashboardShell>
+	);
+};

--- a/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.tsx
@@ -1,0 +1,96 @@
+import { notFound } from 'next/navigation';
+import type { ChatMessage } from '@/shared/chat/chat.types';
+import {
+	getBoosterOrder,
+	getBoosterOrderChatMessages,
+	getBoosterUserId,
+} from '../../actions/booster-actions';
+import {
+	formatCurrency,
+	formatDate,
+	formatOrderRoute,
+	toBoosterWork,
+} from '../../model/booster-orders';
+import type { BoosterOrderOutput } from '../../server/booster-contracts';
+import { BoosterChatPanel } from '../overview/booster-chat-panel';
+
+type BoosterOrderDetailsPageProps = {
+	orderId: string;
+};
+
+const toSingleOrderWork = (order: BoosterOrderOutput) =>
+	toBoosterWork({
+		activeOrders: [order],
+		recentCompletedOrders: [],
+		summary: {
+			activeOrders: 1,
+			completedOrders: 0,
+			earnedFromRecentCompletions: 0,
+		},
+	}).activeOrders[0];
+
+export const BoosterOrderDetailsPage = async ({
+	orderId,
+}: BoosterOrderDetailsPageProps) => {
+	const [orderOutput, currentUserId, chatResult] = await Promise.all([
+		getBoosterOrder(orderId),
+		getBoosterUserId(),
+		getBoosterOrderChatMessages(orderId),
+	]);
+	if (!orderOutput) notFound();
+
+	const order = toSingleOrderWork(orderOutput);
+	const chatMessages: ChatMessage[] = chatResult.items;
+
+	return (
+		<div className="space-y-8">
+			<section className="space-y-3">
+				<p className="text-[10px] font-black uppercase tracking-[0.2em] text-hextech-cyan">
+					Pedido em execução
+				</p>
+				<div>
+					<h1 className="font-display text-3xl font-black text-white">
+						{formatOrderRoute(order)}
+					</h1>
+					<p className="mt-2 font-mono text-xs text-white/35">{order.id}</p>
+				</div>
+			</section>
+
+			<div className="grid gap-8 lg:grid-cols-[1fr_380px]">
+				<section className="grid gap-4 sm:grid-cols-3">
+					<div className="border border-white/5 bg-white/5 p-5">
+						<p className="text-[9px] font-black uppercase tracking-widest text-white/35">
+							Status
+						</p>
+						<p className="mt-2 text-sm font-black uppercase tracking-widest text-white">
+							{order.statusLabel}
+						</p>
+					</div>
+					<div className="border border-white/5 bg-white/5 p-5">
+						<p className="text-[9px] font-black uppercase tracking-widest text-white/35">
+							Prazo
+						</p>
+						<p className="mt-2 text-sm font-black text-white">
+							{formatDate(order.deadline)}
+						</p>
+					</div>
+					<div className="border border-white/5 bg-white/5 p-5">
+						<p className="text-[9px] font-black uppercase tracking-widest text-white/35">
+							Repasse
+						</p>
+						<p className="mt-2 text-sm font-black text-hextech-gold">
+							{formatCurrency(order.boosterAmount)}
+						</p>
+					</div>
+				</section>
+
+				<BoosterChatPanel
+					orderId={order.id}
+					orderLabel={formatOrderRoute(order)}
+					currentUserId={currentUserId}
+					initialMessages={chatMessages}
+				/>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/modules/client-dashboard/presentation/dashboard/dashboard-shell.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/dashboard/dashboard-shell.spec.tsx
@@ -4,6 +4,7 @@ import type {
 	AnchorHTMLAttributes,
 	HTMLAttributes,
 	PropsWithChildren,
+	ReactNode,
 } from 'react';
 import { DashboardShell } from './dashboard-shell';
 
@@ -13,6 +14,18 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('@/modules/auth/actions/auth-actions', () => ({
 	logoutAction: jest.fn(),
+}));
+
+jest.mock('@/modules/notifications/actions/notification-actions', () => ({
+	getDashboardNotifications: jest.fn().mockResolvedValue({
+		items: [],
+		nextCursor: null,
+		unreadCount: 0,
+	}),
+}));
+
+jest.mock('@/modules/notifications/presentation/notification-popover', () => ({
+	NotificationPopover: () => <div data-testid="notification-popover" />,
 }));
 
 jest.mock('@packages/ui/brand/glitch-logo', () => ({
@@ -66,48 +79,42 @@ describe('DashboardShell', () => {
 		(usePathname as jest.Mock).mockReturnValue('/client');
 	});
 
-	it('should render dashboard shell with user info', () => {
+	const renderShell = async (children: ReactNode) => {
 		render(
-			<DashboardShell user={mockUser}>
-				<div data-testid="children">Content</div>
-			</DashboardShell>,
+			await DashboardShell({
+				user: mockUser,
+				children,
+			}),
 		);
+	};
+
+	it('should render dashboard shell with user info', async () => {
+		await renderShell(<div data-testid="children">Content</div>);
 
 		expect(screen.getByText('TestUser')).toBeInTheDocument();
 		expect(screen.getByTestId('glitch-logo')).toBeInTheDocument();
+		expect(screen.getByTestId('notification-popover')).toBeInTheDocument();
 		expect(screen.getByTestId('children')).toBeInTheDocument();
 	});
 
-	it('should highlight active sidebar item', () => {
+	it('should highlight active sidebar item', async () => {
 		(usePathname as jest.Mock).mockReturnValue('/client/orders/new');
 
-		render(
-			<DashboardShell user={mockUser}>
-				<div>Content</div>
-			</DashboardShell>,
-		);
+		await renderShell(<div>Content</div>);
 
 		const activeItem = screen.getByRole('link', { name: /Novo Pedido/i });
 		expect(activeItem).toHaveAttribute('aria-current', 'page');
 	});
 
-	it('should render sidebar navigation items', () => {
-		render(
-			<DashboardShell user={mockUser}>
-				<div>Content</div>
-			</DashboardShell>,
-		);
+	it('should render sidebar navigation items', async () => {
+		await renderShell(<div>Content</div>);
 
 		expect(screen.getByText('Painel')).toBeInTheDocument();
 		expect(screen.getByText('Novo Pedido')).toBeInTheDocument();
 	});
 
-	it('should have logout button', () => {
-		render(
-			<DashboardShell user={mockUser}>
-				<div>Content</div>
-			</DashboardShell>,
-		);
+	it('should have logout button', async () => {
+		await renderShell(<div>Content</div>);
 
 		expect(screen.getByRole('button', { name: /Sair/i })).toBeInTheDocument();
 	});

--- a/apps/web/src/modules/client-dashboard/presentation/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/dashboard/dashboard-shell.tsx
@@ -1,6 +1,8 @@
 import { User } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { logoutAction } from '@/modules/auth/actions/auth-actions';
+import { getDashboardNotifications } from '@/modules/notifications/actions/notification-actions';
+import { NotificationPopover } from '@/modules/notifications/presentation/notification-popover';
 import { DashboardShell as SharedDashboardShell } from '@/shared/dashboard/dashboard-shell';
 import { DashboardNavigation } from './dashboard-navigation';
 
@@ -11,28 +13,41 @@ type DashboardShellProps = {
 	};
 };
 
-export const DashboardShell = ({ children, user }: DashboardShellProps) => (
-	<SharedDashboardShell
-		user={user}
-		roleLabel="CLIENTE"
-		roleIcon={User}
-		portalLabel="Portal do Cliente"
-		navigation={<DashboardNavigation />}
-		logoutAction={logoutAction}
-		headerAside={
-			<div className="text-right">
-				<p className="text-[8px] font-medium uppercase tracking-widest text-white/40">
-					Status do Sistema
-				</p>
-				<div className="flex items-center justify-end gap-1.5">
-					<div className="h-1 w-1 rounded-full bg-emerald-500" />
-					<p className="text-[9px] font-black uppercase tracking-widest text-emerald-400">
-						Online
-					</p>
+export const DashboardShell = async ({
+	children,
+	user,
+}: DashboardShellProps) => {
+	const notifications = await getDashboardNotifications();
+
+	return (
+		<SharedDashboardShell
+			user={user}
+			roleLabel="CLIENTE"
+			roleIcon={User}
+			portalLabel="Portal do Cliente"
+			navigation={<DashboardNavigation />}
+			logoutAction={logoutAction}
+			headerAside={
+				<div className="flex items-center gap-4">
+					<NotificationPopover
+						initialNotifications={notifications}
+						viewerRole="CLIENT"
+					/>
+					<div className="text-right">
+						<p className="text-[8px] font-medium uppercase tracking-widest text-white/40">
+							Status do Sistema
+						</p>
+						<div className="flex items-center justify-end gap-1.5">
+							<div className="h-1 w-1 rounded-full bg-emerald-500" />
+							<p className="text-[9px] font-black uppercase tracking-widest text-emerald-400">
+								Online
+							</p>
+						</div>
+					</div>
 				</div>
-			</div>
-		}
-	>
-		{children}
-	</SharedDashboardShell>
-);
+			}
+		>
+			{children}
+		</SharedDashboardShell>
+	);
+};

--- a/apps/web/src/modules/notifications/actions/notification-actions.ts
+++ b/apps/web/src/modules/notifications/actions/notification-actions.ts
@@ -1,0 +1,99 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { api } from '@/shared/api-client-management/api-client';
+import { ApiRequestError } from '@/shared/api-client-management/http';
+import { redirectOnAuthError } from '@/shared/auth/redirect-on-auth-error';
+import type {
+	ListNotificationsResponse,
+	NotificationOutput,
+} from '@/shared/notifications/notification-contracts';
+import {
+	listNotifications,
+	markAllNotificationsRead,
+	markNotificationRead,
+} from '@/shared/notifications/notification-service';
+import { assertSameOriginRequest } from '@/shared/security/origin';
+
+export type NotificationActionState =
+	| {
+			notification: NotificationOutput;
+			conflict?: never;
+			error?: never;
+	  }
+	| {
+			error: string;
+			conflict?: boolean;
+			notification?: never;
+	  };
+
+export const getDashboardNotifications =
+	async (): Promise<ListNotificationsResponse> => {
+		try {
+			return await listNotifications((path, init) =>
+				api.request(path, { ...init, allowSessionRefresh: false }),
+			);
+		} catch (error) {
+			return redirectOnAuthError(error);
+		}
+	};
+
+export const markDashboardNotificationReadAction = async (
+	notificationId: string,
+	expectedActivityAt: string,
+): Promise<NotificationActionState> => {
+	try {
+		await assertSameOriginRequest();
+		const notification = await markNotificationRead(
+			notificationId,
+			expectedActivityAt,
+			api.request,
+		);
+		revalidatePath('/client');
+		revalidatePath('/booster');
+		revalidatePath('/admin');
+		return { notification };
+	} catch (error) {
+		if (
+			error instanceof ApiRequestError &&
+			(error.status === 401 || error.status === 403)
+		) {
+			return { error: 'Entre novamente para continuar.' };
+		}
+		if (error instanceof ApiRequestError && error.status === 409) {
+			return {
+				conflict: true,
+				error: 'A notificação mudou. Atualizando a lista.',
+			};
+		}
+
+		return { error: 'Não foi possível marcar a notificação como lida.' };
+	}
+};
+
+export const markAllDashboardNotificationsReadAction = async (): Promise<{
+	cutoffActivityAt?: string;
+	error?: string;
+	unreadCount?: number;
+}> => {
+	try {
+		await assertSameOriginRequest();
+		const result = await markAllNotificationsRead(api.request);
+		revalidatePath('/client');
+		revalidatePath('/booster');
+		revalidatePath('/admin');
+		return {
+			cutoffActivityAt: result.cutoffActivityAt,
+			unreadCount: result.unreadCount,
+		};
+	} catch (error) {
+		if (
+			error instanceof ApiRequestError &&
+			(error.status === 401 || error.status === 403)
+		) {
+			return { error: 'Entre novamente para continuar.' };
+		}
+
+		return { error: 'Não foi possível marcar as notificações como lidas.' };
+	}
+};

--- a/apps/web/src/modules/notifications/presentation/notification-live-state.spec.ts
+++ b/apps/web/src/modules/notifications/presentation/notification-live-state.spec.ts
@@ -1,0 +1,93 @@
+import type { ListNotificationsResponse } from '@/shared/notifications/notification-contracts';
+import {
+	applyNotificationsReadAll,
+	applyNotificationUpdated,
+} from './notification-live-state';
+
+const makeNotification = (input: {
+	id: string;
+	chatMessageId: string;
+	activityAt: string;
+	readAt?: string | null;
+	updatedAt: string;
+}) => ({
+	id: input.id,
+	type: 'CHAT_MESSAGE_CREATED' as const,
+	payload: {
+		type: 'CHAT_MESSAGE_CREATED' as const,
+		metadata: {
+			orderId: 'order-1',
+			chatMessageId: input.chatMessageId,
+			senderId: 'booster-1',
+			senderUsername: 'Booster',
+		},
+	},
+	readAt: input.readAt ?? null,
+	activityAt: input.activityAt,
+	createdAt: '2026-05-18T10:00:00.000Z',
+	updatedAt: input.updatedAt,
+});
+
+describe('notification live state', () => {
+	it('deduplicates socket updates and keeps newest notifications first', () => {
+		const state: ListNotificationsResponse = {
+			items: [
+				makeNotification({
+					id: 'notification-1',
+					chatMessageId: 'message-1',
+					activityAt: '2026-05-18T10:00:00.000Z',
+					updatedAt: '2026-05-18T10:00:00.000Z',
+				}),
+			],
+			nextCursor: null,
+			unreadCount: 1,
+		};
+
+		const next = applyNotificationUpdated(
+			state,
+			makeNotification({
+				id: 'notification-1',
+				chatMessageId: 'message-2',
+				activityAt: '2026-05-18T12:00:00.000Z',
+				updatedAt: '2026-05-18T12:00:00.000Z',
+			}),
+			1,
+		);
+
+		expect(next.items).toHaveLength(1);
+		expect(next.items[0]?.payload.metadata.chatMessageId).toBe('message-2');
+		expect(next.unreadCount).toBe(1);
+	});
+
+	it('marks cutoff-eligible local notifications read after a read-all socket event', () => {
+		const state: ListNotificationsResponse = {
+			items: [
+				makeNotification({
+					id: 'notification-1',
+					chatMessageId: 'message-1',
+					activityAt: '2026-05-18T10:00:00.000Z',
+					updatedAt: '2026-05-18T10:00:00.000Z',
+				}),
+				makeNotification({
+					id: 'notification-2',
+					chatMessageId: 'message-2',
+					activityAt: '2026-05-18T13:00:00.000Z',
+					updatedAt: '2026-05-18T13:00:00.000Z',
+				}),
+			],
+			nextCursor: null,
+			unreadCount: 2,
+		};
+
+		const next = applyNotificationsReadAll(
+			state,
+			'2026-05-18T12:00:00.000Z',
+			'2026-05-18T12:00:00.000Z',
+			1,
+		);
+
+		expect(next.unreadCount).toBe(1);
+		expect(next.items[0]?.readAt).toBe('2026-05-18T12:00:00.000Z');
+		expect(next.items[1]?.readAt).toBeNull();
+	});
+});

--- a/apps/web/src/modules/notifications/presentation/notification-live-state.ts
+++ b/apps/web/src/modules/notifications/presentation/notification-live-state.ts
@@ -1,0 +1,58 @@
+import type {
+	ListNotificationsResponse,
+	NotificationOutput,
+} from '@/shared/notifications/notification-contracts';
+
+export const DASHBOARD_NOTIFICATION_LIST_LIMIT = 10;
+
+export const applyNotificationUpdated = (
+	state: ListNotificationsResponse,
+	notification: NotificationOutput,
+	unreadCount: number,
+): ListNotificationsResponse => {
+	const byId = new Map(state.items.map((item) => [item.id, item] as const));
+	byId.set(notification.id, notification);
+
+	return {
+		...state,
+		items: [...byId.values()]
+			.sort(compareNotificationsByActivity)
+			.slice(0, DASHBOARD_NOTIFICATION_LIST_LIMIT),
+		unreadCount,
+	};
+};
+
+export const applyNotificationsReadAll = (
+	state: ListNotificationsResponse,
+	readAt: string,
+	cutoffActivityAt: string,
+	unreadCount: number,
+): ListNotificationsResponse => ({
+	...state,
+	items: state.items.map((notification) => ({
+		...notification,
+		readAt:
+			notification.readAt ??
+			(new Date(notification.activityAt).getTime() <=
+			new Date(cutoffActivityAt).getTime()
+				? readAt
+				: null),
+	})),
+	unreadCount,
+});
+
+export const replaceNotifications = (
+	_state: ListNotificationsResponse,
+	next: ListNotificationsResponse,
+): ListNotificationsResponse => next;
+
+const compareNotificationsByActivity = (
+	left: NotificationOutput,
+	right: NotificationOutput,
+) => {
+	const activityAtDifference =
+		new Date(right.activityAt).getTime() - new Date(left.activityAt).getTime();
+	if (activityAtDifference !== 0) return activityAtDifference;
+
+	return right.id.localeCompare(left.id);
+};

--- a/apps/web/src/modules/notifications/presentation/notification-popover.spec.tsx
+++ b/apps/web/src/modules/notifications/presentation/notification-popover.spec.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NotificationPopover } from './notification-popover';
+
+jest.mock('socket.io-client', () => ({
+	io: jest.fn(() => ({
+		close: jest.fn(),
+		connect: jest.fn(),
+		off: jest.fn(),
+		on: jest.fn(),
+	})),
+}));
+
+jest.mock('../actions/notification-actions', () => ({
+	markAllDashboardNotificationsReadAction: jest.fn().mockResolvedValue({}),
+	markDashboardNotificationReadAction: jest.fn().mockResolvedValue({
+		notification: {
+			id: 'notification-1',
+			type: 'CHAT_MESSAGE_CREATED',
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED',
+				metadata: {
+					orderId: 'order-1',
+					chatMessageId: 'message-1',
+					senderId: 'booster-1',
+					senderUsername: 'Booster',
+				},
+			},
+			readAt: '2026-05-18T12:00:00.000Z',
+			activityAt: '2026-05-18T11:00:00.000Z',
+			createdAt: '2026-05-18T11:00:00.000Z',
+			updatedAt: '2026-05-18T11:00:00.000Z',
+		},
+	}),
+}));
+
+const unreadNotifications = {
+	items: [
+		{
+			id: 'notification-1',
+			type: 'CHAT_MESSAGE_CREATED' as const,
+			payload: {
+				type: 'CHAT_MESSAGE_CREATED' as const,
+				metadata: {
+					orderId: 'order-1',
+					chatMessageId: 'message-1',
+					senderId: 'booster-1',
+					senderUsername: 'Booster',
+				},
+			},
+			readAt: null,
+			activityAt: '2026-05-18T11:00:00.000Z',
+			createdAt: '2026-05-18T11:00:00.000Z',
+			updatedAt: '2026-05-18T11:00:00.000Z',
+		},
+	],
+	nextCursor: null,
+	unreadCount: 1,
+};
+
+describe('NotificationPopover', () => {
+	it('renders unread notifications with the client order link', async () => {
+		render(
+			<NotificationPopover
+				initialNotifications={unreadNotifications}
+				viewerRole="CLIENT"
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole('button', { name: /abrir notificações/i }),
+		);
+
+		expect(screen.getByText('1 nova')).toBeInTheDocument();
+		expect(
+			screen.getByText(/Booster enviou uma mensagem/i),
+		).toBeInTheDocument();
+		expect(screen.getByRole('link')).toHaveAttribute(
+			'href',
+			'/client/orders/order-1',
+		);
+	});
+
+	it('renders the empty state for admins', async () => {
+		render(
+			<NotificationPopover
+				initialNotifications={{ items: [], nextCursor: null, unreadCount: 0 }}
+				viewerRole="ADMIN"
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole('button', { name: /abrir notificações/i }),
+		);
+
+		expect(screen.getByText('Sem notificações')).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/modules/notifications/presentation/notification-popover.tsx
+++ b/apps/web/src/modules/notifications/presentation/notification-popover.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { getButtonClassName } from '@packages/ui/components/button';
+import { cn } from '@packages/ui/utils/cn';
+import { Bell, Check, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { useMemo, useState, useTransition } from 'react';
+import type {
+	ListNotificationsResponse,
+	NotificationOutput,
+} from '@/shared/notifications/notification-contracts';
+import {
+	markAllDashboardNotificationsReadAction,
+	markDashboardNotificationReadAction,
+} from '../actions/notification-actions';
+import { useLiveNotifications } from './use-live-notifications';
+
+type NotificationPopoverProps = {
+	initialNotifications: ListNotificationsResponse;
+	viewerRole: 'CLIENT' | 'BOOSTER' | 'ADMIN';
+};
+
+export const NotificationPopover = ({
+	initialNotifications,
+	viewerRole,
+}: NotificationPopoverProps) => {
+	const [isOpen, setIsOpen] = useState(false);
+	const [pendingNotificationId, setPendingNotificationId] = useState<
+		string | null
+	>(null);
+	const [isPending, startTransition] = useTransition();
+	const {
+		liveError,
+		notifications,
+		refetchNotifications,
+		setLiveError,
+		setNotifications,
+	} = useLiveNotifications(initialNotifications);
+	const visibleUnreadCount = notifications.unreadCount;
+	const unreadLabel =
+		visibleUnreadCount > 9 ? '9+' : String(visibleUnreadCount);
+
+	const hasNotifications = notifications.items.length > 0;
+	const summary = useMemo(() => {
+		if (visibleUnreadCount === 0) return 'Tudo lido';
+		if (visibleUnreadCount === 1) return '1 nova';
+		return `${visibleUnreadCount} novas`;
+	}, [visibleUnreadCount]);
+
+	const markOneRead = (notificationId: string) => {
+		setLiveError(null);
+		setPendingNotificationId(notificationId);
+		startTransition(async () => {
+			const expectedActivityAt = notifications.items.find(
+				(notification) => notification.id === notificationId,
+			)?.activityAt;
+			if (!expectedActivityAt) {
+				setPendingNotificationId(null);
+				return;
+			}
+
+			const result = await markDashboardNotificationReadAction(
+				notificationId,
+				expectedActivityAt,
+			);
+			setPendingNotificationId(null);
+			if (result.error) {
+				setLiveError(result.error);
+				if (result.conflict) await refetchNotifications();
+				return;
+			}
+
+			setNotifications((current) => ({
+				...current,
+				unreadCount: Math.max(
+					current.unreadCount -
+						(current.items.find(
+							(notification) => notification.id === notificationId,
+						)?.readAt
+							? 0
+							: 1),
+					0,
+				),
+				items: current.items.map((notification) =>
+					notification.id === notificationId && result.notification
+						? result.notification
+						: notification,
+				),
+			}));
+		});
+	};
+
+	const markAllRead = () => {
+		setLiveError(null);
+		startTransition(async () => {
+			const result = await markAllDashboardNotificationsReadAction();
+			if (result.error) {
+				setLiveError(result.error);
+				return;
+			}
+
+			const readAt = new Date().toISOString();
+			const cutoffActivityAt = result.cutoffActivityAt ?? readAt;
+			const unreadCount = result.unreadCount ?? 0;
+			setNotifications((current) => ({
+				...current,
+				unreadCount,
+				items: current.items.map((notification) => ({
+					...notification,
+					readAt:
+						notification.readAt ??
+						(new Date(notification.activityAt).getTime() <=
+						new Date(cutoffActivityAt).getTime()
+							? readAt
+							: null),
+				})),
+			}));
+		});
+	};
+
+	return (
+		<div className="relative">
+			<button
+				type="button"
+				aria-label="Abrir notificações"
+				aria-expanded={isOpen}
+				onClick={() => setIsOpen((current) => !current)}
+				className="relative flex h-9 w-9 cursor-pointer items-center justify-center rounded-sm border border-white/10 bg-white/5 text-white/70 transition-colors hover:border-hextech-cyan/40 hover:text-white"
+			>
+				<Bell className="h-4 w-4" />
+				{visibleUnreadCount > 0 ? (
+					<span className="-right-1 -top-1 absolute flex h-4 min-w-4 items-center justify-center rounded-full bg-hextech-cyan px-1 text-[8px] font-black text-black">
+						{unreadLabel}
+					</span>
+				) : null}
+			</button>
+
+			{isOpen ? (
+				<div className="absolute right-0 mt-3 w-[360px] border border-white/10 bg-background shadow-2xl">
+					<div className="flex items-center justify-between border-white/5 border-b p-4">
+						<div>
+							<p className="text-[9px] font-black uppercase tracking-widest text-white/40">
+								Notificações
+							</p>
+							<p className="text-xs font-black uppercase tracking-widest text-white">
+								{summary}
+							</p>
+						</div>
+						<button
+							type="button"
+							onClick={markAllRead}
+							disabled={isPending || visibleUnreadCount === 0}
+							className="cursor-pointer text-[9px] font-black uppercase tracking-widest text-hextech-cyan disabled:cursor-not-allowed disabled:text-white/20"
+						>
+							Ler todas
+						</button>
+					</div>
+
+					<div className="max-h-[420px] overflow-y-auto">
+						{liveError ? (
+							<div className="border-red-400/20 border-b bg-red-500/10 px-4 py-3 text-[10px] font-semibold text-red-200">
+								{liveError}
+							</div>
+						) : null}
+
+						{isPending && !pendingNotificationId ? (
+							<div className="flex items-center gap-2 border-white/5 border-b px-4 py-3 text-[10px] text-white/50">
+								<Loader2 className="h-3 w-3 animate-spin" />
+								Atualizando notificações
+							</div>
+						) : null}
+
+						{hasNotifications ? (
+							notifications.items.map((notification) => (
+								<NotificationItem
+									key={notification.id}
+									notification={notification}
+									viewerRole={viewerRole}
+									isPending={pendingNotificationId === notification.id}
+									onMarkRead={markOneRead}
+								/>
+							))
+						) : (
+							<div className="px-4 py-10 text-center">
+								<p className="text-[10px] font-black uppercase tracking-widest text-white/50">
+									Sem notificações
+								</p>
+								<p className="mt-2 text-xs text-white/35">
+									Novas mensagens do chat aparecerão aqui.
+								</p>
+							</div>
+						)}
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
+};
+
+type NotificationItemProps = {
+	notification: NotificationOutput;
+	viewerRole: NotificationPopoverProps['viewerRole'];
+	isPending: boolean;
+	onMarkRead: (notificationId: string) => void;
+};
+
+const NotificationItem = ({
+	notification,
+	viewerRole,
+	isPending,
+	onMarkRead,
+}: NotificationItemProps) => {
+	const href = getNotificationHref(notification, viewerRole);
+	const isUnread = !notification.readAt;
+
+	return (
+		<div
+			className={cn(
+				'grid grid-cols-[1fr_auto] gap-3 border-white/5 border-b p-4',
+				isUnread ? 'bg-hextech-cyan/5' : 'bg-transparent',
+			)}
+		>
+			<Link href={href} className="min-w-0">
+				<p className="truncate text-[10px] font-black uppercase tracking-widest text-white">
+					Nova mensagem no pedido
+				</p>
+				<p className="mt-1 line-clamp-2 text-xs text-white/50">
+					{notification.payload.metadata.senderUsername} enviou uma mensagem.
+				</p>
+			</Link>
+			{isUnread ? (
+				<button
+					type="button"
+					aria-label="Marcar notificação como lida"
+					onClick={() => onMarkRead(notification.id)}
+					disabled={isPending}
+					className={getButtonClassName({
+						variant: 'ghost',
+						size: 'icon',
+						className: 'h-7 w-7',
+					})}
+				>
+					{isPending ? (
+						<Loader2 className="h-3 w-3 animate-spin" />
+					) : (
+						<Check className="h-3 w-3" />
+					)}
+				</button>
+			) : null}
+		</div>
+	);
+};
+
+const getNotificationHref = (
+	notification: NotificationOutput,
+	role: NotificationPopoverProps['viewerRole'],
+): string => {
+	const orderId = notification.payload.metadata.orderId;
+	if (role === 'BOOSTER')
+		return `/booster/orders/${encodeURIComponent(orderId)}`;
+	if (role === 'CLIENT') return `/client/orders/${encodeURIComponent(orderId)}`;
+	return '/admin/support';
+};

--- a/apps/web/src/modules/notifications/presentation/use-live-notifications.ts
+++ b/apps/web/src/modules/notifications/presentation/use-live-notifications.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { io } from 'socket.io-client';
+import { getPublicApiBaseUrl } from '@/shared/env/public-env';
+import type { ListNotificationsResponse } from '@/shared/notifications/notification-contracts';
+import {
+	listNotificationsResponseSchema,
+	notificationsReadAllEventSchema,
+	notificationUpdatedEventSchema,
+} from '@/shared/notifications/notification-contracts';
+import {
+	applyNotificationsReadAll,
+	applyNotificationUpdated,
+	replaceNotifications,
+} from './notification-live-state';
+
+const NOTIFICATION_NAMESPACE = '/notifications';
+
+export const useLiveNotifications = (
+	initialNotifications: ListNotificationsResponse,
+) => {
+	const [notifications, setNotifications] = useState(initialNotifications);
+	const [liveError, setLiveError] = useState<string | null>(null);
+	const didRetryAuthRef = useRef(false);
+
+	const refetchNotifications = useCallback(async () => {
+		const response = await fetch('/api/notifications', {
+			cache: 'no-store',
+			credentials: 'same-origin',
+		});
+		if (response.status === 401 || response.status === 403) return false;
+		if (!response.ok) throw new Error('Unable to refresh notifications.');
+
+		const next = listNotificationsResponseSchema.parse(await response.json());
+		setNotifications((current) => replaceNotifications(current, next));
+		return true;
+	}, []);
+
+	useEffect(() => {
+		const socket = io(`${getPublicApiBaseUrl()}${NOTIFICATION_NAMESPACE}`, {
+			withCredentials: true,
+			transports: ['websocket', 'polling'],
+		});
+
+		const refreshFromSource = () => {
+			void refetchNotifications().catch(() => {
+				setLiveError('Não foi possível atualizar as notificações.');
+			});
+		};
+		const handleUpdated = (payload: unknown) => {
+			const parsed = notificationUpdatedEventSchema.safeParse(payload);
+			if (!parsed.success) {
+				refreshFromSource();
+				return;
+			}
+
+			setNotifications((current) =>
+				applyNotificationUpdated(
+					current,
+					parsed.data.notification,
+					parsed.data.unreadCount,
+				),
+			);
+		};
+		const handleReadAll = (payload: unknown) => {
+			const parsed = notificationsReadAllEventSchema.safeParse(payload);
+			if (!parsed.success) {
+				refreshFromSource();
+				return;
+			}
+
+			setNotifications((current) =>
+				applyNotificationsReadAll(
+					current,
+					parsed.data.readAt,
+					parsed.data.cutoffActivityAt,
+					parsed.data.unreadCount,
+				),
+			);
+		};
+		const handleAuthError = (payload: unknown) => {
+			const code =
+				typeof payload === 'object' && payload && 'code' in payload
+					? payload.code
+					: null;
+			if (code !== 'AUTHENTICATION_REQUIRED' && code !== 'INVALID_ACCESS_TOKEN')
+				return;
+			if (didRetryAuthRef.current) return;
+
+			didRetryAuthRef.current = true;
+			void refetchNotifications()
+				.then((canReconnect) => {
+					if (canReconnect) socket.connect();
+				})
+				.catch(() => undefined);
+		};
+
+		socket.on('connect', refreshFromSource);
+		socket.on('notifications:updated', handleUpdated);
+		socket.on('notifications:read-all', handleReadAll);
+		socket.on('notifications:error', handleAuthError);
+
+		return () => {
+			socket.off('connect', refreshFromSource);
+			socket.off('notifications:updated', handleUpdated);
+			socket.off('notifications:read-all', handleReadAll);
+			socket.off('notifications:error', handleAuthError);
+			socket.close();
+		};
+	}, [refetchNotifications]);
+
+	return {
+		liveError,
+		notifications,
+		refetchNotifications,
+		setLiveError,
+		setNotifications,
+	};
+};

--- a/apps/web/src/shared/auth/session.spec.ts
+++ b/apps/web/src/shared/auth/session.spec.ts
@@ -1,0 +1,41 @@
+jest.mock('server-only', () => ({}), { virtual: true });
+jest.mock('next/headers', () => ({
+	cookies: jest.fn(),
+}));
+
+import { getAuthSessionCookieOptions } from './session';
+
+describe('auth session cookie options', () => {
+	const originalNodeEnv = process.env.NODE_ENV;
+	const originalCookieDomain = process.env.WEB_SESSION_COOKIE_DOMAIN;
+
+	afterEach(() => {
+		(process.env as Record<string, string | undefined>).NODE_ENV =
+			originalNodeEnv;
+		process.env.WEB_SESSION_COOKIE_DOMAIN = originalCookieDomain;
+	});
+
+	it('keeps development cookies host-only', () => {
+		(process.env as Record<string, string | undefined>).NODE_ENV =
+			'development';
+		delete process.env.WEB_SESSION_COOKIE_DOMAIN;
+
+		expect(getAuthSessionCookieOptions()).toMatchObject({
+			httpOnly: true,
+			path: '/',
+			sameSite: 'lax',
+			secure: false,
+		});
+		expect(getAuthSessionCookieOptions()).not.toHaveProperty('domain');
+	});
+
+	it('uses the configured production cookie domain for cross-subdomain sockets', () => {
+		(process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+		process.env.WEB_SESSION_COOKIE_DOMAIN = ' .elonew.com ';
+
+		expect(getAuthSessionCookieOptions()).toMatchObject({
+			domain: '.elonew.com',
+			secure: true,
+		});
+	});
+});

--- a/apps/web/src/shared/auth/session.ts
+++ b/apps/web/src/shared/auth/session.ts
@@ -2,7 +2,11 @@ import 'server-only';
 
 import { SESSION_COOKIE_NAME } from '@packages/auth/session/session-cookie';
 import { cookies } from 'next/headers';
-import { getWebSessionSecret, isProductionRuntime } from '@/shared/env/web-env';
+import {
+	getWebSessionCookieDomain,
+	getWebSessionSecret,
+	isProductionRuntime,
+} from '@/shared/env/web-env';
 import {
 	type SealedSessionPayload,
 	sealSessionPayload,
@@ -28,13 +32,15 @@ export type AuthSession = SealedSessionPayload;
 
 const refreshTokenMaxAgeSeconds = 60 * 60 * 24 * 30;
 
-const getCookieOptions = () => {
+export const getAuthSessionCookieOptions = () => {
+	const domain = getWebSessionCookieDomain();
 	return {
 		httpOnly: true,
 		secure: isProductionRuntime(),
 		sameSite: 'lax' as const,
 		path: '/',
 		maxAge: refreshTokenMaxAgeSeconds,
+		...(domain ? { domain } : {}),
 	};
 };
 
@@ -62,7 +68,11 @@ export const setAuthSession = async (session: AuthSessionInput) => {
 		getSessionSecret(),
 	);
 
-	cookieStore.set(SESSION_COOKIE_NAME, sealedSession, getCookieOptions());
+	cookieStore.set(
+		SESSION_COOKIE_NAME,
+		sealedSession,
+		getAuthSessionCookieOptions(),
+	);
 };
 
 export const clearAuthSession = async () => {

--- a/apps/web/src/shared/env/public-env.ts
+++ b/apps/web/src/shared/env/public-env.ts
@@ -1,0 +1,8 @@
+const DEFAULT_PUBLIC_API_BASE_URL = 'http://localhost:3000';
+
+export const getPublicApiBaseUrl = () => {
+	const configuredUrl = process.env.NEXT_PUBLIC_API_URL;
+	if (configuredUrl) return configuredUrl.replace(/\/$/, '');
+	if (process.env.NODE_ENV !== 'production') return DEFAULT_PUBLIC_API_BASE_URL;
+	throw new Error('NEXT_PUBLIC_API_URL is required in production.');
+};

--- a/apps/web/src/shared/env/web-env.ts
+++ b/apps/web/src/shared/env/web-env.ts
@@ -13,6 +13,11 @@ export const getWebSessionSecret = () => {
 	return secret;
 };
 
+export const getWebSessionCookieDomain = () => {
+	const domain = process.env.WEB_SESSION_COOKIE_DOMAIN?.trim();
+	return domain || undefined;
+};
+
 export const getWebAppUrl = () => process.env.NEXT_PUBLIC_APP_URL;
 
 export const isProductionRuntime = () => process.env.NODE_ENV === 'production';

--- a/apps/web/src/shared/notifications/notification-contracts.ts
+++ b/apps/web/src/shared/notifications/notification-contracts.ts
@@ -1,0 +1,25 @@
+import {
+	type ListNotificationsResponse,
+	listNotificationsResponseSchema,
+	type MarkAllNotificationsReadResponse,
+	markAllNotificationsReadResponseSchema,
+	type NotificationOutput,
+	type NotificationsReadAllEvent,
+	type NotificationUpdatedEvent,
+	notificationSchema,
+	notificationsReadAllEventSchema,
+	notificationUpdatedEventSchema,
+} from '@packages/shared/notifications/notification.schema';
+
+export {
+	listNotificationsResponseSchema,
+	notificationSchema,
+	notificationUpdatedEventSchema,
+	notificationsReadAllEventSchema,
+	type ListNotificationsResponse,
+	type MarkAllNotificationsReadResponse,
+	markAllNotificationsReadResponseSchema,
+	type NotificationUpdatedEvent,
+	type NotificationOutput,
+	type NotificationsReadAllEvent,
+};

--- a/apps/web/src/shared/notifications/notification-service.spec.ts
+++ b/apps/web/src/shared/notifications/notification-service.spec.ts
@@ -1,0 +1,85 @@
+import {
+	listNotifications,
+	markAllNotificationsRead,
+	markNotificationRead,
+} from './notification-service';
+
+const notification = {
+	id: 'notification-1',
+	type: 'CHAT_MESSAGE_CREATED',
+	payload: {
+		type: 'CHAT_MESSAGE_CREATED',
+		metadata: {
+			orderId: 'order-1',
+			chatMessageId: 'message-1',
+			senderId: 'booster-1',
+			senderUsername: 'Booster',
+		},
+	},
+	readAt: null,
+	activityAt: '2026-05-18T11:00:00.000Z',
+	createdAt: '2026-05-18T11:00:00.000Z',
+	updatedAt: '2026-05-18T11:00:00.000Z',
+};
+
+describe('notification service', () => {
+	it('uses authenticated requests for listing notifications', async () => {
+		const apiRequest = jest.fn().mockResolvedValue({
+			items: [notification],
+			nextCursor: null,
+			unreadCount: 1,
+		});
+
+		await expect(listNotifications(apiRequest)).resolves.toEqual({
+			items: [notification],
+			nextCursor: null,
+			unreadCount: 1,
+		});
+		expect(apiRequest).toHaveBeenCalledWith('/notifications?limit=10', {
+			auth: true,
+		});
+	});
+
+	it('sends the expected activity timestamp when marking one notification read', async () => {
+		const readNotification = {
+			...notification,
+			readAt: '2026-05-18T12:00:00.000Z',
+		};
+		const apiRequest = jest.fn().mockResolvedValue(readNotification);
+
+		await expect(
+			markNotificationRead(
+				'notification-1',
+				'2026-05-18T11:00:00.000Z',
+				apiRequest,
+			),
+		).resolves.toEqual(readNotification);
+		expect(apiRequest).toHaveBeenCalledWith(
+			'/notifications/notification-1/read',
+			{
+				auth: true,
+				method: 'PATCH',
+				body: JSON.stringify({
+					expectedActivityAt: '2026-05-18T11:00:00.000Z',
+				}),
+			},
+		);
+	});
+
+	it('parses the mark-all response from the backend', async () => {
+		const response = {
+			cutoffActivityAt: '2026-05-18T12:00:00.000Z',
+			unreadCount: 1,
+			updatedCount: 2,
+		};
+		const apiRequest = jest.fn().mockResolvedValue(response);
+
+		await expect(markAllNotificationsRead(apiRequest)).resolves.toEqual(
+			response,
+		);
+		expect(apiRequest).toHaveBeenCalledWith('/notifications/read-all', {
+			auth: true,
+			method: 'PATCH',
+		});
+	});
+});

--- a/apps/web/src/shared/notifications/notification-service.ts
+++ b/apps/web/src/shared/notifications/notification-service.ts
@@ -1,0 +1,53 @@
+import {
+	type ListNotificationsResponse,
+	listNotificationsResponseSchema,
+	type MarkAllNotificationsReadResponse,
+	markAllNotificationsReadResponseSchema,
+	type NotificationOutput,
+	notificationSchema,
+} from './notification-contracts';
+
+type AuthenticatedApiRequest = <T>(
+	path: string,
+	init: RequestInit & { auth: true },
+) => Promise<T>;
+
+export const listNotifications = async (
+	apiRequest: AuthenticatedApiRequest,
+	limit = 10,
+): Promise<ListNotificationsResponse> => {
+	const response = await apiRequest<unknown>(
+		`/notifications?limit=${encodeURIComponent(String(limit))}`,
+		{ auth: true },
+	);
+
+	return listNotificationsResponseSchema.parse(response);
+};
+
+export const markNotificationRead = async (
+	notificationId: string,
+	expectedActivityAt: string,
+	apiRequest: AuthenticatedApiRequest,
+): Promise<NotificationOutput> => {
+	const response = await apiRequest<unknown>(
+		`/notifications/${encodeURIComponent(notificationId)}/read`,
+		{
+			auth: true,
+			method: 'PATCH',
+			body: JSON.stringify({ expectedActivityAt }),
+		},
+	);
+
+	return notificationSchema.parse(response);
+};
+
+export const markAllNotificationsRead = async (
+	apiRequest: AuthenticatedApiRequest,
+): Promise<MarkAllNotificationsReadResponse> => {
+	const response = await apiRequest<unknown>('/notifications/read-all', {
+		auth: true,
+		method: 'PATCH',
+	});
+
+	return markAllNotificationsReadResponseSchema.parse(response);
+};

--- a/docs/notifications-websocket.md
+++ b/docs/notifications-websocket.md
@@ -1,0 +1,57 @@
+# Notifications WebSocket Contract
+
+## Scope
+
+Issue `#64` adds authenticated Socket.IO delivery for persisted in-platform
+notifications. The persisted REST API remains the source of truth for
+notification history, unread counts, reconnect recovery, and authorization.
+
+Notifications are in-platform only. Email, Discord, push, SMS, and external
+provider delivery are out of scope.
+
+## Connection
+
+- Namespace: `/notifications`
+- Allowed browser origins: configured by the same API Socket.IO adapter path
+  used for dashboard sockets.
+- Authentication: existing JWT access token passed as either:
+  - Socket.IO `auth.token`
+  - `Authorization: Bearer <token>` handshake header
+- Browser dashboard connections may instead rely on the existing
+  `elonew.session` httpOnly cookie. Browser JavaScript must not read JWTs.
+- Allowed roles: `CLIENT`, `BOOSTER`, `ADMIN`
+
+## Server Events
+
+- `notifications:connected`
+  - Payload: `{ "userId": "<user-id>" }`
+- `notifications:updated`
+  - Payload:
+    `{ "notification": <NotificationResponse>, "unreadCount": <number> }`
+  - Emitted only to the authenticated recipient's room.
+- `notifications:read-all`
+  - Payload:
+    `{ "readAt": "<iso-date>", "cutoffActivityAt": "<iso-date>", "unreadCount": <number> }`
+  - Emitted only to the authenticated recipient's room after explicit
+    mark-all-read actions.
+- `notifications:error`
+  - Payload: `{ "code": "<code>", "message": "<safe message>" }`
+  - Error codes: `AUTHENTICATION_REQUIRED`, `INVALID_ACCESS_TOKEN`,
+    `INSUFFICIENT_PERMISSIONS`, `INTERNAL_ERROR`
+
+## MVP Constraints
+
+- Delivery is in-process only; no Redis Socket.IO adapter yet.
+- REST remains authoritative after reconnect.
+- Browser clients must refetch `GET /notifications` after initial socket
+  connection and reconnect.
+- Browser clients must apply `notifications:read-all` only to local items with
+  `activityAt <= cutoffActivityAt`; newer items remain unread.
+- Chat notifications are coalesced per recipient and order.
+- Read state changes only through explicit REST read actions.
+- Browser clients use the `elonew.session` httpOnly cookie handshake and must
+  not read JWTs.
+- Production deployments with separate web/API subdomains must set
+  `NEXT_PUBLIC_API_URL`, `CHAT_SOCKET_ALLOWED_ORIGINS`, shared
+  `WEB_SESSION_SECRET`, and `WEB_SESSION_COOKIE_DOMAIN` so the httpOnly session
+  cookie is sent during the Socket.IO handshake.

--- a/docs/tech-architecture.md
+++ b/docs/tech-architecture.md
@@ -132,8 +132,9 @@ External provider adapters and integration logic.
 - Style: modular monolith.
 - Internal style: pragmatic hexagonal/layered modules.
 - API protocol: REST.
-- Realtime protocol: Socket.IO for authenticated chat delivery, documented in
-  `docs/chat-websocket.md`.
+- Realtime protocol: Socket.IO for authenticated chat and notification delivery,
+  documented in `docs/chat-websocket.md` and
+  `docs/notifications-websocket.md`.
 - API contracts: OpenAPI/Swagger.
 - Authentication: JWT access token + refresh token rotation.
 

--- a/infrastructure/docker/dev/docker-compose.dev.yml
+++ b/infrastructure/docker/dev/docker-compose.dev.yml
@@ -55,6 +55,16 @@ services:
       TSC_WATCHFILE: UsePolling
     ports:
       - '3000:3000'
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://127.0.0.1:3000/api/health/api'').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
     volumes:
       - ../../../:/workspace
     command:
@@ -74,7 +84,7 @@ services:
     working_dir: /workspace
     depends_on:
       api:
-        condition: service_started
+        condition: service_healthy
     env_file:
       - ../../../apps/web/.env
     environment:
@@ -109,7 +119,7 @@ services:
       redis:
         condition: service_healthy
       api:
-        condition: service_started
+        condition: service_healthy
     env_file:
       - ../../../apps/workers/.env
     environment:

--- a/packages/database/prisma/migrations/20260518210759_add_in_platform_notifications/migration.sql
+++ b/packages/database/prisma/migrations/20260518210759_add_in_platform_notifications/migration.sql
@@ -1,0 +1,28 @@
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('CHAT_MESSAGE_CREATED');
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" TEXT NOT NULL,
+    "recipientId" TEXT NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "aggregateKey" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "readAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "notifications_recipientId_createdAt_id_idx" ON "notifications"("recipientId", "createdAt", "id");
+
+-- CreateIndex
+CREATE INDEX "notifications_recipientId_readAt_idx" ON "notifications"("recipientId", "readAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "notifications_recipientId_type_aggregateKey_key" ON "notifications"("recipientId", "type", "aggregateKey");
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260518223000_add_notification_activity_at/migration.sql
+++ b/packages/database/prisma/migrations/20260518223000_add_notification_activity_at/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "notifications" ADD COLUMN "activityAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- DropIndex
+DROP INDEX "notifications_recipientId_createdAt_id_idx";
+
+-- CreateIndex
+CREATE INDEX "notifications_recipientId_activityAt_id_idx" ON "notifications"("recipientId", "activityAt", "id");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -57,6 +57,10 @@ enum PricingVersionStatus {
   ARCHIVED
 }
 
+enum NotificationType {
+  CHAT_MESSAGE_CREATED
+}
+
 model User {
   id               String    @id @default(cuid())
   username         String    @unique
@@ -85,6 +89,7 @@ model User {
   ratingsGiven     Rating[]  @relation("RatingsGiven")
   ratingsReceived  Rating[]  @relation("RatingsReceived")
   authSessions     AuthSession[]
+  notifications     Notification[] @relation("UserNotifications")
 
   @@map("users")
 }
@@ -361,6 +366,24 @@ model ChatMessage {
 
   @@index([chatId, createdAt, id])
   @@map("chat_messages")
+}
+
+model Notification {
+  id           String           @id @default(cuid())
+  recipientId  String
+  recipient    User             @relation("UserNotifications", fields: [recipientId], references: [id], onDelete: Cascade)
+  type         NotificationType
+  aggregateKey String
+  payload      Json
+  readAt       DateTime?
+  activityAt   DateTime         @default(now())
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @updatedAt
+
+  @@unique([recipientId, type, aggregateKey])
+  @@index([recipientId, activityAt, id])
+  @@index([recipientId, readAt])
+  @@map("notifications")
 }
 
 model Ticket {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,10 @@
 			"types": "./dist/chat/send-chat-message.schema.d.ts",
 			"default": "./dist/chat/send-chat-message.schema.js"
 		},
+		"./notifications/notification.schema": {
+			"types": "./dist/notifications/notification.schema.d.ts",
+			"default": "./dist/notifications/notification.schema.js"
+		},
 		"./orders/create-order-quote.schema": {
 			"types": "./dist/orders/create-order-quote.schema.d.ts",
 			"default": "./dist/orders/create-order-quote.schema.js"

--- a/packages/shared/src/notifications/notification.schema.ts
+++ b/packages/shared/src/notifications/notification.schema.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+
+export const notificationTypeSchema = z.enum(['CHAT_MESSAGE_CREATED']);
+
+export const chatMessageNotificationPayloadSchema = z.object({
+	orderId: z.string().min(1),
+	chatMessageId: z.string().min(1),
+	senderId: z.string().min(1),
+	senderUsername: z.string().min(1),
+});
+
+export const notificationPayloadSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('CHAT_MESSAGE_CREATED'),
+		metadata: chatMessageNotificationPayloadSchema,
+	}),
+]);
+
+export const notificationSchema = z.object({
+	id: z.string(),
+	type: notificationTypeSchema,
+	payload: notificationPayloadSchema,
+	readAt: z.string().datetime().nullable(),
+	activityAt: z.string().datetime(),
+	createdAt: z.string().datetime(),
+	updatedAt: z.string().datetime(),
+});
+
+export const listNotificationsQuerySchema = z.object({
+	limit: z.coerce.number().int().min(1).max(50).default(10),
+	cursor: z.string().trim().min(1).optional(),
+});
+
+export const notificationIdParamSchema = z.string().trim().min(1);
+
+export const markNotificationReadSchema = z
+	.object({
+		expectedActivityAt: z.string().datetime().optional(),
+	})
+	.default({});
+
+export const listNotificationsResponseSchema = z.object({
+	items: z.array(notificationSchema),
+	nextCursor: z.string().nullable(),
+	unreadCount: z.number().int().nonnegative(),
+});
+
+export const notificationUpdatedEventSchema = z.object({
+	notification: notificationSchema,
+	unreadCount: z.number().int().nonnegative(),
+});
+
+export const notificationsReadAllEventSchema = z.object({
+	readAt: z.string().datetime(),
+	cutoffActivityAt: z.string().datetime(),
+	unreadCount: z.number().int().nonnegative(),
+});
+
+export const markAllNotificationsReadResponseSchema = z.object({
+	updatedCount: z.number().int().nonnegative(),
+	cutoffActivityAt: z.string().datetime(),
+	unreadCount: z.number().int().nonnegative(),
+});
+
+export type NotificationType = z.infer<typeof notificationTypeSchema>;
+export type ChatMessageNotificationPayload = z.infer<
+	typeof chatMessageNotificationPayloadSchema
+>;
+export type NotificationPayload = z.infer<typeof notificationPayloadSchema>;
+export type NotificationOutput = z.infer<typeof notificationSchema>;
+export type ListNotificationsQueryInput = z.input<
+	typeof listNotificationsQuerySchema
+>;
+export type ListNotificationsQuery = z.infer<
+	typeof listNotificationsQuerySchema
+>;
+export type ListNotificationsResponse = z.infer<
+	typeof listNotificationsResponseSchema
+>;
+export type MarkNotificationReadInput = z.infer<
+	typeof markNotificationReadSchema
+>;
+export type NotificationUpdatedEvent = z.infer<
+	typeof notificationUpdatedEventSchema
+>;
+export type NotificationsReadAllEvent = z.infer<
+	typeof notificationsReadAllEventSchema
+>;
+export type MarkAllNotificationsReadResponse = z.infer<
+	typeof markAllNotificationsReadResponseSchema
+>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       react-hook-form:
         specifier: ^7.72.1
         version: 7.72.1(react@19.2.3)
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0


### PR DESCRIPTION
## Summary

Adds full-stack in-platform notifications for dashboard users, starting with durable chat-message notifications.

Closes: https://github.com/caiohenrqq/elonew/issues/64

---

## What Changed

- Added recipient-scoped notification persistence, shared notification schemas, REST endpoints, and authenticated Socket.IO delivery.
- Modified chat message delivery so message persistence and notification persistence happen atomically, with socket events emitted after persistence succeeds.
- Added dashboard notification popovers, unread counts, read/read-all actions, notification BFF route, and production cookie-domain support for cross-subdomain Socket.IO auth.
- Added notification API integration coverage, web notification state/component coverage, and DB cleanup for chat/notification dependencies.

---

## Why

FR-056 requires notifications to stay in-platform. This gives clients and boosters durable notification history for new chat activity without relying on external providers, while preserving the web security model where browser JavaScript does not read JWTs.

---

## Implementation Notes

Important details reviewers should know:

- Chat notifications are coalesced per recipient and order.
- Bulk read emits a cutoff timestamp and actual unread count so newer notifications are not incorrectly cleared by stale browser state.
- Browser Socket.IO auth uses the existing httpOnly web session cookie; production deployments with separate web/API subdomains should configure `WEB_SESSION_COOKIE_DOMAIN`, `NEXT_PUBLIC_API_URL`, `CHAT_SOCKET_ALLOWED_ORIGINS`, and shared `WEB_SESSION_SECRET`.
- Admin-specific notification event definitions remain out of scope for this PR.

---

## Testing

How this was validated.

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manually tested through automated local verification commands

Steps to reproduce if needed:

1. `pnpm docker:dev:up`
2. `pnpm db:test:prepare`
3. Run the verification commands listed below.

Verification commands run:

- `pnpm db:validate`
- `pnpm build:packages`
- `pnpm biome:fix:all`
- `pnpm biome:check:all`
- `pnpm api exec tsc --noEmit -p tsconfig.json`
- `pnpm web exec tsc --noEmit -p tsconfig.json`
- `pnpm api test:unit`
- `pnpm api test:integration`
- `pnpm db:test:prepare`
- `pnpm api test:integration:db`
- `pnpm api test:e2e`
- `pnpm api test:e2e:db`
- `pnpm web test`
- `pnpm workers test`
- `pnpm web test:e2e`
- `pnpm build`
- `git diff --check`

---

## Screenshots (if UI)

Not captured. UI behavior is covered by component tests and the existing Playwright suite; there is no seeded authenticated notification-specific Playwright scenario yet.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated where needed
- [x] Lint and type checks pass
- [x] Documentation updated if required
- [x] No breaking changes

---

## Breaking Changes

None.
