### PR TITLE
feat(web): add admin support ticket workspace

### DIFF
--- a/apps/web/src/app/(dashboard)/admin/support/page.tsx
+++ b/apps/web/src/app/(dashboard)/admin/support/page.tsx
@@ -1,10 +1,30 @@
-import { getAdminSupportTickets } from '@/modules/admin-dashboard/actions/admin-actions';
-import { AdminSupportPage } from '@/modules/admin-dashboard/presentation/overview/admin-dashboard-page';
+import { getAdminSupportWorkspace } from '@/modules/admin-dashboard/actions/admin-actions';
+import { AdminSupportWorkspace } from '@/modules/admin-dashboard/presentation/support/admin-support-workspace';
+import { adminTicketStatusSchema } from '@/modules/admin-dashboard/server/admin-contracts';
 
-const Page = async () => {
-	const tickets = await getAdminSupportTickets();
+type PageProps = {
+	searchParams?: Promise<{
+		query?: string;
+		status?: string;
+		ticketId?: string;
+	}>;
+};
 
-	return <AdminSupportPage tickets={tickets} />;
+const Page = async ({ searchParams }: PageProps) => {
+	const params = await searchParams;
+	const status = adminTicketStatusSchema.safeParse(params?.status);
+	const query = params?.query?.trim() || undefined;
+	const ticketId = params?.ticketId?.trim() || undefined;
+	const filters = {
+		query,
+		status: status.success ? status.data : undefined,
+	};
+	const workspace = await getAdminSupportWorkspace({
+		...filters,
+		ticketId,
+	});
+
+	return <AdminSupportWorkspace {...workspace} filters={filters} />;
 };
 
 export default Page;

--- a/apps/web/src/modules/admin-dashboard/actions/admin-actions.ts
+++ b/apps/web/src/modules/admin-dashboard/actions/admin-actions.ts
@@ -16,9 +16,15 @@ import type {
 	AdminMetricsOutput,
 	AdminOrderOutput,
 	AdminSupportTicketOutput,
+	AdminTicketDetailOutput,
 	AdminUserOutput,
+	ListAdminTicketsInput,
 } from '../server/admin-contracts';
-import { adminGovernanceInputSchema } from '../server/admin-contracts';
+import {
+	adminGovernanceInputSchema,
+	replyAdminTicketInputSchema,
+	updateAdminTicketStatusInputSchema,
+} from '../server/admin-contracts';
 import {
 	blockAdminUser,
 	forceCancelAdminOrder,
@@ -27,11 +33,19 @@ import {
 	getAdminOrderChatMessages as getAdminOrderChatMessagesFromApi,
 	getAdminOrders as getAdminOrdersFromApi,
 	getAdminSupportTickets as getAdminSupportTicketsFromApi,
+	getAdminTicket as getAdminTicketFromApi,
 	getAdminUsers as getAdminUsersFromApi,
+	replyAdminTicket,
 	unblockAdminUser,
+	updateAdminTicketStatus,
 } from '../server/admin-service';
 
 export type AdminGovernanceActionState = {
+	error?: string;
+	success?: boolean;
+};
+
+export type AdminTicketActionState = {
 	error?: string;
 	success?: boolean;
 };
@@ -53,6 +67,27 @@ const parseGovernanceForm = (formData: FormData) =>
 		targetId: formData.get('targetId'),
 		reason: formData.get('reason'),
 	}) satisfies AdminGovernanceInput;
+
+const getValidationMessage = (error: unknown) => {
+	if (
+		error &&
+		typeof error === 'object' &&
+		'issues' in error &&
+		Array.isArray(error.issues)
+	) {
+		const [issue] = error.issues;
+		if (
+			issue &&
+			typeof issue === 'object' &&
+			'message' in issue &&
+			typeof issue.message === 'string'
+		) {
+			return issue.message;
+		}
+	}
+
+	return getAuthErrorMessage(error);
+};
 
 export const getAdminDashboard = async (): Promise<AdminDashboardOutput> => {
 	await getAdminSessionOrRedirect();
@@ -124,6 +159,43 @@ export const getAdminSupportTickets = async (): Promise<
 	}
 };
 
