### PR TITLE
feat(api): add support ticket lifecycle

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { NotificationsModule } from '@modules/notifications/notifications.module
 import { OrdersModule } from '@modules/orders/orders.module';
 import { PaymentsModule } from '@modules/payments/payments.module';
 import { SystemModule } from '@modules/system/system.module';
+import { TicketsModule } from '@modules/tickets/tickets.module';
 import { UsersModule } from '@modules/users/users.module';
 import { WalletModule } from '@modules/wallet/wallet.module';
 import { Module } from '@nestjs/common';
@@ -24,6 +25,7 @@ import { AppSettingsModule } from './common/settings/app-settings.module';
 		OrdersModule,
 		PaymentsModule,
 		SystemModule,
+		TicketsModule,
 		UsersModule,
 		WalletModule,
 	],

--- a/apps/api/src/common/http/api-domain-error.filter.ts
+++ b/apps/api/src/common/http/api-domain-error.filter.ts
@@ -76,6 +76,14 @@ import {
 	PaymentWebhookTopicNotSupportedError,
 } from '@modules/payments/domain/payment.errors';
 import {
+	TicketAccessDeniedError,
+	TicketInvalidStatusTransitionError,
+	TicketMessageOperationInvalidError,
+	TicketNotFoundError,
+	TicketOrderAccessDeniedError,
+	TicketOrderLinkUnsupportedError,
+} from '@modules/tickets/domain/ticket.errors';
+import {
 	UserEmailAlreadyInUseError,
 	UserEmailConfirmationTokenInvalidError,
 	UsernameAlreadyInUseError,
@@ -135,6 +143,7 @@ export function mapApiDomainErrorToHttpException(
 		mapAsForbidden(AuthUserInactiveError, AuthUserBlockedError),
 		mapAsForbidden(InsufficientPermissionsError),
 		mapAsForbidden(ChatForbiddenError),
+		mapAsForbidden(TicketAccessDeniedError),
 		mapAsNotFound(
 			ChatOrderNotFoundError,
 			ChatMessageNotFoundError,
@@ -148,6 +157,7 @@ export function mapApiDomainErrorToHttpException(
 			PaymentOrderNotFoundError,
 			WalletNotFoundError,
 			NotificationNotFoundError,
+			TicketNotFoundError,
 		),
 		mapAsBadRequest(
 			OrderAlreadyExistsError,
@@ -174,6 +184,10 @@ export function mapApiDomainErrorToHttpException(
 			WalletInsufficientWithdrawableBalanceError,
 			UserEmailConfirmationTokenInvalidError,
 			AdminGovernanceReasonRequiredError,
+			TicketInvalidStatusTransitionError,
+			TicketMessageOperationInvalidError,
+			TicketOrderAccessDeniedError,
+			TicketOrderLinkUnsupportedError,
 		),
 		mapAsConflict(OrderPricingVersionActiveConflictError, ChatNotWritableError),
 		mapAsConflict(NotificationReadConflictError),

--- a/apps/api/src/modules/auth/application/use-cases/refresh-session/refresh-session.use-case.spec.ts
+++ b/apps/api/src/modules/auth/application/use-cases/refresh-session/refresh-session.use-case.spec.ts
@@ -48,6 +48,9 @@ class InMemoryAuthSessionRepository implements AuthSessionRepositoryPort {
 	save = jest.fn();
 }
 
+const futureRefreshExpiry = () =>
+	new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
 describe('RefreshSessionUseCase', () => {
 	it('rotates a valid refresh token and rejects the previous token afterwards', async () => {
 		const users = new InMemoryUserRepository();
@@ -72,7 +75,7 @@ describe('RefreshSessionUseCase', () => {
 				id: 'session-1',
 				userId: 'user-1',
 				refreshTokenHash: 'current-hash',
-				expiresAt: new Date('2026-05-24T00:00:00.000Z'),
+				expiresAt: futureRefreshExpiry(),
 				revokedAt: null,
 				lastUsedAt: null,
 				createdAt: new Date('2026-03-17T00:00:00.000Z'),
@@ -136,7 +139,7 @@ describe('RefreshSessionUseCase', () => {
 			id: 'session-1',
 			userId: 'user-1',
 			refreshTokenHash: 'current-hash',
-			expiresAt: new Date('2026-05-24T00:00:00.000Z'),
+			expiresAt: futureRefreshExpiry(),
 			revokedAt: new Date('2026-03-18T00:00:00.000Z'),
 			lastUsedAt: null,
 			createdAt: new Date('2026-03-17T00:00:00.000Z'),
@@ -187,7 +190,7 @@ describe('RefreshSessionUseCase', () => {
 			id: 'session-1',
 			userId: 'user-1',
 			refreshTokenHash: 'current-hash',
-			expiresAt: new Date('2026-05-24T00:00:00.000Z'),
+			expiresAt: futureRefreshExpiry(),
 			revokedAt: null,
 			lastUsedAt: null,
 			createdAt: new Date('2026-03-17T00:00:00.000Z'),

--- a/apps/api/src/modules/tickets/application/ports/ticket-repository.port.ts
+++ b/apps/api/src/modules/tickets/application/ports/ticket-repository.port.ts
@@ -1,0 +1,61 @@
+import type {
+	Ticket,
+	TicketMessage,
+	TicketStatus,
+} from '@modules/tickets/domain/ticket.entity';
+import type { Role } from '@packages/auth/roles/role';
+
+export const TICKET_REPOSITORY_KEY = Symbol('TICKET_REPOSITORY_KEY');
+
+export type TicketDetailRecord = {
+	id: string;
+	userId: string;
+	orderId: string | null;
+	subject: string;
+	status: TicketStatus;
+	createdAt: Date;
+	updatedAt: Date;
+	messages: TicketMessage[];
+};
+
+export type TicketSummaryRecord = Omit<TicketDetailRecord, 'messages'> & {
+	messageCount: number;
+	latestMessageAt: Date | null;
+};
+
+export interface TicketRepositoryPort {
+	isClientOrderOwner(input: {
+		orderId: string;
+		clientId: string;
+	}): Promise<boolean>;
+	createWithInitialMessage(input: {
+		userId: string;
+		userRole: Role;
+		orderId: string | null;
+		subject: string;
+		content: string;
+		now: Date;
+	}): Promise<TicketDetailRecord>;
+	listForUser(input: {
+		userId: string;
+		limit: number;
+	}): Promise<TicketSummaryRecord[]>;
+	listForAdmin(input: {
+		limit: number;
+		status?: TicketStatus;
+		query?: string;
+	}): Promise<TicketSummaryRecord[]>;
+	findById(ticketId: string): Promise<TicketDetailRecord | null>;
+	addMessage(input: {
+		ticket: Ticket;
+		senderId: string;
+		senderRole: Role;
+		content: string;
+		now: Date;
+	}): Promise<TicketDetailRecord>;
+	updateStatus(input: {
+		ticket: Ticket;
+		status: TicketStatus;
+		now: Date;
+	}): Promise<TicketDetailRecord>;
+}

--- a/apps/api/src/modules/tickets/application/use-cases/add-admin-ticket-message/add-admin-ticket-message.use-case.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/add-admin-ticket-message/add-admin-ticket-message.use-case.ts
@@ -1,0 +1,50 @@
+import {
+	TICKET_REPOSITORY_KEY,
+	type TicketRepositoryPort,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import {
+	mapTicketResponse,
+	type TicketResponse,
+} from '@modules/tickets/application/use-cases/ticket-response';
+import { Ticket } from '@modules/tickets/domain/ticket.entity';
+import { TicketNotFoundError } from '@modules/tickets/domain/ticket.errors';
+import { Inject, Injectable } from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+
+type AddAdminTicketMessageInput = {
+	ticketId: string;
+	adminUserId: string;
+	content: string;
+	now?: Date;
+};
+
+@Injectable()
+export class AddAdminTicketMessageUseCase {
+	constructor(
+		@Inject(TICKET_REPOSITORY_KEY)
+		private readonly tickets: TicketRepositoryPort,
+	) {}
+
+	async execute(input: AddAdminTicketMessageInput): Promise<TicketResponse> {
+		const record = await this.tickets.findById(input.ticketId);
+		if (!record) throw new TicketNotFoundError();
+
+		const ticket = Ticket.rehydrate(record);
+		const now = input.now ?? new Date();
+		ticket.recordReply({
+			senderId: input.adminUserId,
+			senderRole: Role.ADMIN,
+			now,
+		});
+
+		return mapTicketResponse(
+			await this.tickets.addMessage({
+				ticket,
+				senderId: input.adminUserId,
+				senderRole: Role.ADMIN,
+				content: input.content,
+				now,
+			}),
+		);
+	}
+}

--- a/apps/api/src/modules/tickets/application/use-cases/add-ticket-message/add-ticket-message.use-case.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/add-ticket-message/add-ticket-message.use-case.ts
@@ -1,0 +1,52 @@
+import {
+	TICKET_REPOSITORY_KEY,
+	type TicketRepositoryPort,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import {
+	mapTicketResponse,
+	type TicketResponse,
+} from '@modules/tickets/application/use-cases/ticket-response';
+import { Ticket } from '@modules/tickets/domain/ticket.entity';
+import { TicketNotFoundError } from '@modules/tickets/domain/ticket.errors';
+import { Inject, Injectable } from '@nestjs/common';
+import type { Role } from '@packages/auth/roles/role';
+
+type AddTicketMessageInput = {
+	ticketId: string;
+	userId: string;
+	role: Role;
+	content: string;
+	now?: Date;
+};
+
+@Injectable()
+export class AddTicketMessageUseCase {
+	constructor(
+		@Inject(TICKET_REPOSITORY_KEY)
+		private readonly tickets: TicketRepositoryPort,
+	) {}
+
+	async execute(input: AddTicketMessageInput): Promise<TicketResponse> {
+		const record = await this.tickets.findById(input.ticketId);
+		if (!record || record.userId !== input.userId)
+			throw new TicketNotFoundError();
+
+		const ticket = Ticket.rehydrate(record);
+		const now = input.now ?? new Date();
+		ticket.recordReply({
+			senderId: input.userId,
+			senderRole: input.role,
+			now,
+		});
+
+		return mapTicketResponse(
+			await this.tickets.addMessage({
+				ticket,
+				senderId: input.userId,
+				senderRole: input.role,
+				content: input.content,
+				now,
+			}),
+		);
+	}
+}

--- a/apps/api/src/modules/tickets/application/use-cases/create-ticket/create-ticket.use-case.spec.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/create-ticket/create-ticket.use-case.spec.ts
@@ -1,0 +1,197 @@
+import {
+	TICKET_REPOSITORY_KEY,
+	type TicketRepositoryPort,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import { CreateTicketUseCase } from '@modules/tickets/application/use-cases/create-ticket/create-ticket.use-case';
+import { TicketStatus } from '@modules/tickets/domain/ticket.entity';
+import {
+	TicketOrderAccessDeniedError,
+	TicketOrderLinkUnsupportedError,
+} from '@modules/tickets/domain/ticket.errors';
+import { Test } from '@nestjs/testing';
+import { Role } from '@packages/auth/roles/role';
+
+class TicketRepositoryStub implements TicketRepositoryPort {
+	public clientOrderOwners = new Map<string, string>();
+	public createdTickets: Array<{
+		id: string;
+		userId: string;
+		orderId: string | null;
+		subject: string;
+		status: TicketStatus;
+		message: {
+			senderId: string;
+			content: string;
+		};
+	}> = [];
+
+	async isClientOrderOwner(input: {
+		orderId: string;
+		clientId: string;
+	}): Promise<boolean> {
+		return this.clientOrderOwners.get(input.orderId) === input.clientId;
+	}
+
+	async createWithInitialMessage(input: {
+		userId: string;
+		userRole: Role;
+		orderId: string | null;
+		subject: string;
+		content: string;
+		now: Date;
+	}) {
+		const ticket = {
+			id: `ticket-${this.createdTickets.length + 1}`,
+			userId: input.userId,
+			orderId: input.orderId,
+			subject: input.subject,
+			status: TicketStatus.WAITING_SUPPORT,
+			createdAt: input.now,
+			updatedAt: input.now,
+			messages: [
+				{
+					id: 'message-1',
+					ticketId: `ticket-${this.createdTickets.length + 1}`,
+					senderId: input.userId,
+					senderRole: input.userRole,
+					content: input.content,
+					createdAt: input.now,
+				},
+			],
+		};
+		this.createdTickets.push({
+			id: ticket.id,
+			userId: input.userId,
+			orderId: input.orderId,
+			subject: input.subject,
+			status: ticket.status,
+			message: {
+				senderId: input.userId,
+				content: input.content,
+			},
+		});
+
+		return ticket;
+	}
+
+	listForUser(): never {
+		throw new Error('Method not implemented.');
+	}
+
+	listForAdmin(): never {
+		throw new Error('Method not implemented.');
+	}
+
+	findById(): never {
+		throw new Error('Method not implemented.');
+	}
+
+	addMessage(): never {
+		throw new Error('Method not implemented.');
+	}
+
+	updateStatus(): never {
+		throw new Error('Method not implemented.');
+	}
+}
+
+describe('CreateTicketUseCase', () => {
+	let repository: TicketRepositoryStub;
+	let useCase: CreateTicketUseCase;
+
+	beforeEach(async () => {
+		repository = new TicketRepositoryStub();
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				CreateTicketUseCase,
+				{
+					provide: TICKET_REPOSITORY_KEY,
+					useValue: repository,
+				},
+			],
+		}).compile();
+
+		useCase = moduleRef.get(CreateTicketUseCase);
+	});
+
+	it('creates a general ticket waiting for support', async () => {
+		const result = await useCase.execute({
+			userId: 'client-1',
+			role: Role.CLIENT,
+			subject: 'Payment question',
+			content: 'Can you check this?',
+			now: new Date('2026-05-28T10:00:00.000Z'),
+		});
+
+		expect(result.status).toBe(TicketStatus.WAITING_SUPPORT);
+		expect(result.orderId).toBeNull();
+		expect(repository.createdTickets).toEqual([
+			expect.objectContaining({
+				userId: 'client-1',
+				orderId: null,
+				subject: 'Payment question',
+				status: TicketStatus.WAITING_SUPPORT,
+			}),
+		]);
+	});
+
+	it('creates booster general tickets with the booster sender role', async () => {
+		const result = await useCase.execute({
+			userId: 'booster-1',
+			role: Role.BOOSTER,
+			subject: 'Account question',
+			content: 'Can support check this?',
+			now: new Date('2026-05-28T10:00:00.000Z'),
+		});
+
+		expect(result.messages[0]).toEqual(
+			expect.objectContaining({
+				senderId: 'booster-1',
+				senderRole: Role.BOOSTER,
+			}),
+		);
+	});
+
+	it('allows clients to link tickets to their own orders', async () => {
+		repository.clientOrderOwners.set('order-1', 'client-1');
+
+		const result = await useCase.execute({
+			userId: 'client-1',
+			role: Role.CLIENT,
+			subject: 'Order question',
+			content: 'Can you check this order?',
+			orderId: 'order-1',
+			now: new Date('2026-05-28T10:00:00.000Z'),
+		});
+
+		expect(result.orderId).toBe('order-1');
+	});
+
+	it('rejects booster order-linked tickets', async () => {
+		await expect(
+			useCase.execute({
+				userId: 'booster-1',
+				role: Role.BOOSTER,
+				subject: 'Order question',
+				content: 'Can you check this order?',
+				orderId: 'order-1',
+				now: new Date('2026-05-28T10:00:00.000Z'),
+			}),
+		).rejects.toBeInstanceOf(TicketOrderLinkUnsupportedError);
+	});
+
+	it('rejects non-owned client order links', async () => {
+		repository.clientOrderOwners.set('order-1', 'client-2');
+
+		await expect(
+			useCase.execute({
+				userId: 'client-1',
+				role: Role.CLIENT,
+				subject: 'Order question',
+				content: 'Can you check this order?',
+				orderId: 'order-1',
+				now: new Date('2026-05-28T10:00:00.000Z'),
+			}),
+		).rejects.toBeInstanceOf(TicketOrderAccessDeniedError);
+	});
+});

--- a/apps/api/src/modules/tickets/application/use-cases/create-ticket/create-ticket.use-case.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/create-ticket/create-ticket.use-case.ts
@@ -1,0 +1,55 @@
+import {
+	TICKET_REPOSITORY_KEY,
+	type TicketRepositoryPort,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import {
+	mapTicketResponse,
+	type TicketResponse,
+} from '@modules/tickets/application/use-cases/ticket-response';
+import {
+	TicketOrderAccessDeniedError,
+	TicketOrderLinkUnsupportedError,
+} from '@modules/tickets/domain/ticket.errors';
+import { Inject, Injectable } from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+
+type CreateTicketInput = {
+	userId: string;
+	role: Role;
+	subject: string;
+	content: string;
+	orderId?: string;
+	now?: Date;
+};
+
+@Injectable()
+export class CreateTicketUseCase {
+	constructor(
+		@Inject(TICKET_REPOSITORY_KEY)
+		private readonly tickets: TicketRepositoryPort,
+	) {}
+
+	async execute(input: CreateTicketInput): Promise<TicketResponse> {
+		const orderId = input.orderId ?? null;
+		if (orderId) {
+			if (input.role !== Role.CLIENT)
+				throw new TicketOrderLinkUnsupportedError();
+			const ownsOrder = await this.tickets.isClientOrderOwner({
+				orderId,
+				clientId: input.userId,
+			});
+			if (!ownsOrder) throw new TicketOrderAccessDeniedError();
+		}
+
+		return mapTicketResponse(
+			await this.tickets.createWithInitialMessage({
+				userId: input.userId,
+				userRole: input.role,
+				orderId,
+				subject: input.subject,
+				content: input.content,
+				now: input.now ?? new Date(),
+			}),
+		);
+	}
+}

--- a/apps/api/src/modules/tickets/application/use-cases/get-admin-ticket/get-admin-ticket.use-case.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/get-admin-ticket/get-admin-ticket.use-case.ts
@@ -1,0 +1,25 @@
+import {
+	TICKET_REPOSITORY_KEY,
+	type TicketRepositoryPort,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import {
+	mapTicketResponse,
+	type TicketResponse,
+} from '@modules/tickets/application/use-cases/ticket-response';
+import { TicketNotFoundError } from '@modules/tickets/domain/ticket.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class GetAdminTicketUseCase {
+	constructor(
+		@Inject(TICKET_REPOSITORY_KEY)
+		private readonly tickets: TicketRepositoryPort,
+	) {}
+
+	async execute(ticketId: string): Promise<TicketResponse> {
+		const ticket = await this.tickets.findById(ticketId);
+		if (!ticket) throw new TicketNotFoundError();
+
+		return mapTicketResponse(ticket);
+	}
+}

--- a/apps/api/src/modules/tickets/application/use-cases/get-ticket/get-ticket.use-case.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/get-ticket/get-ticket.use-case.ts
@@ -1,0 +1,31 @@
+import {
+	TICKET_REPOSITORY_KEY,
+	type TicketRepositoryPort,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import {
+	mapTicketResponse,
+	type TicketResponse,
+} from '@modules/tickets/application/use-cases/ticket-response';
+import { TicketNotFoundError } from '@modules/tickets/domain/ticket.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+type GetTicketInput = {
+	ticketId: string;
+	userId: string;
+};
+
+@Injectable()
+export class GetTicketUseCase {
+	constructor(
+		@Inject(TICKET_REPOSITORY_KEY)
+		private readonly tickets: TicketRepositoryPort,
+	) {}
+
+	async execute(input: GetTicketInput): Promise<TicketResponse> {
+		const ticket = await this.tickets.findById(input.ticketId);
+		if (!ticket || ticket.userId !== input.userId)
+			throw new TicketNotFoundError();
+
+		return mapTicketResponse(ticket);
+	}
+}

--- a/apps/api/src/modules/tickets/application/use-cases/list-admin-tickets/list-admin-tickets.use-case.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/list-admin-tickets/list-admin-tickets.use-case.ts
@@ -1,0 +1,27 @@
+import {
+	TICKET_REPOSITORY_KEY,
+	type TicketRepositoryPort,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import type { TicketSummaryResponse } from '@modules/tickets/application/use-cases/ticket-response';
+import type { TicketStatus } from '@modules/tickets/domain/ticket.entity';
+import { Inject, Injectable } from '@nestjs/common';
+
+type ListAdminTicketsInput = {
+	limit: number;
+	status?: TicketStatus;
+	query?: string;
+};
+
+@Injectable()
+export class ListAdminTicketsUseCase {
+	constructor(
+		@Inject(TICKET_REPOSITORY_KEY)
+		private readonly tickets: TicketRepositoryPort,
+	) {}
+
+	async execute(
+		input: ListAdminTicketsInput,
+	): Promise<TicketSummaryResponse[]> {
+		return await this.tickets.listForAdmin(input);
+	}
+}

--- a/apps/api/src/modules/tickets/application/use-cases/list-tickets/list-tickets.use-case.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/list-tickets/list-tickets.use-case.ts
@@ -1,0 +1,23 @@
+import {
+	TICKET_REPOSITORY_KEY,
+	type TicketRepositoryPort,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import type { TicketSummaryResponse } from '@modules/tickets/application/use-cases/ticket-response';
+import { Inject, Injectable } from '@nestjs/common';
+
+type ListTicketsInput = {
+	userId: string;
+	limit: number;
+};
+
+@Injectable()
+export class ListTicketsUseCase {
+	constructor(
+		@Inject(TICKET_REPOSITORY_KEY)
+		private readonly tickets: TicketRepositoryPort,
+	) {}
+
+	async execute(input: ListTicketsInput): Promise<TicketSummaryResponse[]> {
+		return await this.tickets.listForUser(input);
+	}
+}

--- a/apps/api/src/modules/tickets/application/use-cases/ticket-response.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/ticket-response.ts
@@ -1,0 +1,52 @@
+import type {
+	TicketMessage,
+	TicketStatus,
+} from '@modules/tickets/domain/ticket.entity';
+import type { Role } from '@packages/auth/roles/role';
+
+export type TicketResponse = {
+	id: string;
+	userId: string;
+	orderId: string | null;
+	subject: string;
+	status: TicketStatus;
+	createdAt: Date;
+	updatedAt: Date;
+	messages: TicketMessageResponse[];
+};
+
+export type TicketSummaryResponse = Omit<TicketResponse, 'messages'> & {
+	messageCount: number;
+	latestMessageAt: Date | null;
+};
+
+export type TicketMessageResponse = {
+	id: string;
+	ticketId: string;
+	senderId: string;
+	senderRole: Role;
+	content: string;
+	createdAt: Date;
+};
+
+export function mapTicketResponse(input: {
+	id: string;
+	userId: string;
+	orderId: string | null;
+	subject: string;
+	status: TicketStatus;
+	createdAt: Date;
+	updatedAt: Date;
+	messages: TicketMessage[];
+}): TicketResponse {
+	return {
+		...input,
+		messages: input.messages.map(mapTicketMessageResponse),
+	};
+}
+
+export function mapTicketMessageResponse(
+	message: TicketMessage,
+): TicketMessageResponse {
+	return { ...message };
+}

--- a/apps/api/src/modules/tickets/application/use-cases/update-ticket-status/update-ticket-status.use-case.ts
+++ b/apps/api/src/modules/tickets/application/use-cases/update-ticket-status/update-ticket-status.use-case.ts
@@ -1,0 +1,44 @@
+import {
+	TICKET_REPOSITORY_KEY,
+	type TicketRepositoryPort,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import {
+	mapTicketResponse,
+	type TicketResponse,
+} from '@modules/tickets/application/use-cases/ticket-response';
+import {
+	Ticket,
+	type TicketStatus,
+} from '@modules/tickets/domain/ticket.entity';
+import { TicketNotFoundError } from '@modules/tickets/domain/ticket.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+type UpdateTicketStatusInput = {
+	ticketId: string;
+	status: TicketStatus;
+	now?: Date;
+};
+
+@Injectable()
+export class UpdateTicketStatusUseCase {
+	constructor(
+		@Inject(TICKET_REPOSITORY_KEY)
+		private readonly tickets: TicketRepositoryPort,
+	) {}
+
+	async execute(input: UpdateTicketStatusInput): Promise<TicketResponse> {
+		const record = await this.tickets.findById(input.ticketId);
+		if (!record) throw new TicketNotFoundError();
+
+		const ticket = Ticket.rehydrate(record);
+		ticket.updateStatus(input.status, input.now ?? new Date());
+
+		return mapTicketResponse(
+			await this.tickets.updateStatus({
+				ticket,
+				status: ticket.status,
+				now: ticket.updatedAt,
+			}),
+		);
+	}
+}

--- a/apps/api/src/modules/tickets/domain/ticket.entity.spec.ts
+++ b/apps/api/src/modules/tickets/domain/ticket.entity.spec.ts
@@ -1,0 +1,78 @@
+import { Role } from '@packages/auth/roles/role';
+import { Ticket, TicketStatus } from './ticket.entity';
+import { TicketAccessDeniedError } from './ticket.errors';
+
+describe('Ticket', () => {
+	it('starts user-created tickets waiting for support', () => {
+		const ticket = Ticket.create({
+			id: 'ticket-1',
+			userId: 'client-1',
+			subject: 'Payment question',
+			orderId: 'order-1',
+			now: new Date('2026-05-28T10:00:00.000Z'),
+		});
+
+		expect(ticket.status).toBe(TicketStatus.WAITING_SUPPORT);
+		expect(ticket.orderId).toBe('order-1');
+	});
+
+	it('moves to waiting for user after an admin reply', () => {
+		const ticket = Ticket.rehydrate({
+			id: 'ticket-1',
+			userId: 'client-1',
+			orderId: null,
+			subject: 'Payment question',
+			status: TicketStatus.WAITING_SUPPORT,
+			createdAt: new Date('2026-05-28T10:00:00.000Z'),
+			updatedAt: new Date('2026-05-28T10:00:00.000Z'),
+		});
+
+		ticket.recordReply({
+			senderId: 'admin-1',
+			senderRole: Role.ADMIN,
+			now: new Date('2026-05-28T10:05:00.000Z'),
+		});
+
+		expect(ticket.status).toBe(TicketStatus.WAITING_USER);
+	});
+
+	it('reopens closed tickets when the owner replies', () => {
+		const ticket = Ticket.rehydrate({
+			id: 'ticket-1',
+			userId: 'client-1',
+			orderId: null,
+			subject: 'Payment question',
+			status: TicketStatus.CLOSED,
+			createdAt: new Date('2026-05-28T10:00:00.000Z'),
+			updatedAt: new Date('2026-05-28T10:00:00.000Z'),
+		});
+
+		ticket.recordReply({
+			senderId: 'client-1',
+			senderRole: Role.CLIENT,
+			now: new Date('2026-05-28T10:05:00.000Z'),
+		});
+
+		expect(ticket.status).toBe(TicketStatus.WAITING_SUPPORT);
+	});
+
+	it('rejects replies from unrelated users', () => {
+		const ticket = Ticket.rehydrate({
+			id: 'ticket-1',
+			userId: 'client-1',
+			orderId: null,
+			subject: 'Payment question',
+			status: TicketStatus.WAITING_SUPPORT,
+			createdAt: new Date('2026-05-28T10:00:00.000Z'),
+			updatedAt: new Date('2026-05-28T10:00:00.000Z'),
+		});
+
+		expect(() =>
+			ticket.recordReply({
+				senderId: 'client-2',
+				senderRole: Role.CLIENT,
+				now: new Date('2026-05-28T10:05:00.000Z'),
+			}),
+		).toThrow(TicketAccessDeniedError);
+	});
+});

--- a/apps/api/src/modules/tickets/domain/ticket.entity.ts
+++ b/apps/api/src/modules/tickets/domain/ticket.entity.ts
@@ -1,0 +1,112 @@
+import { Role } from '@packages/auth/roles/role';
+import {
+	TicketAccessDeniedError,
+	TicketInvalidStatusTransitionError,
+	TicketMessageOperationInvalidError,
+} from './ticket.errors';
+
+export enum TicketStatus {
+	OPEN = 'OPEN',
+	WAITING_USER = 'WAITING_USER',
+	WAITING_SUPPORT = 'WAITING_SUPPORT',
+	CLOSED = 'CLOSED',
+}
+
+export type TicketMessage = {
+	id: string;
+	ticketId: string;
+	senderId: string;
+	senderRole: Role;
+	content: string;
+	createdAt: Date;
+};
+
+const USER_ROLES = new Set<Role>([Role.CLIENT, Role.BOOSTER]);
+const TICKET_STATUSES = new Set<string>(Object.values(TicketStatus));
+
+export class Ticket {
+	private constructor(
+		public readonly id: string,
+		public readonly userId: string,
+		public readonly orderId: string | null,
+		public readonly subject: string,
+		private currentStatus: TicketStatus,
+		public readonly createdAt: Date,
+		private currentUpdatedAt: Date,
+	) {}
+
+	static create(input: {
+		id?: string;
+		userId: string;
+		orderId?: string | null;
+		subject: string;
+		now: Date;
+	}): Ticket {
+		return new Ticket(
+			input.id ?? '',
+			input.userId,
+			input.orderId ?? null,
+			input.subject,
+			TicketStatus.WAITING_SUPPORT,
+			input.now,
+			input.now,
+		);
+	}
+
+	static rehydrate(input: {
+		id: string;
+		userId: string;
+		orderId?: string | null;
+		subject: string;
+		status: TicketStatus | string;
+		createdAt: Date;
+		updatedAt: Date;
+	}): Ticket {
+		return new Ticket(
+			input.id,
+			input.userId,
+			input.orderId ?? null,
+			input.subject,
+			ensureTicketStatus(input.status),
+			input.createdAt,
+			input.updatedAt,
+		);
+	}
+
+	get status(): TicketStatus {
+		return this.currentStatus;
+	}
+
+	get updatedAt(): Date {
+		return this.currentUpdatedAt;
+	}
+
+	recordReply(input: { senderId: string; senderRole: Role; now: Date }): void {
+		if (input.senderRole === Role.ADMIN) {
+			this.currentStatus = TicketStatus.WAITING_USER;
+			this.currentUpdatedAt = input.now;
+
+			return;
+		}
+
+		if (!USER_ROLES.has(input.senderRole))
+			throw new TicketMessageOperationInvalidError();
+		if (input.senderId !== this.userId) throw new TicketAccessDeniedError();
+
+		this.currentStatus = TicketStatus.WAITING_SUPPORT;
+		this.currentUpdatedAt = input.now;
+	}
+
+	updateStatus(status: TicketStatus, now: Date): void {
+		if (!TICKET_STATUSES.has(status))
+			throw new TicketInvalidStatusTransitionError();
+		this.currentStatus = status;
+		this.currentUpdatedAt = now;
+	}
+}
+
+export function ensureTicketStatus(value: TicketStatus | string): TicketStatus {
+	if (TICKET_STATUSES.has(value)) return value as TicketStatus;
+
+	throw new TicketInvalidStatusTransitionError();
+}

--- a/apps/api/src/modules/tickets/domain/ticket.errors.ts
+++ b/apps/api/src/modules/tickets/domain/ticket.errors.ts
@@ -1,0 +1,35 @@
+export class TicketNotFoundError extends Error {
+	constructor() {
+		super('Ticket was not found.');
+	}
+}
+
+export class TicketAccessDeniedError extends Error {
+	constructor() {
+		super('Ticket access is denied.');
+	}
+}
+
+export class TicketInvalidStatusTransitionError extends Error {
+	constructor() {
+		super('Ticket status transition is invalid.');
+	}
+}
+
+export class TicketMessageOperationInvalidError extends Error {
+	constructor() {
+		super('Ticket message operation is invalid.');
+	}
+}
+
+export class TicketOrderAccessDeniedError extends Error {
+	constructor() {
+		super('Ticket order link is not allowed.');
+	}
+}
+
+export class TicketOrderLinkUnsupportedError extends Error {
+	constructor() {
+		super('Ticket order link is unsupported for this role.');
+	}
+}

--- a/apps/api/src/modules/tickets/infrastructure/repositories/prisma-ticket.repository.ts
+++ b/apps/api/src/modules/tickets/infrastructure/repositories/prisma-ticket.repository.ts
@@ -1,0 +1,357 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import type {
+	TicketDetailRecord,
+	TicketRepositoryPort,
+	TicketSummaryRecord,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import {
+	ensureTicketStatus,
+	type Ticket,
+	type TicketMessage,
+	TicketStatus,
+} from '@modules/tickets/domain/ticket.entity';
+import { Injectable } from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+import { ensurePersistedEnum } from '@packages/shared/utils/enum.utils';
+
+type TicketMessageRecord = {
+	id: string;
+	ticketId: string;
+	senderId: string;
+	content: string;
+	createdAt: Date;
+	sender: {
+		role: string;
+	};
+};
+
+type TicketRecord = {
+	id: string;
+	userId: string;
+	orderId: string | null;
+	subject: string;
+	status: string;
+	createdAt: Date;
+	updatedAt: Date;
+	messages: TicketMessageRecord[];
+};
+
+type TicketSummaryPrismaRecord = Omit<TicketRecord, 'messages'> & {
+	messages: Array<{ createdAt: Date }>;
+	_count: { messages: number };
+};
+
+type TicketPrismaClient = {
+	order: {
+		findFirst(args: {
+			where: { id: string; clientId: string };
+			select: { id: true };
+		}): Promise<{ id: string } | null>;
+	};
+	ticket: {
+		create(args: {
+			data: {
+				userId: string;
+				orderId: string | null;
+				subject: string;
+				status: string;
+				createdAt: Date;
+				updatedAt: Date;
+				messages: {
+					create: {
+						senderId: string;
+						content: string;
+						createdAt: Date;
+					};
+				};
+			};
+			include: TicketDetailInclude;
+		}): Promise<TicketRecord>;
+		findMany(args: {
+			where:
+				| { userId: string }
+				| {
+						status?: string;
+						OR?: Array<
+							| { subject: { contains: string; mode: 'insensitive' } }
+							| {
+									user: { username: { contains: string; mode: 'insensitive' } };
+							  }
+							| { user: { email: { contains: string; mode: 'insensitive' } } }
+						>;
+				  };
+			select: TicketSummarySelect;
+			orderBy: { updatedAt: 'desc' };
+			take: number;
+		}): Promise<TicketSummaryPrismaRecord[]>;
+		findUnique(args: {
+			where: { id: string };
+			include: TicketDetailInclude;
+		}): Promise<TicketRecord | null>;
+		update(args: {
+			where: { id: string };
+			data: {
+				status: string;
+				updatedAt: Date;
+				messages?: {
+					create: {
+						senderId: string;
+						content: string;
+						createdAt: Date;
+					};
+				};
+			};
+			include: TicketDetailInclude;
+		}): Promise<TicketRecord>;
+	};
+	$transaction<T>(
+		fn: (transaction: TicketPrismaClient) => Promise<T>,
+	): Promise<T>;
+};
+
+type TicketDetailInclude = {
+	messages: {
+		orderBy: [{ createdAt: 'asc' }, { id: 'asc' }];
+		include: {
+			sender: {
+				select: { role: true };
+			};
+		};
+	};
+};
+
+type TicketSummarySelect = {
+	id: true;
+	userId: true;
+	orderId: true;
+	subject: true;
+	status: true;
+	createdAt: true;
+	updatedAt: true;
+	messages: {
+		select: { createdAt: true };
+		orderBy: { createdAt: 'desc' };
+		take: 1;
+	};
+	_count: { select: { messages: true } };
+};
+
+const ticketDetailInclude = {
+	messages: {
+		orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+		include: {
+			sender: {
+				select: { role: true },
+			},
+		},
+	},
+} satisfies TicketDetailInclude;
+
+const ticketSummarySelect = {
+	id: true,
+	userId: true,
+	orderId: true,
+	subject: true,
+	status: true,
+	createdAt: true,
+	updatedAt: true,
+	messages: {
+		select: { createdAt: true },
+		orderBy: { createdAt: 'desc' },
+		take: 1,
+	},
+	_count: { select: { messages: true } },
+} satisfies TicketSummarySelect;
+
+@Injectable()
+export class PrismaTicketRepository implements TicketRepositoryPort {
+	constructor(private readonly prisma: PrismaService) {}
+
+	async isClientOrderOwner(input: {
+		orderId: string;
+		clientId: string;
+	}): Promise<boolean> {
+		const order = await this.getClient().order.findFirst({
+			where: {
+				id: input.orderId,
+				clientId: input.clientId,
+			},
+			select: { id: true },
+		});
+
+		return Boolean(order);
+	}
+
+	async createWithInitialMessage(input: {
+		userId: string;
+		userRole: Role;
+		orderId: string | null;
+		subject: string;
+		content: string;
+		now: Date;
+	}): Promise<TicketDetailRecord> {
+		const record = await this.getClient().ticket.create({
+			data: {
+				userId: input.userId,
+				orderId: input.orderId,
+				subject: input.subject,
+				status: TicketStatus.WAITING_SUPPORT,
+				createdAt: input.now,
+				updatedAt: input.now,
+				messages: {
+					create: {
+						senderId: input.userId,
+						content: input.content,
+						createdAt: input.now,
+					},
+				},
+			},
+			include: ticketDetailInclude,
+		});
+
+		return this.mapDetail(record);
+	}
+
+	async listForUser(input: {
+		userId: string;
+		limit: number;
+	}): Promise<TicketSummaryRecord[]> {
+		const records = await this.getClient().ticket.findMany({
+			where: { userId: input.userId },
+			select: ticketSummarySelect,
+			orderBy: { updatedAt: 'desc' },
+			take: input.limit,
+		});
+
+		return records.map((record) => this.mapSummary(record));
+	}
+
+	async listForAdmin(input: {
+		limit: number;
+		status?: TicketStatus;
+		query?: string;
+	}): Promise<TicketSummaryRecord[]> {
+		const query = input.query?.trim();
+		const records = await this.getClient().ticket.findMany({
+			where: {
+				...(input.status ? { status: input.status } : {}),
+				...(query
+					? {
+							OR: [
+								{ subject: { contains: query, mode: 'insensitive' } },
+								{
+									user: {
+										username: { contains: query, mode: 'insensitive' },
+									},
+								},
+								{
+									user: {
+										email: { contains: query, mode: 'insensitive' },
+									},
+								},
+							],
+						}
+					: {}),
+			},
+			select: ticketSummarySelect,
+			orderBy: { updatedAt: 'desc' },
+			take: input.limit,
+		});
+
+		return records.map((record) => this.mapSummary(record));
+	}
+
+	async findById(ticketId: string): Promise<TicketDetailRecord | null> {
+		const record = await this.getClient().ticket.findUnique({
+			where: { id: ticketId },
+			include: ticketDetailInclude,
+		});
+		if (!record) return null;
+
+		return this.mapDetail(record);
+	}
+
+	async addMessage(input: {
+		ticket: Ticket;
+		senderId: string;
+		content: string;
+		now: Date;
+	}): Promise<TicketDetailRecord> {
+		const record = await this.getClient().ticket.update({
+			where: { id: input.ticket.id },
+			data: {
+				status: input.ticket.status,
+				updatedAt: input.ticket.updatedAt,
+				messages: {
+					create: {
+						senderId: input.senderId,
+						content: input.content,
+						createdAt: input.now,
+					},
+				},
+			},
+			include: ticketDetailInclude,
+		});
+
+		return this.mapDetail(record);
+	}
+
+	async updateStatus(input: {
+		ticket: Ticket;
+		status: TicketStatus;
+		now: Date;
+	}): Promise<TicketDetailRecord> {
+		const record = await this.getClient().ticket.update({
+			where: { id: input.ticket.id },
+			data: {
+				status: input.status,
+				updatedAt: input.now,
+			},
+			include: ticketDetailInclude,
+		});
+
+		return this.mapDetail(record);
+	}
+
+	private mapDetail(record: TicketRecord): TicketDetailRecord {
+		return {
+			id: record.id,
+			userId: record.userId,
+			orderId: record.orderId,
+			subject: record.subject,
+			status: ensureTicketStatus(record.status),
+			createdAt: record.createdAt,
+			updatedAt: record.updatedAt,
+			messages: record.messages.map((message) => this.mapMessage(message)),
+		};
+	}
+
+	private mapSummary(record: TicketSummaryPrismaRecord): TicketSummaryRecord {
+		return {
+			id: record.id,
+			userId: record.userId,
+			orderId: record.orderId,
+			subject: record.subject,
+			status: ensureTicketStatus(record.status),
+			createdAt: record.createdAt,
+			updatedAt: record.updatedAt,
+			messageCount: record._count.messages,
+			latestMessageAt: record.messages[0]?.createdAt ?? null,
+		};
+	}
+
+	private mapMessage(message: TicketMessageRecord): TicketMessage {
+		return {
+			id: message.id,
+			ticketId: message.ticketId,
+			senderId: message.senderId,
+			senderRole: ensurePersistedEnum(Role, message.sender.role, 'user role'),
+			content: message.content,
+			createdAt: message.createdAt,
+		};
+	}
+
+	private getClient(): TicketPrismaClient {
+		return this.prisma as unknown as TicketPrismaClient;
+	}
+}

--- a/apps/api/src/modules/tickets/presentation/admin-tickets.controller.ts
+++ b/apps/api/src/modules/tickets/presentation/admin-tickets.controller.ts
@@ -1,0 +1,90 @@
+import { ZodValidationPipe } from '@app/common/http/zod-validation.pipe';
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import { CurrentUser } from '@modules/auth/presentation/decorators/current-user.decorator';
+import { Roles } from '@modules/auth/presentation/decorators/roles.decorator';
+import { JwtAuthGuard } from '@modules/auth/presentation/guards/jwt-auth.guard';
+import { RolesGuard } from '@modules/auth/presentation/guards/roles.guard';
+import { AddAdminTicketMessageUseCase } from '@modules/tickets/application/use-cases/add-admin-ticket-message/add-admin-ticket-message.use-case';
+import { GetAdminTicketUseCase } from '@modules/tickets/application/use-cases/get-admin-ticket/get-admin-ticket.use-case';
+import { ListAdminTicketsUseCase } from '@modules/tickets/application/use-cases/list-admin-tickets/list-admin-tickets.use-case';
+import { UpdateTicketStatusUseCase } from '@modules/tickets/application/use-cases/update-ticket-status/update-ticket-status.use-case';
+import {
+	Body,
+	Controller,
+	Get,
+	Param,
+	Patch,
+	Post,
+	Query,
+	UseGuards,
+} from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+import {
+	type AddTicketMessageSchemaInput,
+	addTicketMessageSchema,
+	type ListAdminTicketsQuerySchemaInput,
+	listAdminTicketsQuerySchema,
+	type TicketIdParamSchemaInput,
+	ticketIdParamSchema,
+	type UpdateTicketStatusSchemaInput,
+	updateTicketStatusSchema,
+} from './tickets.request-schemas';
+
+@Controller('admin/tickets')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN)
+export class AdminTicketsController {
+	constructor(
+		private readonly listAdminTickets: ListAdminTicketsUseCase,
+		private readonly getAdminTicket: GetAdminTicketUseCase,
+		private readonly addAdminTicketMessage: AddAdminTicketMessageUseCase,
+		private readonly updateTicketStatus: UpdateTicketStatusUseCase,
+	) {}
+
+	@Get()
+	async list(
+		@Query(new ZodValidationPipe(listAdminTicketsQuerySchema))
+		query: ListAdminTicketsQuerySchemaInput,
+		@CurrentUser() _currentUser: AuthenticatedUser,
+	) {
+		return await this.listAdminTickets.execute(query);
+	}
+
+	@Get(':ticketId')
+	async get(
+		@Param('ticketId', new ZodValidationPipe(ticketIdParamSchema))
+		ticketId: TicketIdParamSchemaInput,
+		@CurrentUser() _currentUser: AuthenticatedUser,
+	) {
+		return await this.getAdminTicket.execute(ticketId);
+	}
+
+	@Post(':ticketId/messages')
+	async reply(
+		@Param('ticketId', new ZodValidationPipe(ticketIdParamSchema))
+		ticketId: TicketIdParamSchemaInput,
+		@Body(new ZodValidationPipe(addTicketMessageSchema))
+		body: AddTicketMessageSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.addAdminTicketMessage.execute({
+			ticketId,
+			adminUserId: currentUser.id,
+			content: body.content,
+		});
+	}
+
+	@Patch(':ticketId/status')
+	async updateStatus(
+		@Param('ticketId', new ZodValidationPipe(ticketIdParamSchema))
+		ticketId: TicketIdParamSchemaInput,
+		@Body(new ZodValidationPipe(updateTicketStatusSchema))
+		body: UpdateTicketStatusSchemaInput,
+		@CurrentUser() _currentUser: AuthenticatedUser,
+	) {
+		return await this.updateTicketStatus.execute({
+			ticketId,
+			status: body.status,
+		});
+	}
+}

--- a/apps/api/src/modules/tickets/presentation/tickets.controller.ts
+++ b/apps/api/src/modules/tickets/presentation/tickets.controller.ts
@@ -1,0 +1,97 @@
+import { ZodValidationPipe } from '@app/common/http/zod-validation.pipe';
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import { CurrentUser } from '@modules/auth/presentation/decorators/current-user.decorator';
+import { Roles } from '@modules/auth/presentation/decorators/roles.decorator';
+import { JwtAuthGuard } from '@modules/auth/presentation/guards/jwt-auth.guard';
+import { RolesGuard } from '@modules/auth/presentation/guards/roles.guard';
+import { AddTicketMessageUseCase } from '@modules/tickets/application/use-cases/add-ticket-message/add-ticket-message.use-case';
+import { CreateTicketUseCase } from '@modules/tickets/application/use-cases/create-ticket/create-ticket.use-case';
+import { GetTicketUseCase } from '@modules/tickets/application/use-cases/get-ticket/get-ticket.use-case';
+import { ListTicketsUseCase } from '@modules/tickets/application/use-cases/list-tickets/list-tickets.use-case';
+import {
+	Body,
+	Controller,
+	Get,
+	Param,
+	Post,
+	Query,
+	UseGuards,
+} from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+import {
+	type AddTicketMessageSchemaInput,
+	addTicketMessageSchema,
+	type CreateTicketSchemaInput,
+	createTicketSchema,
+	type ListTicketsQuerySchemaInput,
+	listTicketsQuerySchema,
+	type TicketIdParamSchemaInput,
+	ticketIdParamSchema,
+} from './tickets.request-schemas';
+
+@Controller('tickets')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.CLIENT, Role.BOOSTER)
+export class TicketsController {
+	constructor(
+		private readonly createTicket: CreateTicketUseCase,
+		private readonly listTickets: ListTicketsUseCase,
+		private readonly getTicket: GetTicketUseCase,
+		private readonly addTicketMessage: AddTicketMessageUseCase,
+	) {}
+
+	@Post()
+	async create(
+		@Body(new ZodValidationPipe(createTicketSchema))
+		body: CreateTicketSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.createTicket.execute({
+			userId: currentUser.id,
+			role: currentUser.role,
+			subject: body.subject,
+			content: body.content,
+			orderId: body.orderId,
+		});
+	}
+
+	@Get()
+	async list(
+		@Query(new ZodValidationPipe(listTicketsQuerySchema))
+		query: ListTicketsQuerySchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.listTickets.execute({
+			userId: currentUser.id,
+			limit: query.limit,
+		});
+	}
+
+	@Get(':ticketId')
+	async get(
+		@Param('ticketId', new ZodValidationPipe(ticketIdParamSchema))
+		ticketId: TicketIdParamSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.getTicket.execute({
+			ticketId,
+			userId: currentUser.id,
+		});
+	}
+
+	@Post(':ticketId/messages')
+	async reply(
+		@Param('ticketId', new ZodValidationPipe(ticketIdParamSchema))
+		ticketId: TicketIdParamSchemaInput,
+		@Body(new ZodValidationPipe(addTicketMessageSchema))
+		body: AddTicketMessageSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.addTicketMessage.execute({
+			ticketId,
+			userId: currentUser.id,
+			role: currentUser.role,
+			content: body.content,
+		});
+	}
+}

--- a/apps/api/src/modules/tickets/presentation/tickets.request-schemas.ts
+++ b/apps/api/src/modules/tickets/presentation/tickets.request-schemas.ts
@@ -1,0 +1,47 @@
+import { TicketStatus } from '@modules/tickets/domain/ticket.entity';
+import { z } from 'zod';
+
+export const ticketIdParamSchema = z.string().trim().min(1);
+
+export type TicketIdParamSchemaInput = z.infer<typeof ticketIdParamSchema>;
+
+export const createTicketSchema = z.object({
+	subject: z.string().trim().min(3).max(160),
+	content: z.string().trim().min(1).max(5000),
+	orderId: z.string().trim().min(1).optional(),
+});
+
+export type CreateTicketSchemaInput = z.infer<typeof createTicketSchema>;
+
+export const addTicketMessageSchema = z.object({
+	content: z.string().trim().min(1).max(5000),
+});
+
+export type AddTicketMessageSchemaInput = z.infer<
+	typeof addTicketMessageSchema
+>;
+
+export const listTicketsQuerySchema = z.object({
+	limit: z.coerce.number().int().min(1).max(100).default(25),
+});
+
+export type ListTicketsQuerySchemaInput = z.infer<
+	typeof listTicketsQuerySchema
+>;
+
+export const listAdminTicketsQuerySchema = listTicketsQuerySchema.extend({
+	status: z.nativeEnum(TicketStatus).optional(),
+	query: z.string().trim().min(1).max(120).optional(),
+});
+
+export type ListAdminTicketsQuerySchemaInput = z.infer<
+	typeof listAdminTicketsQuerySchema
+>;
+
+export const updateTicketStatusSchema = z.object({
+	status: z.nativeEnum(TicketStatus),
+});
+
+export type UpdateTicketStatusSchemaInput = z.infer<
+	typeof updateTicketStatusSchema
+>;

--- a/apps/api/src/modules/tickets/tickets.module.ts
+++ b/apps/api/src/modules/tickets/tickets.module.ts
@@ -1,0 +1,39 @@
+import { PrismaModule } from '@app/common/prisma/prisma.module';
+import { AuthModule } from '@modules/auth/auth.module';
+import { TICKET_REPOSITORY_KEY } from '@modules/tickets/application/ports/ticket-repository.port';
+import { AddAdminTicketMessageUseCase } from '@modules/tickets/application/use-cases/add-admin-ticket-message/add-admin-ticket-message.use-case';
+import { AddTicketMessageUseCase } from '@modules/tickets/application/use-cases/add-ticket-message/add-ticket-message.use-case';
+import { CreateTicketUseCase } from '@modules/tickets/application/use-cases/create-ticket/create-ticket.use-case';
+import { GetAdminTicketUseCase } from '@modules/tickets/application/use-cases/get-admin-ticket/get-admin-ticket.use-case';
+import { GetTicketUseCase } from '@modules/tickets/application/use-cases/get-ticket/get-ticket.use-case';
+import { ListAdminTicketsUseCase } from '@modules/tickets/application/use-cases/list-admin-tickets/list-admin-tickets.use-case';
+import { ListTicketsUseCase } from '@modules/tickets/application/use-cases/list-tickets/list-tickets.use-case';
+import { UpdateTicketStatusUseCase } from '@modules/tickets/application/use-cases/update-ticket-status/update-ticket-status.use-case';
+import { PrismaTicketRepository } from '@modules/tickets/infrastructure/repositories/prisma-ticket.repository';
+import { AdminTicketsController } from '@modules/tickets/presentation/admin-tickets.controller';
+import { TicketsController } from '@modules/tickets/presentation/tickets.controller';
+import { Module } from '@nestjs/common';
+
+@Module({
+	imports: [PrismaModule, AuthModule],
+	controllers: [AdminTicketsController, TicketsController],
+	providers: [
+		PrismaTicketRepository,
+		{
+			provide: TICKET_REPOSITORY_KEY,
+			useFactory: (
+				ticketRepository: PrismaTicketRepository,
+			): PrismaTicketRepository => ticketRepository,
+			inject: [PrismaTicketRepository],
+		},
+		AddAdminTicketMessageUseCase,
+		AddTicketMessageUseCase,
+		CreateTicketUseCase,
+		GetAdminTicketUseCase,
+		GetTicketUseCase,
+		ListAdminTicketsUseCase,
+		ListTicketsUseCase,
+		UpdateTicketStatusUseCase,
+	],
+})
+export class TicketsModule {}

--- a/apps/api/test/create-test-http-app.ts
+++ b/apps/api/test/create-test-http-app.ts
@@ -30,7 +30,7 @@ class InjectRequestBuilder {
 
 	constructor(
 		private readonly app: ApiHttpApp,
-		private readonly method: 'GET' | 'POST',
+		private readonly method: 'GET' | 'PATCH' | 'POST',
 		private readonly url: string,
 	) {}
 
@@ -104,6 +104,9 @@ export function requestHttp(app: ApiHttpApp) {
 		},
 		post(url: string) {
 			return new InjectRequestBuilder(app, 'POST', url);
+		},
+		patch(url: string) {
+			return new InjectRequestBuilder(app, 'PATCH', url);
 		},
 	};
 }

--- a/apps/api/test/integration-db/tickets/tickets.db.integration.spec.ts
+++ b/apps/api/test/integration-db/tickets/tickets.db.integration.spec.ts
@@ -1,0 +1,157 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import { TicketStatus } from '@modules/tickets/domain/ticket.entity';
+import { AdminTicketsController } from '@modules/tickets/presentation/admin-tickets.controller';
+import { TicketsController } from '@modules/tickets/presentation/tickets.controller';
+import { TicketsModule } from '@modules/tickets/tickets.module';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Role } from '@packages/auth/roles/role';
+
+describe('Tickets module integration (db)', () => {
+	let moduleRef: TestingModule;
+	let controller: TicketsController;
+	let adminController: AdminTicketsController;
+	let prisma: PrismaService;
+	let clientUser: AuthenticatedUser;
+	let adminUser: AuthenticatedUser;
+
+	beforeEach(async () => {
+		moduleRef = await Test.createTestingModule({
+			imports: [TicketsModule],
+		}).compile();
+
+		controller = moduleRef.get(TicketsController);
+		adminController = moduleRef.get(AdminTicketsController);
+		prisma = moduleRef.get(PrismaService);
+		await prisma.ticketMessage.deleteMany();
+		await prisma.ticket.deleteMany();
+		await prisma.order.deleteMany();
+		await prisma.user.deleteMany();
+
+		const user = await prisma.user.create({
+			data: {
+				username: 'ticket-client',
+				email: 'ticket-client@example.com',
+				password: 'secret',
+				role: 'CLIENT',
+			},
+		});
+		clientUser = {
+			id: user.id,
+			role: Role.CLIENT,
+		};
+		const admin = await prisma.user.create({
+			data: {
+				username: 'ticket-admin',
+				email: 'ticket-admin@example.com',
+				password: 'secret',
+				role: 'ADMIN',
+			},
+		});
+		adminUser = {
+			id: admin.id,
+			role: Role.ADMIN,
+		};
+	});
+
+	afterEach(async () => {
+		await moduleRef.close();
+	});
+
+	it('persists an order-linked ticket with chronological message history', async () => {
+		const order = await prisma.order.create({
+			data: {
+				clientId: clientUser.id,
+				status: 'pending_booster',
+			},
+		});
+
+		const created = await controller.create(
+			{
+				subject: 'Order support',
+				content: 'Initial message',
+				orderId: order.id,
+			},
+			clientUser,
+		);
+		const replied = await controller.reply(
+			created.id,
+			{ content: 'Second message' },
+			clientUser,
+		);
+
+		expect(replied).toMatchObject({
+			id: created.id,
+			orderId: order.id,
+			status: TicketStatus.WAITING_SUPPORT,
+			messages: [
+				expect.objectContaining({ content: 'Initial message' }),
+				expect.objectContaining({ content: 'Second message' }),
+			],
+		});
+
+		const persisted = await prisma.ticket.findUnique({
+			where: { id: created.id },
+			include: {
+				messages: {
+					orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+				},
+			},
+		});
+
+		expect(persisted).toMatchObject({
+			orderId: order.id,
+			status: TicketStatus.WAITING_SUPPORT,
+		});
+		expect(persisted?.messages.map((message) => message.content)).toEqual([
+			'Initial message',
+			'Second message',
+		]);
+	});
+
+	it('persists admin replies and reopens closed tickets', async () => {
+		const created = await controller.create(
+			{
+				subject: 'Payment support',
+				content: 'Initial message',
+			},
+			clientUser,
+		);
+		await adminController.updateStatus(
+			created.id,
+			{ status: TicketStatus.CLOSED },
+			adminUser,
+		);
+
+		const replied = await adminController.reply(
+			created.id,
+			{ content: 'Reopening with a support response.' },
+			adminUser,
+		);
+
+		expect(replied).toMatchObject({
+			status: TicketStatus.WAITING_USER,
+			messages: [
+				expect.objectContaining({ senderRole: Role.CLIENT }),
+				expect.objectContaining({ senderRole: Role.ADMIN }),
+			],
+		});
+
+		const persisted = await prisma.ticket.findUnique({
+			where: { id: created.id },
+			include: {
+				messages: {
+					include: { sender: true },
+					orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+				},
+			},
+		});
+
+		expect(persisted?.status).toBe(TicketStatus.WAITING_USER);
+		expect(persisted?.messages.map((message) => message.sender.role)).toEqual([
+			'CLIENT',
+			'ADMIN',
+		]);
+	});
+});

--- a/apps/api/test/support/in-memory/tickets/in-memory-ticket.repository.ts
+++ b/apps/api/test/support/in-memory/tickets/in-memory-ticket.repository.ts
@@ -1,0 +1,175 @@
+import type {
+	TicketDetailRecord,
+	TicketRepositoryPort,
+	TicketSummaryRecord,
+} from '@modules/tickets/application/ports/ticket-repository.port';
+import {
+	type Ticket,
+	TicketStatus,
+} from '@modules/tickets/domain/ticket.entity';
+import type { Role } from '@packages/auth/roles/role';
+
+export class InMemoryTicketRepository implements TicketRepositoryPort {
+	private readonly tickets = new Map<string, TicketDetailRecord>();
+	private readonly clientOrderOwners = new Map<string, string>();
+
+	setClientOrderOwner(orderId: string, clientId: string): void {
+		this.clientOrderOwners.set(orderId, clientId);
+	}
+
+	async isClientOrderOwner(input: {
+		orderId: string;
+		clientId: string;
+	}): Promise<boolean> {
+		return this.clientOrderOwners.get(input.orderId) === input.clientId;
+	}
+
+	async createWithInitialMessage(input: {
+		userId: string;
+		userRole: Role;
+		orderId: string | null;
+		subject: string;
+		content: string;
+		now: Date;
+	}): Promise<TicketDetailRecord> {
+		const ticketId = `ticket-${this.tickets.size + 1}`;
+		const ticket: TicketDetailRecord = {
+			id: ticketId,
+			userId: input.userId,
+			orderId: input.orderId,
+			subject: input.subject,
+			status: TicketStatus.WAITING_SUPPORT,
+			createdAt: input.now,
+			updatedAt: input.now,
+			messages: [
+				{
+					id: `${ticketId}-message-1`,
+					ticketId,
+					senderId: input.userId,
+					senderRole: input.userRole,
+					content: input.content,
+					createdAt: input.now,
+				},
+			],
+		};
+		this.tickets.set(ticketId, ticket);
+
+		return this.cloneDetail(ticket);
+	}
+
+	async listForUser(input: {
+		userId: string;
+		limit: number;
+	}): Promise<TicketSummaryRecord[]> {
+		return this.listTickets({ userId: input.userId, limit: input.limit });
+	}
+
+	async listForAdmin(input: {
+		limit: number;
+		status?: TicketStatus;
+		query?: string;
+	}): Promise<TicketSummaryRecord[]> {
+		return this.listTickets({
+			limit: input.limit,
+			status: input.status,
+			query: input.query,
+		});
+	}
+
+	async findById(ticketId: string): Promise<TicketDetailRecord | null> {
+		const ticket = this.tickets.get(ticketId);
+
+		return ticket ? this.cloneDetail(ticket) : null;
+	}
+
+	async addMessage(input: {
+		ticket: Ticket;
+		senderId: string;
+		senderRole: Role;
+		content: string;
+		now: Date;
+	}): Promise<TicketDetailRecord> {
+		const stored = this.tickets.get(input.ticket.id);
+		if (!stored) throw new Error('Ticket not found in test repository.');
+
+		const next: TicketDetailRecord = {
+			...stored,
+			status: input.ticket.status,
+			updatedAt: input.ticket.updatedAt,
+			messages: [
+				...stored.messages,
+				{
+					id: `${input.ticket.id}-message-${stored.messages.length + 1}`,
+					ticketId: input.ticket.id,
+					senderId: input.senderId,
+					senderRole: input.senderRole,
+					content: input.content,
+					createdAt: input.now,
+				},
+			],
+		};
+		this.tickets.set(next.id, next);
+
+		return this.cloneDetail(next);
+	}
+
+	async updateStatus(input: {
+		ticket: Ticket;
+		status: TicketStatus;
+		now: Date;
+	}): Promise<TicketDetailRecord> {
+		const stored = this.tickets.get(input.ticket.id);
+		if (!stored) throw new Error('Ticket not found in test repository.');
+
+		const next: TicketDetailRecord = {
+			...stored,
+			status: input.status,
+			updatedAt: input.now,
+		};
+		this.tickets.set(next.id, next);
+
+		return this.cloneDetail(next);
+	}
+
+	private listTickets(input: {
+		userId?: string;
+		limit: number;
+		status?: TicketStatus;
+		query?: string;
+	}): TicketSummaryRecord[] {
+		const query = input.query?.toLowerCase();
+
+		return Array.from(this.tickets.values())
+			.filter((ticket) => !input.userId || ticket.userId === input.userId)
+			.filter((ticket) => !input.status || ticket.status === input.status)
+			.filter(
+				(ticket) =>
+					!query ||
+					ticket.subject.toLowerCase().includes(query) ||
+					ticket.userId.toLowerCase().includes(query),
+			)
+			.sort(
+				(left, right) => right.updatedAt.getTime() - left.updatedAt.getTime(),
+			)
+			.slice(0, input.limit)
+			.map((ticket) => ({
+				id: ticket.id,
+				userId: ticket.userId,
+				orderId: ticket.orderId,
+				subject: ticket.subject,
+				status: ticket.status,
+				createdAt: ticket.createdAt,
+				updatedAt: ticket.updatedAt,
+				messageCount: ticket.messages.length,
+				latestMessageAt:
+					ticket.messages[ticket.messages.length - 1]?.createdAt ?? null,
+			}));
+	}
+
+	private cloneDetail(ticket: TicketDetailRecord): TicketDetailRecord {
+		return {
+			...ticket,
+			messages: ticket.messages.map((message) => ({ ...message })),
+		};
+	}
+}

--- a/apps/api/test/tickets.e2e-spec.ts
+++ b/apps/api/test/tickets.e2e-spec.ts
@@ -1,0 +1,208 @@
+import { TICKET_REPOSITORY_KEY } from '@modules/tickets/application/ports/ticket-repository.port';
+import { TicketStatus } from '@modules/tickets/domain/ticket.entity';
+import { Test } from '@nestjs/testing';
+import { Role } from '@packages/auth/roles/role';
+import { AppModule } from '../src/app.module';
+import type { ApiHttpApp } from '../src/common/http/http-app.factory';
+import { createTestHttpApp, requestHttp } from './create-test-http-app';
+import { signTestAccessToken as signToken } from './support/auth-token';
+import { InMemoryTicketRepository } from './support/in-memory/tickets/in-memory-ticket.repository';
+
+describe('Tickets (e2e)', () => {
+	let app: ApiHttpApp;
+	let tickets: InMemoryTicketRepository;
+
+	const clientToken = () => signToken({ sub: 'client-1', role: Role.CLIENT });
+	const otherClientToken = () =>
+		signToken({ sub: 'client-2', role: Role.CLIENT });
+	const boosterToken = () =>
+		signToken({ sub: 'booster-1', role: Role.BOOSTER });
+	const adminToken = () => signToken({ sub: 'admin-1', role: Role.ADMIN });
+
+	beforeEach(async () => {
+		tickets = new InMemoryTicketRepository();
+		const moduleRef = await Test.createTestingModule({
+			imports: [AppModule],
+		})
+			.overrideProvider(TICKET_REPOSITORY_KEY)
+			.useValue(tickets)
+			.compile();
+
+		app = await createTestHttpApp(moduleRef);
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	it('creates a client order-linked ticket and lists it for the owner', async () => {
+		tickets.setClientOrderOwner('order-1', 'client-1');
+
+		await requestHttp(app)
+			.post('/tickets')
+			.set('Authorization', `Bearer ${clientToken()}`)
+			.send({
+				subject: 'Order question',
+				content: 'Can you check my order?',
+				orderId: 'order-1',
+			})
+			.expect(201)
+			.expect<{
+				orderId: string;
+				status: string;
+				messages: Array<{ content: string }>;
+			}>(({ body }) => {
+				expect(body.orderId).toBe('order-1');
+				expect(body.status).toBe(TicketStatus.WAITING_SUPPORT);
+				expect(body.messages).toEqual([
+					expect.objectContaining({ content: 'Can you check my order?' }),
+				]);
+			})
+			.execute();
+
+		await requestHttp(app)
+			.get('/tickets')
+			.set('Authorization', `Bearer ${clientToken()}`)
+			.expect(200)
+			.expect<Array<{ subject: string }>>(({ body }) => {
+				expect(body).toEqual([
+					expect.objectContaining({ subject: 'Order question' }),
+				]);
+			})
+			.execute();
+	});
+
+	it('rejects booster order-linked ticket creation', async () => {
+		await requestHttp(app)
+			.post('/tickets')
+			.set('Authorization', `Bearer ${boosterToken()}`)
+			.send({
+				subject: 'Order question',
+				content: 'Can you check this order?',
+				orderId: 'order-1',
+			})
+			.expect(400)
+			.execute();
+	});
+
+	it('allows boosters to create general support tickets', async () => {
+		await requestHttp(app)
+			.post('/tickets')
+			.set('Authorization', `Bearer ${boosterToken()}`)
+			.send({
+				subject: 'Booster account question',
+				content: 'Can support check my account?',
+			})
+			.expect(201)
+			.expect<{
+				orderId: string | null;
+				status: string;
+				messages: Array<{ senderRole: string }>;
+			}>(({ body }) => {
+				expect(body.orderId).toBeNull();
+				expect(body.status).toBe(TicketStatus.WAITING_SUPPORT);
+				expect(body.messages[0]?.senderRole).toBe(Role.BOOSTER);
+			})
+			.execute();
+	});
+
+	it('hides cross-user tickets as not found', async () => {
+		await requestHttp(app)
+			.post('/tickets')
+			.set('Authorization', `Bearer ${clientToken()}`)
+			.send({
+				subject: 'Private question',
+				content: 'Private content',
+			})
+			.expect(201)
+			.execute();
+
+		await requestHttp(app)
+			.get('/tickets/ticket-1')
+			.set('Authorization', `Bearer ${otherClientToken()}`)
+			.expect(404)
+			.execute();
+	});
+
+	it('updates status when users and admins reply', async () => {
+		await requestHttp(app)
+			.post('/tickets')
+			.set('Authorization', `Bearer ${clientToken()}`)
+			.send({
+				subject: 'Payment question',
+				content: 'Initial message',
+			})
+			.expect(201)
+			.execute();
+
+		await requestHttp(app)
+			.post('/admin/tickets/ticket-1/messages')
+			.set('Authorization', `Bearer ${adminToken()}`)
+			.send({ content: 'Need more details.' })
+			.expect(201)
+			.expect<{ status: string; messages: unknown[] }>(({ body }) => {
+				expect(body.status).toBe(TicketStatus.WAITING_USER);
+				expect(body.messages).toHaveLength(2);
+			})
+			.execute();
+
+		await requestHttp(app)
+			.post('/tickets/ticket-1/messages')
+			.set('Authorization', `Bearer ${clientToken()}`)
+			.send({ content: 'Here are the details.' })
+			.expect(201)
+			.expect<{ status: string; messages: unknown[] }>(({ body }) => {
+				expect(body.status).toBe(TicketStatus.WAITING_SUPPORT);
+				expect(body.messages).toHaveLength(3);
+			})
+			.execute();
+	});
+
+	it('allows admins to list and update tickets', async () => {
+		await requestHttp(app)
+			.post('/tickets')
+			.set('Authorization', `Bearer ${clientToken()}`)
+			.send({
+				subject: 'Payment question',
+				content: 'Initial message',
+			})
+			.expect(201)
+			.execute();
+
+		await requestHttp(app)
+			.get('/admin/tickets')
+			.set('Authorization', `Bearer ${adminToken()}`)
+			.expect(200)
+			.expect<Array<{ id: string }>>(({ body }) => {
+				expect(body).toEqual([expect.objectContaining({ id: 'ticket-1' })]);
+			})
+			.execute();
+
+		await requestHttp(app)
+			.patch('/admin/tickets/ticket-1/status')
+			.set('Authorization', `Bearer ${adminToken()}`)
+			.send({ status: TicketStatus.CLOSED })
+			.expect(200)
+			.expect<{ status: string }>(({ body }) => {
+				expect(body.status).toBe(TicketStatus.CLOSED);
+			})
+			.execute();
+	});
+
+	it('rejects non-admin access to admin ticket routes', async () => {
+		await requestHttp(app)
+			.get('/admin/tickets')
+			.set('Authorization', `Bearer ${clientToken()}`)
+			.expect(403)
+			.execute();
+	});
+
+	it('rejects invalid request payloads', async () => {
+		await requestHttp(app)
+			.post('/tickets')
+			.set('Authorization', `Bearer ${clientToken()}`)
+			.send({ subject: '  ', content: '' })
+			.expect(400)
+			.execute();
+	});
+});

--- a/issue-52.md
+++ b/issue-52.md
@@ -1,0 +1,236 @@
+# Issue #52 Implementation Plan
+
+Source: https://github.com/caiohenrqq/elonew/issues/52
+
+Title: `[FR-058/FR-059/FR-060] Implement support tickets domain, persistence, and API lifecycle`
+
+## Goal
+
+Implement the backend support ticket system required by FR-058, FR-059, and FR-060. The MVP scope is authenticated API behavior, persisted ticket history, and privacy-aware access control.
+
+Frontend dashboard implementation remains out of scope for this issue.
+
+## Quality Overview
+
+The original draft correctly identified the backend-only scope and the existing `Ticket` and `TicketMessage` database models, but it left key implementation decisions open. This enhanced plan locks the status model, order-linking behavior, reopen policy, admin route shape, schema impact, access rules, and test coverage so the issue can be implemented without additional product decisions.
+
+## Current State
+
+- `Ticket` and `TicketMessage` already exist in `packages/database/prisma/schema.prisma`.
+- There is no `apps/api/src/modules/tickets` module yet.
+- Admin dashboard can list ticket summaries through `GET /admin/support/tickets`, but this is read-only dashboard plumbing, not a ticket lifecycle API.
+- The client order details UI has an `Abrir Ticket` button, but frontend wiring is deferred.
+- Requirements require a ticketing system, persisted history, and privacy-aware handling.
+
+## Locked Product Decisions
+
+- Ticket statuses are `OPEN`, `WAITING_USER`, `WAITING_SUPPORT`, and `CLOSED`.
+- A user-created ticket starts as `WAITING_SUPPORT`.
+- A requester reply sets the ticket to `WAITING_SUPPORT`.
+- An admin reply sets the ticket to `WAITING_USER`.
+- A reply to a `CLOSED` ticket reopens it automatically using the same reply-status rule.
+- Admins can also reopen closed tickets through status update.
+- Tickets can optionally link to an order through `orderId`.
+- Only clients can create order-linked tickets, and the linked order must belong to the current client.
+- Boosters can create general support tickets, but cannot create order-linked tickets in this issue.
+- Admin ticket lifecycle routes should use `/admin/tickets`.
+- Keep existing `GET /admin/support/tickets` as the dashboard summary endpoint.
+
+## Proposed Backend Scope
+
+### Domain
+
+- Add a `tickets` module using the existing module structure:
+  - `presentation`
+  - `application/use-cases`
+  - `application/ports`
+  - `domain`
+  - `infrastructure`
+- Define a typed ticket status model with:
+  - `OPEN`
+  - `WAITING_USER`
+  - `WAITING_SUPPORT`
+  - `CLOSED`
+- Define domain errors for:
+  - ticket not found
+  - ticket access denied
+  - invalid ticket status transition
+  - invalid ticket message operation
+  - invalid order-linked ticket ownership
+  - unsupported role for order-linked ticket creation
+
+### Persistence
+
+- Update Prisma schema before implementation:
+  - add a `TicketStatus` enum
+  - change `Ticket.status` from `String` to `TicketStatus`
+  - add optional `Ticket.orderId`
+  - add `Ticket.order` relation to `Order`
+  - add `Order.tickets`
+  - add indexes for user-owned listing, order-linked lookup, and admin operational listing
+- Suggested migration name:
+
+```bash
+pnpm db:migrate:dev --name add_support_ticket_lifecycle
+```
+
+- Do not hand-write the migration by default. After Prisma generates it, inspect `migration.sql`.
+
+### Application and Repository
+
+- Add a ticket repository port with methods for:
+  - create ticket with initial message
+  - find ticket detail with messages
+  - list tickets for a user
+  - list tickets for admin
+  - add message and update ticket status atomically
+  - update ticket status
+  - verify client-owned order linkage
+- Implement a Prisma repository adapter.
+- Use transactions where message creation and status updates must be persisted together.
+- Return ticket messages in chronological order.
+
+### API
+
+User routes:
+
+- `POST /tickets`
+  - roles: `CLIENT`, `BOOSTER`
+  - body: `subject`, `content`, optional `orderId`
+  - `orderId` accepted only for `CLIENT` users and only when the order belongs to the current client
+- `GET /tickets`
+  - roles: `CLIENT`, `BOOSTER`
+  - lists only the current user's tickets
+- `GET /tickets/:ticketId`
+  - roles: `CLIENT`, `BOOSTER`
+  - returns only the current user's ticket detail and message history
+- `POST /tickets/:ticketId/messages`
+  - roles: `CLIENT`, `BOOSTER`
+  - allows replies only to the current user's ticket
+
+Admin routes:
+
+- `GET /admin/tickets`
+  - roles: `ADMIN`
+  - lists all tickets with filters for status, user query, and limit where practical
+- `GET /admin/tickets/:ticketId`
+  - roles: `ADMIN`
+  - returns any ticket detail and message history
+- `POST /admin/tickets/:ticketId/messages`
+  - roles: `ADMIN`
+  - replies to any ticket and sets status to `WAITING_USER`
+- `PATCH /admin/tickets/:ticketId/status`
+  - roles: `ADMIN`
+  - updates status to `OPEN`, `WAITING_USER`, `WAITING_SUPPORT`, or `CLOSED`
+
+Keep request validation at the boundary with Zod plus `ZodValidationPipe`.
+
+### Response Shape
+
+Return privacy-minimal responses:
+
+- ticket id
+- user id
+- optional order id
+- subject
+- status
+- created at
+- updated at
+- messages with id, sender id, sender role, content, and created at
+
+Do not expose user email, username, order credentials, or unrelated order details from ticket endpoints.
+
+## Security Rules
+
+- Users can list, read, and reply only to tickets where `ticket.userId === currentUser.id`.
+- Admins can list, read, reply, and update status for any ticket.
+- Cross-user ticket access should use not-found style behavior when that better avoids exposing ticket existence.
+- Ticket messages must never expose unrelated user data.
+- Optional `orderId` must be validated against client ownership at creation time.
+- Boosters cannot attach `orderId` in this issue.
+- Closed tickets can be reopened by an involved user or admin reply.
+
+## Acceptance Criteria
+
+- [ ] Authenticated clients and boosters can create general support tickets.
+- [ ] Authenticated clients can create tickets linked to their own orders.
+- [ ] Boosters cannot create order-linked tickets.
+- [ ] Authenticated users can list and read only their own tickets.
+- [ ] Admins can list and read all tickets through `/admin/tickets`.
+- [ ] Existing `GET /admin/support/tickets` summary behavior remains compatible.
+- [ ] Ticket message history is persisted and returned in chronological order.
+- [ ] User replies set status to `WAITING_SUPPORT`.
+- [ ] Admin replies set status to `WAITING_USER`.
+- [ ] Closed tickets reopen automatically on a valid reply.
+- [ ] Admins can update ticket status directly.
+- [ ] Forbidden or cross-user access uses the project-standard domain error mapping.
+- [ ] Runtime request validation rejects malformed bodies, params, and queries.
+- [ ] The implementation does not include frontend dashboard work.
+
+## Test Plan
+
+### Unit
+
+- Ticket domain status transition rules.
+- Create-ticket use case persists initial message and starts as `WAITING_SUPPORT`.
+- User reply sets status to `WAITING_SUPPORT`.
+- Admin reply sets status to `WAITING_USER`.
+- Reply to closed ticket reopens it.
+- Client-owned `orderId` is accepted.
+- Non-owned `orderId` is rejected.
+- Booster-provided `orderId` is rejected.
+- Access policy rejects non-owner user access.
+- Admin access bypasses owner-only restriction.
+
+### Integration / E2E
+
+- `POST /tickets` creates a general ticket and initial message.
+- `POST /tickets` creates an order-linked ticket for a client-owned order.
+- `POST /tickets` rejects a booster-provided `orderId`.
+- `GET /tickets` returns only current user tickets.
+- `GET /tickets/:ticketId` rejects another user's ticket.
+- `POST /tickets/:ticketId/messages` persists replies in chronological order.
+- `POST /admin/tickets/:ticketId/messages` persists admin replies and updates status.
+- `PATCH /admin/tickets/:ticketId/status` is admin-only.
+- `GET /admin/tickets` lists all tickets for admins.
+- `GET /admin/support/tickets` remains compatible for dashboard summary consumers.
+- Invalid payloads return `400 Bad Request`.
+
+Recommended targeted checks:
+
+```bash
+pnpm api test -- src/modules/tickets
+pnpm api test:e2e -- tickets.e2e-spec.ts
+pnpm api test:integration:db -- tickets.db.integration.spec.ts
+pnpm api exec tsc --noEmit -p tsconfig.json
+pnpm biome:fix:all
+```
+
+## Documentation
+
+- Update `docs/requirements.md` roadmap checkbox for support tickets only after the backend API lifecycle is complete.
+- Add or update backend API notes only if there is already a suitable documentation location; otherwise keep endpoint behavior covered by tests.
+- Document deferred scope:
+  - frontend ticket creation UI
+  - attachments
+  - SLA queues
+  - support assignment
+  - live ticket notifications
+  - booster order-linked support tickets
+
+## Suggested Implementation Order
+
+1. Check for dirty Prisma migrations before editing `schema.prisma`.
+2. Update Prisma schema for `TicketStatus` and optional `orderId`.
+3. Ask the human to run `pnpm db:migrate:dev --name add_support_ticket_lifecycle`.
+4. Inspect the generated migration SQL.
+5. Add ticket domain model, status constants, and domain errors.
+6. Add repository port and in-memory test repository.
+7. Write use-case tests for create, list, get, reply, admin reply, and status update.
+8. Implement Prisma ticket repository.
+9. Add controller schemas and routes.
+10. Wire `TicketsModule` into `AppModule`.
+11. Add API domain error mappings.
+12. Add e2e and DB-backed integration coverage for auth, ownership, admin access, order linkage, status behavior, and invalid payloads.
+13. Run targeted quality gates.
+14. Update docs only if the backend lifecycle is complete.

--- a/packages/database/prisma/migrations/20260528020611_add_support_ticket_lifecycle/migration.sql
+++ b/packages/database/prisma/migrations/20260528020611_add_support_ticket_lifecycle/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[status]` on the table `pricing_versions` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "pricing_versions_single_active_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "pricing_versions_single_active_key" ON "pricing_versions"("status") WHERE ("status" = 'ACTIVE');

--- a/packages/database/prisma/migrations/20260528140000_add_support_ticket_lifecycle/migration.sql
+++ b/packages/database/prisma/migrations/20260528140000_add_support_ticket_lifecycle/migration.sql
@@ -1,0 +1,31 @@
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('OPEN', 'WAITING_USER', 'WAITING_SUPPORT', 'CLOSED');
+
+-- AlterTable
+ALTER TABLE "tickets" ADD COLUMN "orderId" TEXT;
+ALTER TABLE "tickets" ADD COLUMN "status_new" "TicketStatus" NOT NULL DEFAULT 'WAITING_SUPPORT';
+
+UPDATE "tickets"
+SET "status_new" = CASE "status"
+    WHEN 'OPEN' THEN 'OPEN'::"TicketStatus"
+    WHEN 'WAITING_USER' THEN 'WAITING_USER'::"TicketStatus"
+    WHEN 'WAITING_SUPPORT' THEN 'WAITING_SUPPORT'::"TicketStatus"
+    WHEN 'PENDING' THEN 'WAITING_SUPPORT'::"TicketStatus"
+    WHEN 'CLOSED' THEN 'CLOSED'::"TicketStatus"
+    ELSE 'WAITING_SUPPORT'::"TicketStatus"
+END;
+
+ALTER TABLE "tickets" DROP COLUMN "status";
+ALTER TABLE "tickets" RENAME COLUMN "status_new" TO "status";
+
+-- CreateIndex
+CREATE INDEX "tickets_userId_updatedAt_idx" ON "tickets"("userId", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "tickets_orderId_idx" ON "tickets"("orderId");
+
+-- CreateIndex
+CREATE INDEX "tickets_status_updatedAt_idx" ON "tickets"("status", "updatedAt");
+
+-- AddForeignKey
+ALTER TABLE "tickets" ADD CONSTRAINT "tickets_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "orders"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -61,6 +61,13 @@ enum NotificationType {
   CHAT_MESSAGE_CREATED
 }
 
+enum TicketStatus {
+  OPEN
+  WAITING_USER
+  WAITING_SUPPORT
+  CLOSED
+}
+
 model User {
   id               String    @id @default(cuid())
   username         String    @unique
@@ -138,6 +145,7 @@ model Order {
   extras           OrderExtra[]
   payments         Payment[]
   chat             Chat?
+  tickets          Ticket[]
   rating           Rating?
   walletTransactions WalletTransaction[]
   boosterRejections OrderBoosterRejection[]
@@ -390,12 +398,17 @@ model Ticket {
   id        String          @id @default(cuid())
   userId    String
   user      User            @relation(fields: [userId], references: [id])
+  orderId   String?
+  order     Order?          @relation(fields: [orderId], references: [id])
   subject   String
-  status    String          @default("OPEN")
+  status    TicketStatus    @default(WAITING_SUPPORT)
   messages  TicketMessage[]
   createdAt DateTime        @default(now())
   updatedAt DateTime        @updatedAt
 
+  @@index([userId, updatedAt])
+  @@index([orderId])
+  @@index([status, updatedAt])
   @@map("tickets")
 }
 


### PR DESCRIPTION
## Summary

Implement the backend support ticket lifecycle for authenticated users and admins.

Closes: https://github.com/caiohenrqq/elonew/issues/52

---

## What Changed

- Added a `tickets` API module with domain rules, use-cases, controllers, and Prisma persistence.
- Added user ticket APIs under `/tickets` and admin lifecycle APIs under `/admin/tickets`.
- Added ticket lifecycle statuses, optional client-owned `orderId` linkage, and privacy-aware access checks.
- Added Prisma schema updates and migrations for `TicketStatus`, ticket order linkage, and ticket listing indexes.
- Stabilized refresh-session test fixtures by using rolling future expiry dates.
- Added unit, e2e, and DB-backed integration tests for support ticket behavior.

---

## Why

FR-058, FR-059, and FR-060 require a backend ticketing system with persisted history and privacy-aware data handling before frontend support flows can rely on it.

---

## Implementation Notes

- Ticket statuses are `OPEN`, `WAITING_USER`, `WAITING_SUPPORT`, and `CLOSED`.
- User replies move tickets to `WAITING_SUPPORT`; admin replies move tickets to `WAITING_USER`.
- Replies to closed tickets reopen them using the same status rules.
- Clients can create order-linked tickets only for their own orders.
- Boosters can create general support tickets; booster order-linked tickets remain deferred.
- Existing `/admin/support/tickets` dashboard summary behavior remains compatible.
- `20260528020611_add_support_ticket_lifecycle` was generated/applied locally and kept in migration history; `20260528140000_add_support_ticket_lifecycle` contains the ticket lifecycle schema changes.

---

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manually tested

Steps run:

1. `pnpm biome:fix:all`
2. `pnpm db:generate`
3. `pnpm db:validate`
4. `pnpm api test -- src/modules/auth/application/use-cases/refresh-session/refresh-session.use-case.spec.ts --runInBand`
5. `pnpm api test -- src/modules/tickets --runInBand`
6. `pnpm api test:e2e -- tickets.e2e-spec.ts --runInBand`
7. `pnpm api test:integration:db -- tickets.db.integration.spec.ts`
8. `pnpm api exec tsc --noEmit -p tsconfig.json`
9. `pnpm api test`
10. `git diff --check`

---

## Screenshots (if UI)

None. Backend-only change.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated where needed
- [x] Lint and type checks pass
- [x] Documentation updated if required
- [x] No breaking changes

---

## Breaking Changes

None.