+export const getAdminSupportWorkspace = async (
+	input: Partial<ListAdminTicketsInput> & { ticketId?: string } = {},
+): Promise<{
+	tickets: AdminSupportTicketOutput[];
+	selectedTicket: AdminTicketDetailOutput | null;
+}> => {
+	await getAdminSessionOrRedirect();
+	try {
+		const selectedTicketId = input.ticketId?.trim();
+		const tickets = await getAdminSupportTicketsFromApi(renderReadApiRequest, {
+			limit: input.limit ?? 25,
+			status: input.status,
+			query: input.query,
+		});
+		const fallbackTicketId = selectedTicketId || tickets[0]?.id;
+		if (!fallbackTicketId) return { tickets, selectedTicket: null };
+
+		try {
+			return {
+				tickets,
+				selectedTicket: await getAdminTicketFromApi(
+					fallbackTicketId,
+					renderReadApiRequest,
+				),
+			};
+		} catch (error) {
+			if (error instanceof ApiRequestError && error.status === 404) {
+				return { tickets, selectedTicket: null };
+			}
+
+			throw error;
+		}
+	} catch (error) {
+		return redirectOnAuthError(error);
+	}
+};
+
 export const blockAdminUserAction = async (
 	_state: AdminGovernanceActionState,
 	formData: FormData,
@@ -137,6 +209,50 @@ export const blockAdminUserAction = async (
 		return { success: true };
 	} catch (error) {
 		return { error: getAuthErrorMessage(error) };
+	}
+};
+
+export const replyAdminTicketAction = async (
+	_state: AdminTicketActionState,
+	formData: FormData,
+): Promise<AdminTicketActionState> => {
+	try {
+		await assertSameOriginRequest();
+		await getAdminSessionOrRedirect();
+
+		const input = replyAdminTicketInputSchema.parse({
+			ticketId: formData.get('ticketId'),
+			content: formData.get('content'),
+		});
+
+		await replyAdminTicket(input, api.request);
+		revalidatePath('/admin');
+		revalidatePath('/admin/support');
+		return { success: true };
+	} catch (error) {
+		return { error: getValidationMessage(error) };
+	}
+};
+
+export const updateAdminTicketStatusAction = async (
+	_state: AdminTicketActionState,
+	formData: FormData,
+): Promise<AdminTicketActionState> => {
+	try {
+		await assertSameOriginRequest();
+		await getAdminSessionOrRedirect();
+
+		const input = updateAdminTicketStatusInputSchema.parse({
+			ticketId: formData.get('ticketId'),
+			status: formData.get('status'),
+		});
+
+		await updateAdminTicketStatus(input, api.request);
+		revalidatePath('/admin');
+		revalidatePath('/admin/support');
+		return { success: true };
+	} catch (error) {
+		return { error: getValidationMessage(error) };
 	}
 };
 

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx
@@ -173,8 +173,9 @@ describe('admin dashboard pages', () => {
 					{
 						id: 'ticket-1',
 						userId: 'client-1',
+						orderId: null,
 						subject: 'Preciso de ajuda',
-						status: 'OPEN',
+						status: 'WAITING_SUPPORT',
 						createdAt: '2026-05-01T00:00:00.000Z',
 						updatedAt: '2026-05-02T00:00:00.000Z',
 						messageCount: 2,
@@ -186,7 +187,7 @@ describe('admin dashboard pages', () => {
 
 		expect(screen.getByText('Suporte')).toBeInTheDocument();
 		expect(screen.getByText('Preciso de ajuda')).toBeInTheDocument();
-		expect(screen.getByText('Aberto')).toBeInTheDocument();
+		expect(screen.getByText('Aguardando suporte')).toBeInTheDocument();
 		expect(screen.getByText('2 mensagens')).toBeInTheDocument();
 	});
 

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.tsx
@@ -109,7 +109,8 @@ const formatTicketStatus = (status: string) => {
 	const labels: Record<string, string> = {
 		CLOSED: 'Fechado',
 		OPEN: 'Aberto',
-		PENDING: 'Pendente',
+		WAITING_SUPPORT: 'Aguardando suporte',
+		WAITING_USER: 'Aguardando usuário',
 	};
 
 	return labels[status] ?? formatTitleCase(status);
@@ -590,12 +591,8 @@ export const AdminSupportPage = ({ tickets }: AdminSupportPageProps) => {
 		(ticket) => ticket.status === 'OPEN',
 	).length;
 	const pendingTickets = tickets.filter(
-		(ticket) => ticket.status === 'PENDING',
+		(ticket) => ticket.status === 'WAITING_SUPPORT',
 	).length;
-	const totalMessages = tickets.reduce(
-		(total, ticket) => total + ticket.messageCount,
-		0,
-	);
 
 	return (
 		<DashboardEntrance>
@@ -604,7 +601,7 @@ export const AdminSupportPage = ({ tickets }: AdminSupportPageProps) => {
 					title="Suporte"
 					detail={`${tickets.length} tickets`}
 				/>
-				<div className="grid gap-4 md:grid-cols-3">
+				<div className="grid gap-4 md:grid-cols-2">
 					<DashboardMetricCard
 						label="Abertos"
 						value={formatMetricCount(openTickets)}
@@ -612,10 +609,6 @@ export const AdminSupportPage = ({ tickets }: AdminSupportPageProps) => {
 					<DashboardMetricCard
 						label="Pendentes"
 						value={formatMetricCount(pendingTickets)}
-					/>
-					<DashboardMetricCard
-						label="Mensagens"
-						value={formatMetricCount(totalMessages)}
 					/>
 				</div>
 				<Card className="overflow-hidden border-white/10">

--- a/apps/web/src/modules/admin-dashboard/presentation/support/admin-support-workspace.spec.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/support/admin-support-workspace.spec.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import type {
+	AdminSupportTicketOutput,
+	AdminTicketDetailOutput,
+} from '../../server/admin-contracts';
+import { AdminSupportWorkspace } from './admin-support-workspace';
+
+jest.mock('next/navigation', () => ({
+	useRouter: jest.fn(),
+}));
+
+jest.mock('../../actions/admin-actions', () => ({
+	replyAdminTicketAction: jest.fn(),
+	updateAdminTicketStatusAction: jest.fn(),
+}));
+
+const useRouterMock = useRouter as jest.Mock;
+
+const tickets: AdminSupportTicketOutput[] = [
+	{
+		id: 'ticket-closed',
+		userId: 'client-2',
+		orderId: null,
+		subject: 'Ticket resolvido',
+		status: 'CLOSED' as const,
+		createdAt: '2026-05-01T08:00:00.000Z',
+		updatedAt: '2026-05-01T09:00:00.000Z',
+		messageCount: 1,
+		latestMessageAt: '2026-05-01T09:00:00.000Z',
+	},
+	{
+		id: 'ticket-waiting-support',
+		userId: 'client-1',
+		orderId: 'order-1',
+		subject: 'Pagamento não atualizou',
+		status: 'WAITING_SUPPORT' as const,
+		createdAt: '2026-05-02T08:00:00.000Z',
+		updatedAt: '2026-05-02T09:00:00.000Z',
+		messageCount: 2,
+		latestMessageAt: '2026-05-02T09:00:00.000Z',
+	},
+];
+
+const selectedTicket: AdminTicketDetailOutput = {
+	id: 'ticket-waiting-support',
+	userId: 'client-1',
+	orderId: 'order-1',
+	subject: 'Pagamento não atualizou',
+	status: 'WAITING_SUPPORT' as const,
+	createdAt: '2026-05-02T08:00:00.000Z',
+	updatedAt: '2026-05-02T09:00:00.000Z',
+	messages: [
+		{
+			id: 'message-1',
+			ticketId: 'ticket-waiting-support',
+			senderId: 'client-1',
+			senderRole: 'CLIENT',
+			content: 'Meu pagamento ainda aparece pendente.',
+			createdAt: '2026-05-02T08:00:00.000Z',
+		},
+		{
+			id: 'message-2',
+			ticketId: 'ticket-waiting-support',
+			senderId: 'admin-1',
+			senderRole: 'ADMIN',
+			content: 'Vamos revisar o status do pedido.',
+			createdAt: '2026-05-02T09:00:00.000Z',
+		},
+	],
+};
+
+describe('AdminSupportWorkspace', () => {
+	beforeEach(() => {
+		useRouterMock.mockReturnValue({ refresh: jest.fn() });
+	});
+
+	it('renders the ticket queue and selected ticket detail', () => {
+		render(
+			<AdminSupportWorkspace
+				filters={{}}
+				selectedTicket={selectedTicket}
+				tickets={tickets}
+			/>,
+		);
+
+		expect(
+			screen.getByRole('heading', { name: 'Suporte' }),
+		).toBeInTheDocument();
+		expect(screen.getAllByText('Pagamento não atualizou')).toHaveLength(2);
+		expect(
+			screen.getAllByText('Aguardando suporte').length,
+		).toBeGreaterThanOrEqual(2);
+		expect(
+			screen.getByText('Meu pagamento ainda aparece pendente.'),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('Vamos revisar o status do pedido.'),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: /responder/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: /atualizar/i }),
+		).toBeInTheDocument();
+	});
+
+	it('renders tickets in the same table action pattern used by admin pages', () => {
+		render(
+			<AdminSupportWorkspace
+				filters={{}}
+				selectedTicket={selectedTicket}
+				tickets={tickets}
+			/>,
+		);
+
+		expect(
+			screen.getByRole('columnheader', { name: 'Chamado' }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('columnheader', { name: 'Atendimento' }),
+		).toBeInTheDocument();
+
+		const openLinks = screen.getAllByRole('link', { name: /abrir/i });
+		expect(openLinks).toHaveLength(2);
+		expect(openLinks[0]).toHaveAttribute(
+			'href',
+			'/admin/support?ticketId=ticket-waiting-support',
+		);
+		expect(openLinks[1]).toHaveAttribute(
+			'href',
+			'/admin/support?ticketId=ticket-closed',
+		);
+	});
+
+	it('renders an empty state when no ticket is selected', () => {
+		render(
+			<AdminSupportWorkspace filters={{}} selectedTicket={null} tickets={[]} />,
+		);
+
+		expect(screen.getByText('Nenhum ticket encontrado')).toBeInTheDocument();
+		expect(screen.getByText('Selecione um ticket')).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/modules/admin-dashboard/presentation/support/admin-support-workspace.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/support/admin-support-workspace.tsx
@@ -1,0 +1,527 @@
+'use client';
+
+import { Badge } from '@packages/ui/components/badge';
+import { getButtonClassName } from '@packages/ui/components/button';
+import { Card } from '@packages/ui/components/card';
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@packages/ui/components/table';
+import { fieldSurface, labelText } from '@packages/ui/styles/classes';
+import { cn } from '@packages/ui/utils/cn';
+import {
+	ArrowRight,
+	CheckCircle2,
+	Clock3,
+	MessageSquare,
+	Search,
+	Send,
+	Ticket,
+	UserRound,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useActionState, useEffect, useMemo, useRef } from 'react';
+import { DashboardEmptyState } from '@/shared/dashboard/dashboard-empty-state';
+import { DashboardEntrance } from '@/shared/dashboard/dashboard-entrance';
+import { DashboardSectionHeader } from '@/shared/dashboard/dashboard-section-header';
+import {
+	replyAdminTicketAction,
+	updateAdminTicketStatusAction,
+} from '../../actions/admin-actions';
+import type {
+	AdminSupportTicketOutput,
+	AdminTicketDetailOutput,
+	AdminTicketStatus,
+} from '../../server/admin-contracts';
+
+type AdminSupportWorkspaceProps = {
+	tickets: AdminSupportTicketOutput[];
+	selectedTicket: AdminTicketDetailOutput | null;
+	filters: {
+		query?: string;
+		status?: AdminTicketStatus;
+	};
+};
+
+const ticketStatuses = [
+	'WAITING_SUPPORT',
+	'OPEN',
+	'WAITING_USER',
+	'CLOSED',
+] as const satisfies readonly AdminTicketStatus[];
+
+const ticketStatusLabels: Record<AdminTicketStatus, string> = {
+	CLOSED: 'Fechado',
+	OPEN: 'Aberto',
+	WAITING_SUPPORT: 'Aguardando suporte',
+	WAITING_USER: 'Aguardando usuário',
+};
+
+const ticketStatusDescriptions: Record<AdminTicketStatus, string> = {
+	CLOSED: 'Encerrado',
+	OPEN: 'Triagem',
+	WAITING_SUPPORT: 'Responder',
+	WAITING_USER: 'Com cliente',
+};
+
+const ticketStatusBadgeVariants: Record<
+	AdminTicketStatus,
+	'default' | 'outline' | 'success' | 'warning' | 'error'
+> = {
+	CLOSED: 'outline',
+	OPEN: 'default',
+	WAITING_SUPPORT: 'warning',
+	WAITING_USER: 'success',
+};
+
+const roleLabels: Record<string, string> = {
+	ADMIN: 'Admin',
+	BOOSTER: 'Booster',
+	CLIENT: 'Cliente',
+};
+
+const dateTimeFormatter = new Intl.DateTimeFormat('pt-BR', {
+	dateStyle: 'short',
+	timeStyle: 'short',
+});
+
+const formatDate = (value: string | null) =>
+	value ? dateTimeFormatter.format(new Date(value)) : 'Sem registro';
+
+const buildSupportHref = (
+	params: AdminSupportWorkspaceProps['filters'] & {
+		ticketId?: string;
+	},
+) => {
+	const searchParams = new URLSearchParams();
+	if (params.status) searchParams.set('status', params.status);
+	if (params.query) searchParams.set('query', params.query);
+	if (params.ticketId) searchParams.set('ticketId', params.ticketId);
+	const search = searchParams.toString();
+
+	return search ? `/admin/support?${search}` : '/admin/support';
+};
+
+const sortTicketsByTriage = (tickets: AdminSupportTicketOutput[]) => {
+	const priority = new Map<AdminTicketStatus, number>(
+		ticketStatuses.map((status, index) => [status, index]),
+	);
+
+	return [...tickets].sort((first, second) => {
+		const statusDiff =
+			(priority.get(first.status) ?? 99) - (priority.get(second.status) ?? 99);
+		if (statusDiff !== 0) return statusDiff;
+
+		return (
+			new Date(second.latestMessageAt ?? second.updatedAt).getTime() -
+			new Date(first.latestMessageAt ?? first.updatedAt).getTime()
+		);
+	});
+};
+
+const TicketStatusBadge = ({ status }: { status: AdminTicketStatus }) => (
+	<Badge variant={ticketStatusBadgeVariants[status]}>
+		{ticketStatusLabels[status]}
+	</Badge>
+);
+
+const SupportQueue = ({
+	filters,
+	selectedTicketId,
+	tickets,
+}: {
+	filters: AdminSupportWorkspaceProps['filters'];
+	selectedTicketId?: string;
+	tickets: AdminSupportTicketOutput[];
+}) => {
+	const sortedTickets = useMemo(() => sortTicketsByTriage(tickets), [tickets]);
+
+	return (
+		<div className="space-y-3">
+			<Card className="border-white/10 p-4">
+				<form
+					action="/admin/support"
+					className="grid gap-2 sm:grid-cols-[1fr_auto]"
+				>
+					<input type="hidden" name="status" value={filters.status ?? ''} />
+					<label className="sr-only" htmlFor="ticket-query">
+						Buscar tickets
+					</label>
+					<div className="relative">
+						<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-3.5 w-3.5 text-white/35" />
+						<input
+							id="ticket-query"
+							name="query"
+							defaultValue={filters.query ?? ''}
+							placeholder="Buscar por assunto"
+							className={cn(fieldSurface, 'pl-9')}
+						/>
+					</div>
+					<button
+						type="submit"
+						className={getButtonClassName({
+							variant: 'outline',
+							size: 'icon',
+							className: 'h-10 w-10',
+						})}
+						aria-label="Buscar tickets"
+					>
+						<Search className="h-3.5 w-3.5" />
+					</button>
+				</form>
+				<div className="mt-3 flex flex-wrap gap-2">
+					<Link
+						href={buildSupportHref({ query: filters.query })}
+						className={getButtonClassName({
+							variant: filters.status ? 'outline' : 'secondary',
+							size: 'sm',
+							className: 'h-8 px-3 text-[9px]',
+						})}
+					>
+						Todos
+					</Link>
+					{ticketStatuses.map((status) => (
+						<Link
+							key={status}
+							href={buildSupportHref({ query: filters.query, status })}
+							className={getButtonClassName({
+								variant: filters.status === status ? 'secondary' : 'outline',
+								size: 'sm',
+								className: 'h-8 px-3 text-[9px]',
+							})}
+						>
+							{ticketStatusDescriptions[status]}
+						</Link>
+					))}
+				</div>
+			</Card>
+			<Card className="overflow-hidden border-white/10">
+				{sortedTickets.length > 0 ? (
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Chamado</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead>Usuário</TableHead>
+								<TableHead>Pedido</TableHead>
+								<TableHead>Mensagens</TableHead>
+								<TableHead>Última mensagem</TableHead>
+								<TableHead className="text-right">Atendimento</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{sortedTickets.map((ticket) => (
+								<TableRow
+									key={ticket.id}
+									data-state={
+										ticket.id === selectedTicketId ? 'selected' : undefined
+									}
+								>
+									<TableCell>
+										<div className="flex items-center gap-2.5">
+											<Ticket className="h-4 w-4 shrink-0 text-hextech-cyan/70" />
+											<div className="min-w-0 space-y-1">
+												<p className="truncate font-black text-white">
+													{ticket.subject}
+												</p>
+												<p className="max-w-[190px] truncate font-mono text-[10px] text-white/45">
+													{ticket.id}
+												</p>
+											</div>
+										</div>
+									</TableCell>
+									<TableCell>
+										<TicketStatusBadge status={ticket.status} />
+									</TableCell>
+									<TableCell>
+										<p className="text-[10px] uppercase tracking-widest text-white/35">
+											{ticket.userId}
+										</p>
+									</TableCell>
+									<TableCell>
+										<p className="max-w-[190px] truncate font-mono text-[10px] text-white/45">
+											{ticket.orderId ?? 'Não vinculado'}
+										</p>
+									</TableCell>
+									<TableCell>
+										<div className="flex items-center gap-2 text-[10px] font-bold text-white/45">
+											<MessageSquare className="h-3.5 w-3.5 text-hextech-cyan/70" />
+											{ticket.messageCount} mensagens
+										</div>
+									</TableCell>
+									<TableCell className="text-[10px] uppercase tracking-widest text-white/35">
+										{formatDate(ticket.latestMessageAt)}
+									</TableCell>
+									<TableCell className="text-right">
+										<Link
+											href={buildSupportHref({
+												...filters,
+												ticketId: ticket.id,
+											})}
+											aria-current={
+												ticket.id === selectedTicketId ? 'page' : undefined
+											}
+											className={getButtonClassName({
+												size: 'sm',
+												variant: 'outline',
+												className: 'gap-2',
+											})}
+										>
+											Abrir
+											<ArrowRight className="h-3.5 w-3.5" />
+										</Link>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				) : (
+					<div className="p-6">
+						<DashboardEmptyState
+							icon={Ticket}
+							title="Nenhum ticket encontrado"
+							description="Ajuste os filtros para revisar outros chamados."
+						/>
+					</div>
+				)}
+			</Card>
+		</div>
+	);
+};
+
+const ReplyForm = ({ ticketId }: { ticketId: string }) => {
+	const router = useRouter();
+	const formRef = useRef<HTMLFormElement>(null);
+	const [state, formAction, isPending] = useActionState(
+		replyAdminTicketAction,
+		{},
+	);
+
+	useEffect(() => {
+		if (!state.success) return;
+
+		formRef.current?.reset();
+		router.refresh();
+	}, [router, state.success]);
+
+	return (
+		<form ref={formRef} action={formAction} className="grid gap-3">
+			<input type="hidden" name="ticketId" value={ticketId} />
+			<label className="sr-only" htmlFor="ticket-reply">
+				Resposta
+			</label>
+			<textarea
+				id="ticket-reply"
+				name="content"
+				placeholder="Responder ao ticket"
+				className={cn(
+					fieldSurface,
+					'h-28 min-h-28 resize-none bg-black/20 leading-relaxed placeholder:text-white/30',
+				)}
+				disabled={isPending}
+				required
+			/>
+			<div className="flex items-center justify-between gap-3">
+				<p className="min-h-4 text-[10px] font-bold uppercase tracking-wider text-red-300">
+					{state.error ?? ''}
+				</p>
+				<button
+					type="submit"
+					disabled={isPending}
+					aria-busy={isPending}
+					className={getButtonClassName({
+						variant: 'secondary',
+						size: 'sm',
+						className: 'gap-2',
+					})}
+				>
+					<Send className="h-3.5 w-3.5" />
+					{isPending ? 'Enviando' : 'Responder'}
+				</button>
+			</div>
+		</form>
+	);
+};
+
+const StatusForm = ({
+	status,
+	ticketId,
+}: {
+	status: AdminTicketStatus;
+	ticketId: string;
+}) => {
+	const router = useRouter();
+	const [state, formAction, isPending] = useActionState(
+		updateAdminTicketStatusAction,
+		{},
+	);
+
+	useEffect(() => {
+		if (state.success) router.refresh();
+	}, [router, state.success]);
+
+	return (
+		<form action={formAction} className="grid gap-2 sm:grid-cols-[1fr_auto]">
+			<input type="hidden" name="ticketId" value={ticketId} />
+			<label className="sr-only" htmlFor="ticket-status">
+				Status do ticket
+			</label>
+			<select
+				id="ticket-status"
+				name="status"
+				defaultValue={status}
+				disabled={isPending}
+				className={cn(fieldSurface, 'cursor-pointer bg-black/20')}
+			>
+				{ticketStatuses.map((ticketStatus) => (
+					<option key={ticketStatus} value={ticketStatus}>
+						{ticketStatusLabels[ticketStatus]}
+					</option>
+				))}
+			</select>
+			<button
+				type="submit"
+				disabled={isPending}
+				aria-busy={isPending}
+				className={getButtonClassName({
+					variant: 'outline',
+					size: 'sm',
+					className: 'gap-2',
+				})}
+			>
+				<CheckCircle2 className="h-3.5 w-3.5" />
+				{isPending ? 'Salvando' : 'Atualizar'}
+			</button>
+			<p className="min-h-4 text-[10px] font-bold uppercase tracking-wider text-red-300 sm:col-span-2">
+				{state.error ?? ''}
+			</p>
+		</form>
+	);
+};
+
+const TicketDetail = ({ ticket }: { ticket: AdminTicketDetailOutput }) => (
+	<Card className="min-h-[640px] overflow-hidden border-white/10">
+		<div className="border-b border-white/10 p-5">
+			<div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+				<div className="min-w-0 space-y-3">
+					<TicketStatusBadge status={ticket.status} />
+					<h2 className="text-xl font-black text-white">{ticket.subject}</h2>
+					<div className="flex flex-wrap gap-x-4 gap-y-2 text-[10px] font-bold uppercase tracking-wider text-white/35">
+						<span className="inline-flex items-center gap-1.5">
+							<UserRound className="h-3.5 w-3.5" />
+							{ticket.userId}
+						</span>
+						<span>Pedido: {ticket.orderId ?? 'Não vinculado'}</span>
+						<span>Criado em {formatDate(ticket.createdAt)}</span>
+					</div>
+				</div>
+				<div className="w-full lg:w-72">
+					<StatusForm ticketId={ticket.id} status={ticket.status} />
+				</div>
+			</div>
+		</div>
+		<div className="grid min-h-[420px] gap-0 lg:grid-cols-[1fr_320px]">
+			<div className="border-white/10 border-b p-5 lg:border-r lg:border-b-0">
+				<div className="mb-4 flex items-center justify-between gap-3">
+					<p className={cn(labelText.control, 'text-white')}>Histórico</p>
+					<p className="inline-flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-white/35">
+						<MessageSquare className="h-3.5 w-3.5" />
+						{ticket.messages.length} mensagens
+					</p>
+				</div>
+				{ticket.messages.length > 0 ? (
+					<div className="space-y-4">
+						{ticket.messages.map((message) => {
+							const isAdmin = message.senderRole === 'ADMIN';
+
+							return (
+								<article
+									key={message.id}
+									className={cn(
+										'rounded-sm border p-4',
+										isAdmin
+											? 'border-hextech-cyan/20 bg-hextech-cyan/5'
+											: 'border-white/10 bg-white/[0.03]',
+									)}
+								>
+									<div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+										<p className="text-[10px] font-black uppercase tracking-[0.18em] text-white">
+											{roleLabels[message.senderRole] ?? message.senderRole}
+										</p>
+										<p className="inline-flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-white/35">
+											<Clock3 className="h-3.5 w-3.5" />
+											{formatDate(message.createdAt)}
+										</p>
+									</div>
+									<p className="whitespace-pre-wrap text-sm leading-relaxed text-white/75">
+										{message.content}
+									</p>
+								</article>
+							);
+						})}
+					</div>
+				) : (
+					<DashboardEmptyState
+						icon={MessageSquare}
+						title="Nenhuma mensagem"
+						description="As mensagens deste ticket aparecerão aqui."
+					/>
+				)}
+			</div>
+			<aside className="space-y-5 p-5">
+				<div className="space-y-2">
+					<p className={cn(labelText.control, 'text-white')}>Resposta</p>
+					<p className="text-xs leading-relaxed text-white/40">
+						A resposta do admin move o ticket para aguardando usuário. Use o
+						status manual para fechar ou reclassificar o atendimento.
+					</p>
+				</div>
+				<ReplyForm ticketId={ticket.id} />
+			</aside>
+		</div>
+	</Card>
+);
+
+export const AdminSupportWorkspace = ({
+	filters,
+	selectedTicket,
+	tickets,
+}: AdminSupportWorkspaceProps) => {
+	const waitingSupportCount = tickets.filter(
+		(ticket) => ticket.status === 'WAITING_SUPPORT',
+	).length;
+
+	return (
+		<DashboardEntrance>
+			<section className="dashboard-animate space-y-4">
+				<DashboardSectionHeader
+					title="Suporte"
+					detail={`${waitingSupportCount} aguardando suporte`}
+				/>
+				<div className="space-y-4">
+					<SupportQueue
+						filters={filters}
+						selectedTicketId={selectedTicket?.id}
+						tickets={tickets}
+					/>
+					{selectedTicket ? (
+						<TicketDetail ticket={selectedTicket} />
+					) : (
+						<Card className="flex min-h-[360px] items-center justify-center border-white/10 p-6">
+							<DashboardEmptyState
+								icon={Ticket}
+								title="Selecione um ticket"
+								description="Escolha um chamado na fila para revisar o histórico e responder."
+							/>
+						</Card>
+					)}
+				</div>
+			</section>
+		</DashboardEntrance>
+	);
+};

--- a/apps/web/src/modules/admin-dashboard/server/admin-contracts.ts
+++ b/apps/web/src/modules/admin-dashboard/server/admin-contracts.ts
@@ -39,15 +39,60 @@ export const adminOrderSchema = z.object({
 		.nullable(),
 });
 
+export const adminTicketStatusSchema = z.enum([
+	'OPEN',
+	'WAITING_USER',
+	'WAITING_SUPPORT',
+	'CLOSED',
+]);
+
+export const adminTicketSenderRoleSchema = z.enum([
+	'ADMIN',
+	'BOOSTER',
+	'CLIENT',
+]);
+
 export const adminSupportTicketSchema = z.object({
 	id: z.string(),
 	userId: z.string(),
+	orderId: z.string().nullable().default(null),
 	subject: z.string(),
-	status: z.string(),
+	status: adminTicketStatusSchema,
 	createdAt: z.string(),
 	updatedAt: z.string(),
 	messageCount: z.number().int().nonnegative(),
 	latestMessageAt: z.string().nullable(),
+});
+
+export const adminTicketMessageSchema = z.object({
+	id: z.string(),
+	ticketId: z.string(),
+	senderId: z.string(),
+	senderRole: adminTicketSenderRoleSchema,
+	content: z.string(),
+	createdAt: z.string(),
+});
+
+export const adminTicketDetailSchema = adminSupportTicketSchema
+	.omit({ messageCount: true, latestMessageAt: true })
+	.extend({
+		messages: z.array(adminTicketMessageSchema),
+	});
+
+export const listAdminTicketsInputSchema = z.object({
+	limit: z.number().int().min(1).max(100).default(25),
+	status: adminTicketStatusSchema.optional(),
+	query: z.string().trim().min(1).max(120).optional(),
+});
+
+export const replyAdminTicketInputSchema = z.object({
+	ticketId: z.string().trim().min(1),
+	content: z.string().trim().min(1).max(5000),
+});
+
+export const updateAdminTicketStatusInputSchema = z.object({
+	ticketId: z.string().trim().min(1),
+	status: adminTicketStatusSchema,
 });
 
 export const adminDashboardSchema = z.object({
@@ -60,5 +105,14 @@ export const adminDashboardSchema = z.object({
 export type AdminMetricsOutput = z.infer<typeof adminMetricsSchema>;
 export type AdminUserOutput = z.infer<typeof adminUserSchema>;
 export type AdminOrderOutput = z.infer<typeof adminOrderSchema>;
+export type AdminTicketStatus = z.infer<typeof adminTicketStatusSchema>;
+export type AdminTicketSenderRole = z.infer<typeof adminTicketSenderRoleSchema>;
 export type AdminSupportTicketOutput = z.infer<typeof adminSupportTicketSchema>;
+export type AdminTicketMessageOutput = z.infer<typeof adminTicketMessageSchema>;
+export type AdminTicketDetailOutput = z.infer<typeof adminTicketDetailSchema>;
+export type ListAdminTicketsInput = z.infer<typeof listAdminTicketsInputSchema>;
+export type ReplyAdminTicketInput = z.infer<typeof replyAdminTicketInputSchema>;
+export type UpdateAdminTicketStatusInput = z.infer<
+	typeof updateAdminTicketStatusInputSchema
+>;
 export type AdminDashboardOutput = z.infer<typeof adminDashboardSchema>;

--- a/apps/web/src/modules/admin-dashboard/server/admin-service.spec.ts
+++ b/apps/web/src/modules/admin-dashboard/server/admin-service.spec.ts
@@ -6,7 +6,11 @@ import {
 	getAdminDashboard,
 	getAdminMetrics,
 	getAdminOrderChatMessages,
+	getAdminSupportTickets,
+	getAdminTicket,
+	replyAdminTicket,
 	unblockAdminUser,
+	updateAdminTicketStatus,
 } from './admin-service';
 
 describe('admin service', () => {
@@ -47,13 +51,14 @@ describe('admin service', () => {
 					},
 				] as T;
 			}
-			if (path === '/admin/support/tickets?limit=25') {
+			if (path === '/admin/tickets?limit=25') {
 				return [
 					{
 						id: 'ticket-1',
 						userId: 'user-1',
+						orderId: null,
 						subject: 'Payment question',
-						status: 'OPEN',
+						status: 'WAITING_SUPPORT',
 						createdAt: '2026-04-10T10:00:00.000Z',
 						updatedAt: '2026-04-10T10:05:00.000Z',
 						messageCount: 2,
@@ -150,6 +155,92 @@ describe('admin service', () => {
 			'/admin/orders/order-1/chat/messages?limit=50',
 			{ auth: true },
 		);
+	});
+
+	it('loads admin support tickets from the lifecycle endpoint with filters', async () => {
+		const apiRequest = jest.fn(async <T>(path: string): Promise<T> => {
+			expect(path).toBe(
+				'/admin/tickets?limit=25&status=WAITING_SUPPORT&query=pagamento',
+			);
+			return [
+				{
+					id: 'ticket-1',
+					userId: 'user-1',
+					orderId: 'order-1',
+					subject: 'Pagamento pendente',
+					status: 'WAITING_SUPPORT',
+					createdAt: '2026-04-10T10:00:00.000Z',
+					updatedAt: '2026-04-10T10:05:00.000Z',
+					messageCount: 2,
+					latestMessageAt: '2026-04-10T10:05:00.000Z',
+				},
+			] as T;
+		});
+
+		await expect(
+			getAdminSupportTickets(apiRequest as AuthenticatedApiRequest, {
+				query: 'pagamento',
+				status: 'WAITING_SUPPORT',
+			}),
+		).resolves.toEqual([
+			expect.objectContaining({
+				id: 'ticket-1',
+				orderId: 'order-1',
+				status: 'WAITING_SUPPORT',
+			}),
+		]);
+	});
+
+	it('loads admin ticket details and submits lifecycle actions', async () => {
+		const ticketResponse = {
+			id: 'ticket-1',
+			userId: 'user-1',
+			orderId: null,
+			subject: 'Payment question',
+			status: 'WAITING_USER',
+			createdAt: '2026-04-10T10:00:00.000Z',
+			updatedAt: '2026-04-10T10:05:00.000Z',
+			messages: [
+				{
+					id: 'message-1',
+					ticketId: 'ticket-1',
+					senderId: 'admin-1',
+					senderRole: 'ADMIN',
+					content: 'Vamos verificar.',
+					createdAt: '2026-04-10T10:05:00.000Z',
+				},
+			],
+		};
+		const apiRequest = jest.fn(async <T>(): Promise<T> => ticketResponse as T);
+
+		await expect(
+			getAdminTicket('ticket-1', apiRequest as AuthenticatedApiRequest),
+		).resolves.toEqual(expect.objectContaining({ id: 'ticket-1' }));
+		await replyAdminTicket(
+			{ ticketId: 'ticket-1', content: 'Vamos verificar.' },
+			apiRequest as AuthenticatedApiRequest,
+		);
+		await updateAdminTicketStatus(
+			{ ticketId: 'ticket-1', status: 'CLOSED' },
+			apiRequest as AuthenticatedApiRequest,
+		);
+
+		expect(apiRequest).toHaveBeenCalledWith('/admin/tickets/ticket-1', {
+			auth: true,
+		});
+		expect(apiRequest).toHaveBeenCalledWith(
+			'/admin/tickets/ticket-1/messages',
+			{
+				auth: true,
+				method: 'POST',
+				body: JSON.stringify({ content: 'Vamos verificar.' }),
+			},
+		);
+		expect(apiRequest).toHaveBeenCalledWith('/admin/tickets/ticket-1/status', {
+			auth: true,
+			method: 'PATCH',
+			body: JSON.stringify({ status: 'CLOSED' }),
+		});
 	});
 
 	it('adds admin endpoint context to non-auth read failures', async () => {

--- a/apps/web/src/modules/admin-dashboard/server/admin-service.ts
+++ b/apps/web/src/modules/admin-dashboard/server/admin-service.ts
@@ -6,13 +6,19 @@ import {
 	type AdminMetricsOutput,
 	type AdminOrderOutput,
 	type AdminSupportTicketOutput,
+	type AdminTicketDetailOutput,
 	type AdminUserOutput,
 	adminDashboardSchema,
 	adminGovernanceInputSchema,
 	adminMetricsSchema,
 	adminOrderSchema,
 	adminSupportTicketSchema,
+	adminTicketDetailSchema,
 	adminUserSchema,
+	type ListAdminTicketsInput,
+	listAdminTicketsInputSchema,
+	replyAdminTicketInputSchema,
+	updateAdminTicketStatusInputSchema,
 } from './admin-contracts';
 
 export type AuthenticatedApiRequest = <T>(
@@ -113,8 +119,16 @@ export const getAdminOrderChatMessages = async (
 
 export const getAdminSupportTickets = async (
 	apiRequest: AuthenticatedApiRequest,
+	input: Partial<ListAdminTicketsInput> = {},
 ): Promise<AdminSupportTicketOutput[]> => {
-	const path = '/admin/support/tickets?limit=25';
+	const params = listAdminTicketsInputSchema.parse({ limit: 25, ...input });
+	const searchParams = new URLSearchParams({
+		limit: String(params.limit),
+	});
+	if (params.status) searchParams.set('status', params.status);
+	if (params.query) searchParams.set('query', params.query);
+
+	const path = `/admin/tickets?${searchParams.toString()}`;
 	return await withAdminReadErrorContext(
 		'Admin support tickets request',
 		path,
@@ -123,6 +137,23 @@ export const getAdminSupportTickets = async (
 				auth: true,
 			});
 			return adminSupportTicketSchema.array().parse(response);
+		},
+	);
+};
+
+export const getAdminTicket = async (
+	ticketId: string,
+	apiRequest: AuthenticatedApiRequest,
+): Promise<AdminTicketDetailOutput> => {
+	const path = `/admin/tickets/${encodeURIComponent(ticketId)}`;
+	return await withAdminReadErrorContext(
+		'Admin ticket request',
+		path,
+		async () => {
+			const response = await apiRequest<unknown>(path, {
+				auth: true,
+			});
+			return adminTicketDetailSchema.parse(response);
 		},
 	);
 };
@@ -180,4 +211,32 @@ export const forceCancelAdminOrder = async (
 			body: JSON.stringify({ reason: body.reason }),
 		},
 	);
+};
+
+export const replyAdminTicket = async (
+	input: unknown,
+	apiRequest: AuthenticatedApiRequest,
+): Promise<AdminTicketDetailOutput> => {
+	const body = replyAdminTicketInputSchema.parse(input);
+	const path = `/admin/tickets/${encodeURIComponent(body.ticketId)}/messages`;
+	const response = await apiRequest<unknown>(path, {
+		auth: true,
+		method: 'POST',
+		body: JSON.stringify({ content: body.content }),
+	});
+	return adminTicketDetailSchema.parse(response);
+};
+
+export const updateAdminTicketStatus = async (
+	input: unknown,
+	apiRequest: AuthenticatedApiRequest,
+): Promise<AdminTicketDetailOutput> => {
+	const body = updateAdminTicketStatusInputSchema.parse(input);
+	const path = `/admin/tickets/${encodeURIComponent(body.ticketId)}/status`;
+	const response = await apiRequest<unknown>(path, {
+		auth: true,
+		method: 'PATCH',
+		body: JSON.stringify({ status: body.status }),
+	});
+	return adminTicketDetailSchema.parse(response);
 };


### PR DESCRIPTION
## Summary

Adds the admin support ticket workspace for the ticket lifecycle feature.

Closes: https://github.com/caiohenrqq/elonew/issues/52

---

## What Changed

- Added typed admin ticket lifecycle contracts, service methods, and server actions for replies and status updates.
- Added the `/admin/support` queue + detail workspace using the existing admin table style and dashboard primitives.
- Updated support status labels and tests for the lifecycle statuses.

---

## Why

Admins need a production-ready support surface to view, triage, answer, and update support tickets created by the backend lifecycle feature.

---

## Implementation Notes

- This PR is stacked on `52-support-tickets-backend` because it consumes the new `/admin/tickets` endpoints from that branch.
- Only admins can answer tickets in this frontend scope.
- The support ticket list uses the same shared `Card` and `Table` primitives as the existing admin pages.
- Playwright was not run because the active Docker web container is mounted to `/home/henrqq/Code/elonew`, not this frontend worktree.

---

## Testing

How this was validated.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manually tested

Steps to reproduce if needed:

1. Sign in as an admin.
2. Open `/admin/support`.
3. Select a ticket, submit a reply, and update its status.

Commands run:

- `pnpm biome:fix:all`
- `pnpm web exec tsc --noEmit -p tsconfig.json`
- `pnpm web test -- src/modules/admin-dashboard/server/admin-service.spec.ts src/modules/admin-dashboard/presentation/support/admin-support-workspace.spec.tsx src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx --runInBand`
- `git diff --check`

Known broader check:

- `pnpm web test` still fails in unrelated existing client/booster dashboard tests outside this change.

---

## Screenshots (if UI)

Not captured. Playwright/browser validation was skipped because the running Docker web service points at another worktree.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated where needed
- [x] Lint and type checks pass
- [ ] Documentation updated if required
- [x] No breaking changes

---

## Breaking Changes

None.
