### PR TITLE
feat(api): add ratings & reputation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -641,7 +641,7 @@ Use official docs first when documentation is required.
 ### 6. Communication & Support
 - [x] Implement WebSocket gateway for real-time internal Chat.
 - [x] Create `Ticket` domain and use-cases for support history.
-- [ ] Add `Rating` system (Client rates Booster and vice-versa).
+- [x] Add `Rating` system (Client rates Booster and vice-versa).
 
 ### 7. Admin Governance
 - [x] Implement Admin Dashboard API (Financial metrics: Revenue, active orders).

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,6 +4,7 @@ import { ChatModule } from '@modules/chat/chat.module';
 import { NotificationsModule } from '@modules/notifications/notifications.module';
 import { OrdersModule } from '@modules/orders/orders.module';
 import { PaymentsModule } from '@modules/payments/payments.module';
+import { RatingsModule } from '@modules/ratings/ratings.module';
 import { SystemModule } from '@modules/system/system.module';
 import { TicketsModule } from '@modules/tickets/tickets.module';
 import { UsersModule } from '@modules/users/users.module';
@@ -28,6 +29,7 @@ import { AppSettingsModule } from './common/settings/app-settings.module';
 		NotificationsModule,
 		OrdersModule,
 		PaymentsModule,
+		RatingsModule,
 		SystemModule,
 		TicketsModule,
 		UsersModule,

--- a/apps/api/src/common/http/api-domain-error.filter.ts
+++ b/apps/api/src/common/http/api-domain-error.filter.ts
@@ -76,6 +76,14 @@ import {
 	PaymentWebhookTopicNotSupportedError,
 } from '@modules/payments/domain/payment.errors';
 import {
+	InvalidRatingScoreError,
+	OrderNotRatableError,
+	RatingAlreadySubmittedError,
+	RatingNotAllowedError,
+	RatingOrderNotFoundError,
+	RatingWindowClosedError,
+} from '@modules/ratings/domain/rating.errors';
+import {
 	TicketAccessDeniedError,
 	TicketInvalidStatusTransitionError,
 	TicketMessageOperationInvalidError,
@@ -144,6 +152,7 @@ export function mapApiDomainErrorToHttpException(
 		mapAsForbidden(InsufficientPermissionsError),
 		mapAsForbidden(ChatForbiddenError),
 		mapAsForbidden(TicketAccessDeniedError),
+		mapAsForbidden(RatingNotAllowedError),
 		mapAsNotFound(
 			ChatOrderNotFoundError,
 			ChatMessageNotFoundError,
@@ -158,6 +167,7 @@ export function mapApiDomainErrorToHttpException(
 			WalletNotFoundError,
 			NotificationNotFoundError,
 			TicketNotFoundError,
+			RatingOrderNotFoundError,
 		),
 		mapAsBadRequest(
 			OrderAlreadyExistsError,
@@ -188,9 +198,13 @@ export function mapApiDomainErrorToHttpException(
 			TicketMessageOperationInvalidError,
 			TicketOrderAccessDeniedError,
 			TicketOrderLinkUnsupportedError,
+			OrderNotRatableError,
+			RatingWindowClosedError,
+			InvalidRatingScoreError,
 		),
 		mapAsConflict(OrderPricingVersionActiveConflictError, ChatNotWritableError),
 		mapAsConflict(NotificationReadConflictError),
+		mapAsConflict(RatingAlreadySubmittedError),
 	]);
 }
 

--- a/apps/api/src/modules/orders/application/use-cases/complete-order/complete-order.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/complete-order/complete-order.use-case.ts
@@ -36,7 +36,8 @@ export class CompleteOrderUseCase {
 		if (!order) throw new OrderNotFoundError();
 		if (order.boosterId !== input.boosterId) throw new OrderNotFoundError();
 
-		order.complete();
+		const completedAt = new Date();
+		order.complete(completedAt);
 		await this.orderRepository.save(order);
 		await this.orderEventPublisher?.publish(
 			createOrderEvent('order.completed', order, {
@@ -48,7 +49,7 @@ export class CompleteOrderUseCase {
 		await this.orderCompletionEarningsPort.creditCompletedOrderEarnings({
 			orderId: order.id,
 			boosterId: order.boosterId,
-			completedAt: new Date(),
+			completedAt,
 		});
 	}
 }

--- a/apps/api/src/modules/orders/domain/order.entity.ts
+++ b/apps/api/src/modules/orders/domain/order.entity.ts
@@ -61,6 +61,7 @@ export class Order {
 		private readonly currentTotalAmount: number | null,
 		private readonly currentDiscountAmount: number,
 		private readonly currentExtras: OrderPricedExtra[],
+		private currentCompletedAt: Date | null = null,
 	) {}
 
 	static create(
@@ -130,6 +131,7 @@ export class Order {
 		totalAmount?: number | null;
 		discountAmount?: number;
 		extras?: OrderPricedExtra[];
+		completedAt?: Date | null;
 	}): Order {
 		return new Order(
 			input.id,
@@ -144,6 +146,7 @@ export class Order {
 			input.totalAmount ?? null,
 			input.discountAmount ?? 0,
 			(input.extras ?? []).map((extra) => ({ ...extra })),
+			input.completedAt ?? null,
 		);
 	}
 
@@ -191,6 +194,10 @@ export class Order {
 		return this.currentExtras.map((extra) => ({ ...extra }));
 	}
 
+	get completedAt(): Date | null {
+		return this.currentCompletedAt;
+	}
+
 	confirmPayment(): void {
 		this.transitionTo(OrderStatus.PENDING_BOOSTER);
 	}
@@ -215,9 +222,10 @@ export class Order {
 		this.currentBoosterId = null;
 	}
 
-	complete(): void {
+	complete(now: Date = new Date()): void {
 		this.transitionTo(OrderStatus.COMPLETED);
 		this.currentCredentials = null;
+		this.currentCompletedAt = now;
 	}
 
 	cancel(): void {

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-order.repository.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-order.repository.ts
@@ -43,6 +43,7 @@ type OrderRecord = {
 	subtotal: number | null;
 	totalAmount: number | null;
 	discountAmount: number;
+	completedAt: Date | null;
 	extras: Array<{
 		type: string;
 		price: number;
@@ -108,6 +109,7 @@ type OrderDelegate = {
 			subtotal: number | null;
 			totalAmount: number | null;
 			discountAmount: number;
+			completedAt?: Date | null;
 			extras?: {
 				create: Array<{
 					type: string;
@@ -148,6 +150,7 @@ type OrderDelegate = {
 			subtotal: number | null;
 			totalAmount: number | null;
 			discountAmount: number;
+			completedAt?: Date | null;
 			extras?: {
 				create: Array<{
 					type: string;
@@ -183,6 +186,7 @@ type OrderDelegate = {
 			subtotal: number | null;
 			totalAmount: number | null;
 			discountAmount: number;
+			completedAt?: Date | null;
 			extras?: {
 				deleteMany: Record<string, never>;
 				create: Array<{
@@ -251,6 +255,7 @@ export class PrismaOrderRepository
 				status: order.status,
 				...this.mapRequestDetails(order.requestDetails),
 				...this.mapPricing(order),
+				completedAt: order.completedAt,
 				extras: this.mapExtrasCreate(order.extras),
 				credentials: this.mapCredentialsCreate(order.credentials),
 			},
@@ -438,6 +443,7 @@ export class PrismaOrderRepository
 				status: order.status,
 				...this.mapRequestDetails(order.requestDetails),
 				...this.mapPricing(order),
+				completedAt: order.completedAt,
 				extras: this.mapExtrasCreate(order.extras),
 				credentials: credentialsCreate,
 			},
@@ -449,6 +455,7 @@ export class PrismaOrderRepository
 				status: order.status,
 				...this.mapRequestDetails(order.requestDetails),
 				...this.mapPricing(order),
+				completedAt: order.completedAt,
 				extras: this.mapExtrasUpdate(order.extras),
 				credentials: credentialsUpdate,
 			},
@@ -476,6 +483,7 @@ export class PrismaOrderRepository
 			subtotal: record.subtotal,
 			totalAmount: record.totalAmount,
 			discountAmount: record.discountAmount,
+			completedAt: record.completedAt,
 			extras: (record.extras ?? []).map((extra) =>
 				this.mapExtraFromRecord(extra),
 			),

--- a/apps/api/src/modules/ratings/application/ports/rating-order-lookup.port.ts
+++ b/apps/api/src/modules/ratings/application/ports/rating-order-lookup.port.ts
@@ -1,0 +1,15 @@
+import type { OrderStatus } from '@modules/orders/domain/order-status';
+
+export const RATING_ORDER_LOOKUP_KEY = Symbol('RATING_ORDER_LOOKUP_KEY');
+
+export type RatableOrder = {
+	id: string;
+	clientId: string | null;
+	boosterId: string | null;
+	status: OrderStatus;
+	completedAt: Date | null;
+};
+
+export interface RatingOrderLookupPort {
+	findById(orderId: string): Promise<RatableOrder | null>;
+}

--- a/apps/api/src/modules/ratings/application/ports/rating-repository.port.ts
+++ b/apps/api/src/modules/ratings/application/ports/rating-repository.port.ts
@@ -1,0 +1,22 @@
+import type { Rating } from '@modules/ratings/domain/rating.entity';
+
+export const RATING_REPOSITORY_KEY = Symbol('RATING_REPOSITORY_KEY');
+
+export type RatingRecord = {
+	id: string;
+	orderId: string;
+	fromUserId: string;
+	toUserId: string;
+	score: number;
+	comment: string | null;
+	createdAt: Date;
+};
+
+export interface RatingRepositoryPort {
+	findByOrderAndRater(
+		orderId: string,
+		fromUserId: string,
+	): Promise<RatingRecord | null>;
+	listForOrder(orderId: string): Promise<RatingRecord[]>;
+	save(rating: Rating): Promise<RatingRecord>;
+}

--- a/apps/api/src/modules/ratings/application/use-cases/get-order-ratings/get-order-ratings.use-case.ts
+++ b/apps/api/src/modules/ratings/application/use-cases/get-order-ratings/get-order-ratings.use-case.ts
@@ -1,0 +1,45 @@
+import {
+	RATING_ORDER_LOOKUP_KEY,
+	type RatingOrderLookupPort,
+} from '@modules/ratings/application/ports/rating-order-lookup.port';
+import {
+	RATING_REPOSITORY_KEY,
+	type RatingRepositoryPort,
+} from '@modules/ratings/application/ports/rating-repository.port';
+import {
+	mapRatingResponse,
+	type RatingResponse,
+} from '@modules/ratings/application/use-cases/rating-response';
+import {
+	RatingNotAllowedError,
+	RatingOrderNotFoundError,
+} from '@modules/ratings/domain/rating.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+type GetOrderRatingsInput = {
+	orderId: string;
+	requesterId: string;
+};
+
+@Injectable()
+export class GetOrderRatingsUseCase {
+	constructor(
+		@Inject(RATING_REPOSITORY_KEY)
+		private readonly ratings: RatingRepositoryPort,
+		@Inject(RATING_ORDER_LOOKUP_KEY)
+		private readonly orders: RatingOrderLookupPort,
+	) {}
+
+	async execute(input: GetOrderRatingsInput): Promise<RatingResponse[]> {
+		const order = await this.orders.findById(input.orderId);
+		if (!order) throw new RatingOrderNotFoundError();
+		if (
+			input.requesterId !== order.clientId &&
+			input.requesterId !== order.boosterId
+		)
+			throw new RatingNotAllowedError();
+
+		const records = await this.ratings.listForOrder(input.orderId);
+		return records.map(mapRatingResponse);
+	}
+}

--- a/apps/api/src/modules/ratings/application/use-cases/rating-response.ts
+++ b/apps/api/src/modules/ratings/application/use-cases/rating-response.ts
@@ -1,0 +1,23 @@
+import type { RatingRecord } from '@modules/ratings/application/ports/rating-repository.port';
+
+export type RatingResponse = {
+	id: string;
+	orderId: string;
+	fromUserId: string;
+	toUserId: string;
+	score: number;
+	comment: string | null;
+	createdAt: string;
+};
+
+export function mapRatingResponse(record: RatingRecord): RatingResponse {
+	return {
+		id: record.id,
+		orderId: record.orderId,
+		fromUserId: record.fromUserId,
+		toUserId: record.toUserId,
+		score: record.score,
+		comment: record.comment,
+		createdAt: record.createdAt.toISOString(),
+	};
+}

--- a/apps/api/src/modules/ratings/application/use-cases/submit-rating/submit-rating.use-case.spec.ts
+++ b/apps/api/src/modules/ratings/application/use-cases/submit-rating/submit-rating.use-case.spec.ts
@@ -1,0 +1,221 @@
+import { OrderStatus } from '@modules/orders/domain/order-status';
+import type {
+	RatableOrder,
+	RatingOrderLookupPort,
+} from '@modules/ratings/application/ports/rating-order-lookup.port';
+import type {
+	RatingRecord,
+	RatingRepositoryPort,
+} from '@modules/ratings/application/ports/rating-repository.port';
+import { SubmitRatingUseCase } from '@modules/ratings/application/use-cases/submit-rating/submit-rating.use-case';
+import type { Rating } from '@modules/ratings/domain/rating.entity';
+import {
+	OrderNotRatableError,
+	RatingAlreadySubmittedError,
+	RatingNotAllowedError,
+	RatingOrderNotFoundError,
+	RatingWindowClosedError,
+} from '@modules/ratings/domain/rating.errors';
+
+class FakeRatingRepository
+	implements RatingRepositoryPort, RatingOrderLookupPort
+{
+	public orders = new Map<string, RatableOrder>();
+	public ratings: RatingRecord[] = [];
+	public reputations = new Map<string, number>();
+
+	async findById(orderId: string): Promise<RatableOrder | null> {
+		return this.orders.get(orderId) ?? null;
+	}
+
+	async findByOrderAndRater(
+		orderId: string,
+		fromUserId: string,
+	): Promise<RatingRecord | null> {
+		return (
+			this.ratings.find(
+				(r) => r.orderId === orderId && r.fromUserId === fromUserId,
+			) ?? null
+		);
+	}
+
+	async listForOrder(orderId: string): Promise<RatingRecord[]> {
+		return this.ratings.filter((r) => r.orderId === orderId);
+	}
+
+	async save(rating: Rating): Promise<RatingRecord> {
+		const record: RatingRecord = {
+			id: `rating-${this.ratings.length + 1}`,
+			orderId: rating.orderId,
+			fromUserId: rating.fromUserId,
+			toUserId: rating.toUserId,
+			score: rating.score,
+			comment: rating.comment,
+			createdAt: rating.createdAt,
+		};
+		this.ratings.push(record);
+
+		const received = this.ratings.filter((r) => r.toUserId === rating.toUserId);
+		const average =
+			received.reduce((sum, r) => sum + r.score, 0) / received.length;
+		this.reputations.set(rating.toUserId, average);
+
+		return record;
+	}
+}
+
+const COMPLETED_AT = new Date('2026-06-20T00:00:00.000Z');
+const NOW = new Date('2026-06-24T00:00:00.000Z');
+
+function completedOrder(overrides?: Partial<RatableOrder>): RatableOrder {
+	return {
+		id: 'order-1',
+		clientId: 'client-1',
+		boosterId: 'booster-1',
+		status: OrderStatus.COMPLETED,
+		completedAt: COMPLETED_AT,
+		...overrides,
+	};
+}
+
+function setup() {
+	const repo = new FakeRatingRepository();
+	const useCase = new SubmitRatingUseCase(repo, repo);
+	return { repo, useCase };
+}
+
+describe('SubmitRatingUseCase', () => {
+	it('lets the client rate the booster and updates booster reputation', async () => {
+		const { repo, useCase } = setup();
+		repo.orders.set('order-1', completedOrder());
+
+		const result = await useCase.execute({
+			raterId: 'client-1',
+			orderId: 'order-1',
+			score: 4,
+			now: NOW,
+		});
+
+		expect(result.fromUserId).toBe('client-1');
+		expect(result.toUserId).toBe('booster-1');
+		expect(repo.reputations.get('booster-1')).toBe(4);
+	});
+
+	it('lets the booster rate the client (other direction)', async () => {
+		const { repo, useCase } = setup();
+		repo.orders.set('order-1', completedOrder());
+
+		const result = await useCase.execute({
+			raterId: 'booster-1',
+			orderId: 'order-1',
+			score: 5,
+			now: NOW,
+		});
+
+		expect(result.toUserId).toBe('client-1');
+		expect(repo.reputations.get('client-1')).toBe(5);
+	});
+
+	it('averages multiple ratings received by a user', async () => {
+		const { repo, useCase } = setup();
+		repo.orders.set('order-1', completedOrder());
+		repo.orders.set(
+			'order-2',
+			completedOrder({ id: 'order-2', clientId: 'client-2' }),
+		);
+
+		await useCase.execute({
+			raterId: 'client-1',
+			orderId: 'order-1',
+			score: 5,
+			now: NOW,
+		});
+		await useCase.execute({
+			raterId: 'client-2',
+			orderId: 'order-2',
+			score: 3,
+			now: NOW,
+		});
+
+		expect(repo.reputations.get('booster-1')).toBe(4);
+	});
+
+	it('rejects an unknown order', async () => {
+		const { useCase } = setup();
+		await expect(
+			useCase.execute({
+				raterId: 'client-1',
+				orderId: 'missing',
+				score: 5,
+				now: NOW,
+			}),
+		).rejects.toThrow(RatingOrderNotFoundError);
+	});
+
+	it('rejects rating an order that is not completed', async () => {
+		const { repo, useCase } = setup();
+		repo.orders.set(
+			'order-1',
+			completedOrder({ status: OrderStatus.IN_PROGRESS }),
+		);
+
+		await expect(
+			useCase.execute({
+				raterId: 'client-1',
+				orderId: 'order-1',
+				score: 5,
+				now: NOW,
+			}),
+		).rejects.toThrow(OrderNotRatableError);
+	});
+
+	it('rejects a rater who is not on the order', async () => {
+		const { repo, useCase } = setup();
+		repo.orders.set('order-1', completedOrder());
+
+		await expect(
+			useCase.execute({
+				raterId: 'stranger',
+				orderId: 'order-1',
+				score: 5,
+				now: NOW,
+			}),
+		).rejects.toThrow(RatingNotAllowedError);
+	});
+
+	it('rejects a rating submitted after the window closes', async () => {
+		const { repo, useCase } = setup();
+		repo.orders.set('order-1', completedOrder());
+		const late = new Date(COMPLETED_AT.getTime() + 15 * 24 * 60 * 60 * 1000);
+
+		await expect(
+			useCase.execute({
+				raterId: 'client-1',
+				orderId: 'order-1',
+				score: 5,
+				now: late,
+			}),
+		).rejects.toThrow(RatingWindowClosedError);
+	});
+
+	it('rejects a second rating in the same direction', async () => {
+		const { repo, useCase } = setup();
+		repo.orders.set('order-1', completedOrder());
+
+		await useCase.execute({
+			raterId: 'client-1',
+			orderId: 'order-1',
+			score: 5,
+			now: NOW,
+		});
+
+		await expect(
+			useCase.execute({
+				raterId: 'client-1',
+				orderId: 'order-1',
+				score: 1,
+				now: NOW,
+			}),
+		).rejects.toThrow(RatingAlreadySubmittedError);
+	});
+});

--- a/apps/api/src/modules/ratings/application/use-cases/submit-rating/submit-rating.use-case.ts
+++ b/apps/api/src/modules/ratings/application/use-cases/submit-rating/submit-rating.use-case.ts
@@ -1,0 +1,86 @@
+import { OrderStatus } from '@modules/orders/domain/order-status';
+import {
+	RATING_ORDER_LOOKUP_KEY,
+	type RatableOrder,
+	type RatingOrderLookupPort,
+} from '@modules/ratings/application/ports/rating-order-lookup.port';
+import {
+	RATING_REPOSITORY_KEY,
+	type RatingRepositoryPort,
+} from '@modules/ratings/application/ports/rating-repository.port';
+import {
+	mapRatingResponse,
+	type RatingResponse,
+} from '@modules/ratings/application/use-cases/rating-response';
+import { Rating } from '@modules/ratings/domain/rating.entity';
+import {
+	OrderNotRatableError,
+	RatingAlreadySubmittedError,
+	RatingNotAllowedError,
+	RatingOrderNotFoundError,
+	RatingWindowClosedError,
+} from '@modules/ratings/domain/rating.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+// ponytail: window as a const; lift to env/config if product wants it tunable
+const RATING_WINDOW_DAYS = 14;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+type SubmitRatingInput = {
+	raterId: string;
+	orderId: string;
+	score: number;
+	comment?: string;
+	now?: Date;
+};
+
+@Injectable()
+export class SubmitRatingUseCase {
+	constructor(
+		@Inject(RATING_REPOSITORY_KEY)
+		private readonly ratings: RatingRepositoryPort,
+		@Inject(RATING_ORDER_LOOKUP_KEY)
+		private readonly orders: RatingOrderLookupPort,
+	) {}
+
+	async execute(input: SubmitRatingInput): Promise<RatingResponse> {
+		const now = input.now ?? new Date();
+		const order = await this.orders.findById(input.orderId);
+		if (!order) throw new RatingOrderNotFoundError();
+		if (order.status !== OrderStatus.COMPLETED)
+			throw new OrderNotRatableError();
+
+		const toUserId = this.resolveCounterparty(order, input.raterId);
+		this.assertWithinWindow(order.completedAt, now);
+
+		const existing = await this.ratings.findByOrderAndRater(
+			input.orderId,
+			input.raterId,
+		);
+		if (existing) throw new RatingAlreadySubmittedError();
+
+		const rating = Rating.create({
+			orderId: input.orderId,
+			fromUserId: input.raterId,
+			toUserId,
+			score: input.score,
+			comment: input.comment ?? null,
+			now,
+		});
+
+		return mapRatingResponse(await this.ratings.save(rating));
+	}
+
+	private resolveCounterparty(order: RatableOrder, raterId: string): string {
+		if (raterId === order.clientId && order.boosterId) return order.boosterId;
+		if (raterId === order.boosterId && order.clientId) return order.clientId;
+		throw new RatingNotAllowedError();
+	}
+
+	private assertWithinWindow(completedAt: Date | null, now: Date): void {
+		if (!completedAt) throw new RatingWindowClosedError();
+		const elapsed = now.getTime() - completedAt.getTime();
+		if (elapsed > RATING_WINDOW_DAYS * DAY_IN_MS)
+			throw new RatingWindowClosedError();
+	}
+}

--- a/apps/api/src/modules/ratings/domain/rating.entity.spec.ts
+++ b/apps/api/src/modules/ratings/domain/rating.entity.spec.ts
@@ -1,0 +1,42 @@
+import { Rating } from '@modules/ratings/domain/rating.entity';
+import {
+	InvalidRatingScoreError,
+	RatingNotAllowedError,
+} from '@modules/ratings/domain/rating.errors';
+
+const baseInput = {
+	orderId: 'order-1',
+	fromUserId: 'client-1',
+	toUserId: 'booster-1',
+	score: 5,
+	now: new Date('2026-06-24T00:00:00.000Z'),
+};
+
+describe('Rating.create', () => {
+	it('creates a valid rating', () => {
+		const rating = Rating.create(baseInput);
+
+		expect(rating.score).toBe(5);
+		expect(rating.fromUserId).toBe('client-1');
+		expect(rating.toUserId).toBe('booster-1');
+		expect(rating.comment).toBeNull();
+	});
+
+	it.each([0, 6, -1])('rejects out-of-range score %p', (score) => {
+		expect(() => Rating.create({ ...baseInput, score })).toThrow(
+			InvalidRatingScoreError,
+		);
+	});
+
+	it('rejects a non-integer score', () => {
+		expect(() => Rating.create({ ...baseInput, score: 4.5 })).toThrow(
+			InvalidRatingScoreError,
+		);
+	});
+
+	it('rejects rating yourself', () => {
+		expect(() =>
+			Rating.create({ ...baseInput, toUserId: baseInput.fromUserId }),
+		).toThrow(RatingNotAllowedError);
+	});
+});

--- a/apps/api/src/modules/ratings/domain/rating.entity.ts
+++ b/apps/api/src/modules/ratings/domain/rating.entity.ts
@@ -1,0 +1,44 @@
+import {
+	InvalidRatingScoreError,
+	RatingNotAllowedError,
+} from './rating.errors';
+
+const MIN_SCORE = 1;
+const MAX_SCORE = 5;
+
+export class Rating {
+	private constructor(
+		public readonly id: string,
+		public readonly orderId: string,
+		public readonly fromUserId: string,
+		public readonly toUserId: string,
+		public readonly score: number,
+		public readonly comment: string | null,
+		public readonly createdAt: Date,
+	) {}
+
+	static create(input: {
+		id?: string;
+		orderId: string;
+		fromUserId: string;
+		toUserId: string;
+		score: number;
+		comment?: string | null;
+		now: Date;
+	}): Rating {
+		if (!Number.isInteger(input.score)) throw new InvalidRatingScoreError();
+		if (input.score < MIN_SCORE || input.score > MAX_SCORE)
+			throw new InvalidRatingScoreError();
+		if (input.fromUserId === input.toUserId) throw new RatingNotAllowedError();
+
+		return new Rating(
+			input.id ?? '',
+			input.orderId,
+			input.fromUserId,
+			input.toUserId,
+			input.score,
+			input.comment ?? null,
+			input.now,
+		);
+	}
+}

--- a/apps/api/src/modules/ratings/domain/rating.errors.ts
+++ b/apps/api/src/modules/ratings/domain/rating.errors.ts
@@ -1,0 +1,35 @@
+export class RatingOrderNotFoundError extends Error {
+	constructor() {
+		super('Order to rate was not found.');
+	}
+}
+
+export class RatingNotAllowedError extends Error {
+	constructor() {
+		super('You are not allowed to rate this order.');
+	}
+}
+
+export class OrderNotRatableError extends Error {
+	constructor() {
+		super('Order can only be rated once completed.');
+	}
+}
+
+export class RatingWindowClosedError extends Error {
+	constructor() {
+		super('The rating window for this order has closed.');
+	}
+}
+
+export class RatingAlreadySubmittedError extends Error {
+	constructor() {
+		super('You have already rated this order.');
+	}
+}
+
+export class InvalidRatingScoreError extends Error {
+	constructor() {
+		super('Rating score must be an integer between 1 and 5.');
+	}
+}

--- a/apps/api/src/modules/ratings/infrastructure/repositories/prisma-rating.repository.ts
+++ b/apps/api/src/modules/ratings/infrastructure/repositories/prisma-rating.repository.ts
@@ -1,0 +1,119 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import { OrderStatus } from '@modules/orders/domain/order-status';
+import {
+	type RatableOrder,
+	type RatingOrderLookupPort,
+} from '@modules/ratings/application/ports/rating-order-lookup.port';
+import {
+	type RatingRecord,
+	type RatingRepositoryPort,
+} from '@modules/ratings/application/ports/rating-repository.port';
+import type { Rating } from '@modules/ratings/domain/rating.entity';
+import { RatingAlreadySubmittedError } from '@modules/ratings/domain/rating.errors';
+import { Injectable } from '@nestjs/common';
+import { ensurePersistedEnum } from '@packages/shared/utils/enum.utils';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class PrismaRatingRepository
+	implements RatingRepositoryPort, RatingOrderLookupPort
+{
+	constructor(private readonly prisma: PrismaService) {}
+
+	async findById(orderId: string): Promise<RatableOrder | null> {
+		const order = await this.prisma.order.findUnique({
+			where: { id: orderId },
+			select: {
+				id: true,
+				clientId: true,
+				boosterId: true,
+				status: true,
+				completedAt: true,
+			},
+		});
+		if (!order) return null;
+
+		return {
+			id: order.id,
+			clientId: order.clientId,
+			boosterId: order.boosterId,
+			status: ensurePersistedEnum(OrderStatus, order.status, 'order status'),
+			completedAt: order.completedAt,
+		};
+	}
+
+	async findByOrderAndRater(
+		orderId: string,
+		fromUserId: string,
+	): Promise<RatingRecord | null> {
+		const rating = await this.prisma.rating.findUnique({
+			where: { orderId_fromUserId: { orderId, fromUserId } },
+		});
+
+		return rating ? this.toRecord(rating) : null;
+	}
+
+	async listForOrder(orderId: string): Promise<RatingRecord[]> {
+		const ratings = await this.prisma.rating.findMany({
+			where: { orderId },
+			orderBy: { createdAt: 'asc' },
+		});
+
+		return ratings.map((rating) => this.toRecord(rating));
+	}
+
+	async save(rating: Rating): Promise<RatingRecord> {
+		try {
+			return await this.prisma.$transaction(async (tx) => {
+				const created = await tx.rating.create({
+					data: {
+						orderId: rating.orderId,
+						fromUserId: rating.fromUserId,
+						toUserId: rating.toUserId,
+						score: rating.score,
+						comment: rating.comment,
+						createdAt: rating.createdAt,
+					},
+				});
+
+				const aggregate = await tx.rating.aggregate({
+					where: { toUserId: rating.toUserId },
+					_avg: { score: true },
+				});
+				await tx.profile.updateMany({
+					where: { userId: rating.toUserId },
+					data: { reputation: aggregate._avg.score ?? 0 },
+				});
+
+				return this.toRecord(created);
+			});
+		} catch (error) {
+			if (
+				error instanceof Prisma.PrismaClientKnownRequestError &&
+				error.code === 'P2002'
+			)
+				throw new RatingAlreadySubmittedError();
+			throw error;
+		}
+	}
+
+	private toRecord(rating: {
+		id: string;
+		orderId: string;
+		fromUserId: string;
+		toUserId: string;
+		score: number;
+		comment: string | null;
+		createdAt: Date;
+	}): RatingRecord {
+		return {
+			id: rating.id,
+			orderId: rating.orderId,
+			fromUserId: rating.fromUserId,
+			toUserId: rating.toUserId,
+			score: rating.score,
+			comment: rating.comment,
+			createdAt: rating.createdAt,
+		};
+	}
+}

--- a/apps/api/src/modules/ratings/presentation/ratings.controller.ts
+++ b/apps/api/src/modules/ratings/presentation/ratings.controller.ts
@@ -1,0 +1,52 @@
+import { ZodValidationPipe } from '@app/common/http/zod-validation.pipe';
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import { CurrentUser } from '@modules/auth/presentation/decorators/current-user.decorator';
+import { Roles } from '@modules/auth/presentation/decorators/roles.decorator';
+import { JwtAuthGuard } from '@modules/auth/presentation/guards/jwt-auth.guard';
+import { RolesGuard } from '@modules/auth/presentation/guards/roles.guard';
+import { GetOrderRatingsUseCase } from '@modules/ratings/application/use-cases/get-order-ratings/get-order-ratings.use-case';
+import { SubmitRatingUseCase } from '@modules/ratings/application/use-cases/submit-rating/submit-rating.use-case';
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+import {
+	type OrderIdParamSchemaInput,
+	orderIdParamSchema,
+	type SubmitRatingSchemaInput,
+	submitRatingSchema,
+} from './ratings.request-schemas';
+
+@Controller('ratings')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.CLIENT, Role.BOOSTER)
+export class RatingsController {
+	constructor(
+		private readonly submitRating: SubmitRatingUseCase,
+		private readonly getOrderRatings: GetOrderRatingsUseCase,
+	) {}
+
+	@Post()
+	async submit(
+		@Body(new ZodValidationPipe(submitRatingSchema))
+		body: SubmitRatingSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.submitRating.execute({
+			raterId: currentUser.id,
+			orderId: body.orderId,
+			score: body.score,
+			comment: body.comment,
+		});
+	}
+
+	@Get('orders/:orderId')
+	async listForOrder(
+		@Param('orderId', new ZodValidationPipe(orderIdParamSchema))
+		orderId: OrderIdParamSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.getOrderRatings.execute({
+			orderId,
+			requesterId: currentUser.id,
+		});
+	}
+}

--- a/apps/api/src/modules/ratings/presentation/ratings.request-schemas.ts
+++ b/apps/api/src/modules/ratings/presentation/ratings.request-schemas.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const orderIdParamSchema = z.string().trim().min(1);
+
+export type OrderIdParamSchemaInput = z.infer<typeof orderIdParamSchema>;
+
+export const submitRatingSchema = z.object({
+	orderId: z.string().trim().min(1),
+	score: z.coerce.number().int().min(1).max(5),
+	comment: z.string().trim().min(1).max(2000).optional(),
+});
+
+export type SubmitRatingSchemaInput = z.infer<typeof submitRatingSchema>;

--- a/apps/api/src/modules/ratings/ratings.module.ts
+++ b/apps/api/src/modules/ratings/ratings.module.ts
@@ -1,0 +1,28 @@
+import { PrismaModule } from '@app/common/prisma/prisma.module';
+import { AuthModule } from '@modules/auth/auth.module';
+import { RATING_ORDER_LOOKUP_KEY } from '@modules/ratings/application/ports/rating-order-lookup.port';
+import { RATING_REPOSITORY_KEY } from '@modules/ratings/application/ports/rating-repository.port';
+import { GetOrderRatingsUseCase } from '@modules/ratings/application/use-cases/get-order-ratings/get-order-ratings.use-case';
+import { SubmitRatingUseCase } from '@modules/ratings/application/use-cases/submit-rating/submit-rating.use-case';
+import { PrismaRatingRepository } from '@modules/ratings/infrastructure/repositories/prisma-rating.repository';
+import { RatingsController } from '@modules/ratings/presentation/ratings.controller';
+import { Module } from '@nestjs/common';
+
+@Module({
+	imports: [PrismaModule, AuthModule],
+	controllers: [RatingsController],
+	providers: [
+		PrismaRatingRepository,
+		{
+			provide: RATING_REPOSITORY_KEY,
+			useExisting: PrismaRatingRepository,
+		},
+		{
+			provide: RATING_ORDER_LOOKUP_KEY,
+			useExisting: PrismaRatingRepository,
+		},
+		SubmitRatingUseCase,
+		GetOrderRatingsUseCase,
+	],
+})
+export class RatingsModule {}

--- a/apps/api/test/integration-db/ratings/ratings.db.integration.spec.ts
+++ b/apps/api/test/integration-db/ratings/ratings.db.integration.spec.ts
@@ -78,6 +78,9 @@ describe('Ratings module integration (db)', () => {
 
 	afterEach(async () => {
 		await prisma.rating.deleteMany();
+		await prisma.order.deleteMany();
+		await prisma.profile.deleteMany();
+		await prisma.user.deleteMany();
 		await moduleRef.close();
 	});
 

--- a/apps/api/test/integration-db/ratings/ratings.db.integration.spec.ts
+++ b/apps/api/test/integration-db/ratings/ratings.db.integration.spec.ts
@@ -1,0 +1,163 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import {
+	OrderNotRatableError,
+	RatingAlreadySubmittedError,
+} from '@modules/ratings/domain/rating.errors';
+import { RatingsController } from '@modules/ratings/presentation/ratings.controller';
+import { RatingsModule } from '@modules/ratings/ratings.module';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Role } from '@packages/auth/roles/role';
+
+describe('Ratings module integration (db)', () => {
+	let moduleRef: TestingModule;
+	let controller: RatingsController;
+	let prisma: PrismaService;
+	let clientUser: AuthenticatedUser;
+	let boosterUser: AuthenticatedUser;
+
+	const createUser = async (
+		username: string,
+		role: 'CLIENT' | 'BOOSTER',
+	): Promise<string> => {
+		const user = await prisma.user.create({
+			data: {
+				username,
+				email: `${username}@example.com`,
+				password: 'secret',
+				role,
+				profile: { create: {} },
+			},
+		});
+		return user.id;
+	};
+
+	const createCompletedOrder = async (completedAt = new Date()) =>
+		prisma.order.create({
+			data: {
+				clientId: clientUser.id,
+				boosterId: boosterUser.id,
+				status: 'completed',
+				completedAt,
+			},
+		});
+
+	beforeEach(async () => {
+		moduleRef = await Test.createTestingModule({
+			imports: [RatingsModule],
+		}).compile();
+
+		controller = moduleRef.get(RatingsController);
+		prisma = moduleRef.get(PrismaService);
+
+		await prisma.rating.deleteMany();
+		await prisma.ticketMessage.deleteMany();
+		await prisma.ticket.deleteMany();
+		await prisma.chatMessage.deleteMany();
+		await prisma.chat.deleteMany();
+		await prisma.walletTransaction.deleteMany();
+		await prisma.payment.deleteMany();
+		await prisma.orderCredentials.deleteMany();
+		await prisma.orderQuote.deleteMany();
+		await prisma.order.deleteMany();
+		await prisma.profile.deleteMany();
+		await prisma.authSession.deleteMany();
+		await prisma.wallet.deleteMany();
+		await prisma.user.deleteMany();
+
+		clientUser = {
+			id: await createUser('rating-client', 'CLIENT'),
+			role: Role.CLIENT,
+		};
+		boosterUser = {
+			id: await createUser('rating-booster', 'BOOSTER'),
+			role: Role.BOOSTER,
+		};
+	});
+
+	afterEach(async () => {
+		await prisma.rating.deleteMany();
+		await moduleRef.close();
+	});
+
+	it('persists both rating directions and recomputes reputation in the same transaction', async () => {
+		const order = await createCompletedOrder();
+
+		await controller.submit({ orderId: order.id, score: 4 }, clientUser);
+		await controller.submit({ orderId: order.id, score: 5 }, boosterUser);
+
+		const ratings = await prisma.rating.findMany({
+			where: { orderId: order.id },
+			orderBy: { createdAt: 'asc' },
+		});
+		expect(ratings).toHaveLength(2);
+		expect(ratings.map((r) => r.toUserId).sort()).toEqual(
+			[boosterUser.id, clientUser.id].sort(),
+		);
+
+		const boosterProfile = await prisma.profile.findUnique({
+			where: { userId: boosterUser.id },
+		});
+		expect(boosterProfile?.reputation).toBe(4);
+	});
+
+	it('averages reputation across multiple received ratings', async () => {
+		const orderOne = await createCompletedOrder();
+		const orderTwo = await createCompletedOrder();
+		const secondClient = await createUser('rating-client-2', 'CLIENT');
+		await prisma.order.update({
+			where: { id: orderTwo.id },
+			data: { clientId: secondClient },
+		});
+
+		await controller.submit({ orderId: orderOne.id, score: 5 }, clientUser);
+		await controller.submit(
+			{ orderId: orderTwo.id, score: 3 },
+			{ id: secondClient, role: Role.CLIENT },
+		);
+
+		const boosterProfile = await prisma.profile.findUnique({
+			where: { userId: boosterUser.id },
+		});
+		expect(boosterProfile?.reputation).toBe(4);
+	});
+
+	it('blocks a second rating in the same direction', async () => {
+		const order = await createCompletedOrder();
+		await controller.submit({ orderId: order.id, score: 5 }, clientUser);
+
+		await expect(
+			controller.submit({ orderId: order.id, score: 1 }, clientUser),
+		).rejects.toThrow(RatingAlreadySubmittedError);
+
+		const ratings = await prisma.rating.findMany({
+			where: { orderId: order.id },
+		});
+		expect(ratings).toHaveLength(1);
+		expect(ratings[0]?.score).toBe(5);
+	});
+
+	it('rejects rating an order that is not completed', async () => {
+		const order = await prisma.order.create({
+			data: {
+				clientId: clientUser.id,
+				boosterId: boosterUser.id,
+				status: 'in_progress',
+			},
+		});
+
+		await expect(
+			controller.submit({ orderId: order.id, score: 5 }, clientUser),
+		).rejects.toThrow(OrderNotRatableError);
+	});
+
+	it('returns both ratings for a participant', async () => {
+		const order = await createCompletedOrder();
+		await controller.submit({ orderId: order.id, score: 4 }, clientUser);
+		await controller.submit({ orderId: order.id, score: 5 }, boosterUser);
+
+		const ratings = await controller.listForOrder(order.id, clientUser);
+		expect(ratings).toHaveLength(2);
+	});
+});

--- a/apps/api/test/ratings.e2e-db.spec.ts
+++ b/apps/api/test/ratings.e2e-db.spec.ts
@@ -1,0 +1,139 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import type { ApiHttpApp } from '../src/common/http/http-app.factory';
+import { createTestHttpApp, requestHttp } from './create-test-http-app';
+import { signTestAccessToken as signToken } from './support/auth-token';
+
+describe('Ratings (e2e db)', () => {
+	let app: ApiHttpApp;
+	let prisma: PrismaService;
+	let clientId: string;
+	let boosterId: string;
+
+	const createUser = async (role: 'CLIENT' | 'BOOSTER'): Promise<string> => {
+		const suffix = `${role}-${Date.now()}-${Math.random()}`;
+		const user = await prisma.user.create({
+			data: {
+				username: `rating-${suffix}`,
+				email: `rating-${suffix}@example.com`,
+				password: 'secret',
+				role,
+				profile: { create: {} },
+			},
+		});
+		return user.id;
+	};
+
+	const createCompletedOrder = async (): Promise<string> => {
+		const order = await prisma.order.create({
+			data: {
+				clientId,
+				boosterId,
+				status: 'completed',
+				completedAt: new Date(),
+			},
+		});
+		return order.id;
+	};
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			imports: [AppModule],
+		}).compile();
+
+		app = await createTestHttpApp(moduleRef);
+		prisma = moduleRef.get(PrismaService);
+
+		await prisma.rating.deleteMany();
+		await prisma.payment.deleteMany();
+		await prisma.order.deleteMany();
+		await prisma.profile.deleteMany();
+		await prisma.authSession.deleteMany();
+		await prisma.user.deleteMany();
+
+		clientId = await createUser('CLIENT');
+		boosterId = await createUser('BOOSTER');
+	});
+
+	afterEach(async () => {
+		await prisma.rating.deleteMany();
+		await app.close();
+	});
+
+	it('records both rating directions and updates the booster reputation', async () => {
+		const orderId = await createCompletedOrder();
+		const clientToken = signToken({ sub: clientId, role: 'CLIENT' });
+		const boosterToken = signToken({ sub: boosterId, role: 'BOOSTER' });
+
+		await requestHttp(app)
+			.post('/ratings')
+			.set('Authorization', `Bearer ${clientToken}`)
+			.send({ orderId, score: 4 })
+			.expect(201)
+			.expect<{ fromUserId: string; toUserId: string; score: number }>(
+				({ body }) => {
+					expect(body.fromUserId).toBe(clientId);
+					expect(body.toUserId).toBe(boosterId);
+					expect(body.score).toBe(4);
+				},
+			)
+			.execute();
+
+		await requestHttp(app)
+			.post('/ratings')
+			.set('Authorization', `Bearer ${boosterToken}`)
+			.send({ orderId, score: 5 })
+			.expect(201)
+			.expect<{ toUserId: string }>(({ body }) => {
+				expect(body.toUserId).toBe(clientId);
+			})
+			.execute();
+
+		await requestHttp(app)
+			.get(`/ratings/orders/${orderId}`)
+			.set('Authorization', `Bearer ${clientToken}`)
+			.expect(200)
+			.expect<Array<{ fromUserId: string }>>(({ body }) => {
+				expect(body).toHaveLength(2);
+			})
+			.execute();
+
+		const boosterProfile = await prisma.profile.findUnique({
+			where: { userId: boosterId },
+		});
+		expect(boosterProfile?.reputation).toBe(4);
+	});
+
+	it('rejects a duplicate rating in the same direction with 409', async () => {
+		const orderId = await createCompletedOrder();
+		const clientToken = signToken({ sub: clientId, role: 'CLIENT' });
+
+		await requestHttp(app)
+			.post('/ratings')
+			.set('Authorization', `Bearer ${clientToken}`)
+			.send({ orderId, score: 5 })
+			.expect(201)
+			.execute();
+
+		await requestHttp(app)
+			.post('/ratings')
+			.set('Authorization', `Bearer ${clientToken}`)
+			.send({ orderId, score: 1 })
+			.expect(409)
+			.execute();
+	});
+
+	it('rejects a stranger with 403', async () => {
+		const orderId = await createCompletedOrder();
+		const strangerId = await createUser('CLIENT');
+		const strangerToken = signToken({ sub: strangerId, role: 'CLIENT' });
+
+		await requestHttp(app)
+			.post('/ratings')
+			.set('Authorization', `Bearer ${strangerToken}`)
+			.send({ orderId, score: 5 })
+			.expect(403)
+			.execute();
+	});
+});

--- a/apps/api/test/ratings.e2e-db.spec.ts
+++ b/apps/api/test/ratings.e2e-db.spec.ts
@@ -58,6 +58,9 @@ describe('Ratings (e2e db)', () => {
 
 	afterEach(async () => {
 		await prisma.rating.deleteMany();
+		await prisma.order.deleteMany();
+		await prisma.profile.deleteMany();
+		await prisma.user.deleteMany();
 		await app.close();
 	});
 

--- a/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.spec.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.spec.tsx
@@ -13,6 +13,11 @@ jest.mock('next/navigation', () => ({
 	}),
 }));
 
+jest.mock('@/shared/ratings/rating-actions', () => ({
+	getOrderRatings: jest.fn().mockResolvedValue([]),
+	submitRatingAction: jest.fn(),
+}));
+
 jest.mock('../../actions/booster-actions', () => ({
 	completeBoosterOrderAction: jest.fn(),
 	getBoosterOrder: jest.fn().mockResolvedValue({
@@ -57,6 +62,7 @@ jest.mock('../../actions/booster-actions', () => ({
 jest.mock('lucide-react', () => ({
 	CheckCircle2: () => <svg data-testid="check-icon" />,
 	Send: () => <svg data-testid="send-icon" />,
+	Star: () => <svg data-testid="star-icon" />,
 }));
 
 describe('BoosterOrderDetailsPage', () => {

--- a/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.tsx
@@ -5,6 +5,9 @@ import { DashboardSubmitButton } from '@/shared/dashboard/dashboard-submit-butto
 import { formatCurrency } from '@/shared/format/currency';
 import { formatDate } from '@/shared/format/date';
 import { formatOrderRoute } from '@/shared/format/orders';
+import { getOrderRatings } from '@/shared/ratings/rating-actions';
+import { RatingCard } from '@/shared/ratings/rating-card';
+import type { RatingOutput } from '@/shared/ratings/rating-contracts';
 import { OrderStatusBadge } from '@/shared/ui/components/status-badge';
 import {
 	completeBoosterOrderAction,
@@ -47,6 +50,11 @@ export const BoosterOrderDetailsPage = async ({
 	const order = toSingleOrderWork(orderOutput);
 	const chatMessages: ChatMessage[] = chatResult.items;
 	const isReadOnly = isReadOnlyOrder(order.status);
+
+	let ratings: RatingOutput[] = [];
+	if (order.status === 'completed') {
+		ratings = await getOrderRatings(order.id);
+	}
 
 	return (
 		<div className="space-y-8">
@@ -110,6 +118,13 @@ export const BoosterOrderDetailsPage = async ({
 							{formatCurrency(order.boosterAmount)}
 						</p>
 					</div>
+					{order.status === 'completed' ? (
+						<RatingCard
+							orderId={order.id}
+							currentUserId={currentUserId}
+							initialRatings={ratings}
+						/>
+					) : null}
 				</section>
 			</div>
 		</div>

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
@@ -2,6 +2,9 @@ import { notFound, redirect } from 'next/navigation';
 import { ApiRequestError } from '@/shared/api-client-management/http';
 import { getAuthSession } from '@/shared/auth/session';
 import type { ChatMessage } from '@/shared/chat/chat.types';
+import { getOrderRatings } from '@/shared/ratings/rating-actions';
+import { RatingCard } from '@/shared/ratings/rating-card';
+import type { RatingOutput } from '@/shared/ratings/rating-contracts';
 import { getOrder, getOrderChatMessages } from '../../actions/order-actions';
 import type { ClientOrder } from '../../model/orders';
 import { OrderActivityCard } from './order-activity-card';
@@ -37,6 +40,11 @@ export const OrderDetailsPage = async ({ orderId }: OrderDetailsPageProps) => {
 	const session = await getAuthSession();
 	if (!session?.userId) redirect('/login');
 
+	let ratings: RatingOutput[] = [];
+	if (order.status === 'completed') {
+		ratings = await getOrderRatings(order.id);
+	}
+
 	return (
 		<div className="space-y-8">
 			<OrderDetailsHeader order={order} />
@@ -56,6 +64,13 @@ export const OrderDetailsPage = async ({ orderId }: OrderDetailsPageProps) => {
 						initialMessages={chatMessages}
 					/>
 					<OrderSupportCard />
+					{order.status === 'completed' ? (
+						<RatingCard
+							orderId={order.id}
+							currentUserId={session.userId}
+							initialRatings={ratings}
+						/>
+					) : null}
 				</div>
 			</div>
 		</div>

--- a/apps/web/src/shared/ratings/rating-actions.ts
+++ b/apps/web/src/shared/ratings/rating-actions.ts
@@ -1,0 +1,63 @@
+'use server';
+
+import { api } from '@/shared/api-client-management/api-client';
+import { ApiRequestError } from '@/shared/api-client-management/http';
+import { getAuthSession } from '@/shared/auth/session';
+import { assertSameOriginRequest } from '@/shared/security/origin';
+import {
+	type RatingOutput,
+	ratingSchema,
+	ratingsSchema,
+	submitRatingInputSchema,
+} from './rating-contracts';
+
+export type SubmitRatingActionState = {
+	error?: string;
+	rating?: RatingOutput;
+};
+
+export const getOrderRatings = async (
+	orderId: string,
+): Promise<RatingOutput[]> => {
+	const response = await api.request<unknown>(
+		`/ratings/orders/${encodeURIComponent(orderId)}`,
+		{ auth: true },
+	);
+
+	return ratingsSchema.parse(response);
+};
+
+export const submitRatingAction = async (
+	orderId: string,
+	_previousState: SubmitRatingActionState,
+	formData: FormData,
+): Promise<SubmitRatingActionState> => {
+	const parsed = submitRatingInputSchema.safeParse({
+		orderId,
+		score: formData.get('score'),
+		comment: formData.get('comment') || undefined,
+	});
+	if (!parsed.success) {
+		return { error: 'Selecione uma nota de 1 a 5.' };
+	}
+
+	try {
+		const session = await getAuthSession();
+		if (!session) return { error: 'Sessão expirada. Entre novamente.' };
+
+		await assertSameOriginRequest();
+
+		const response = await api.request<unknown>('/ratings', {
+			auth: true,
+			method: 'POST',
+			body: JSON.stringify(parsed.data),
+		});
+
+		return { rating: ratingSchema.parse(response) };
+	} catch (error) {
+		if (error instanceof ApiRequestError) {
+			return { error: error.message };
+		}
+		return { error: 'Não foi possível enviar a avaliação.' };
+	}
+};

--- a/apps/web/src/shared/ratings/rating-card.spec.tsx
+++ b/apps/web/src/shared/ratings/rating-card.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import { useActionState } from 'react';
+import { RatingCard } from './rating-card';
+import type { RatingOutput } from './rating-contracts';
+
+jest.mock('react', () => ({
+	...jest.requireActual('react'),
+	useActionState: jest.fn(),
+}));
+
+jest.mock('./rating-actions', () => ({
+	submitRatingAction: jest.fn(),
+}));
+
+const useActionStateMock = useActionState as jest.Mock;
+
+const makeRating = (overrides: Partial<RatingOutput>): RatingOutput => ({
+	id: 'rating-1',
+	orderId: 'order-1',
+	fromUserId: 'client-1',
+	toUserId: 'booster-1',
+	score: 4,
+	comment: null,
+	createdAt: '2026-06-24T00:00:00.000Z',
+	...overrides,
+});
+
+describe('RatingCard', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('shows the submit form when the user has not rated yet', () => {
+		useActionStateMock.mockReturnValue([{}, jest.fn(), false]);
+
+		render(
+			<RatingCard
+				orderId="order-1"
+				currentUserId="client-1"
+				initialRatings={[]}
+			/>,
+		);
+
+		expect(
+			screen.getByRole('button', { name: /enviar avaliação/i }),
+		).toBeInTheDocument();
+	});
+
+	it('shows the submitted state when the user already rated', () => {
+		useActionStateMock.mockReturnValue([{}, jest.fn(), false]);
+
+		render(
+			<RatingCard
+				orderId="order-1"
+				currentUserId="client-1"
+				initialRatings={[makeRating({ score: 4, comment: 'Ótimo serviço' })]}
+			/>,
+		);
+
+		expect(screen.getByText(/você avaliou este pedido/i)).toBeInTheDocument();
+		expect(screen.getByText('Ótimo serviço')).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: /enviar avaliação/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it('switches to submitted state after a successful action', () => {
+		useActionStateMock.mockReturnValue([
+			{ rating: makeRating({ score: 5 }) },
+			jest.fn(),
+			false,
+		]);
+
+		render(
+			<RatingCard
+				orderId="order-1"
+				currentUserId="client-1"
+				initialRatings={[]}
+			/>,
+		);
+
+		expect(screen.getByText(/você avaliou este pedido/i)).toBeInTheDocument();
+	});
+
+	it('renders an inline error from the action state', () => {
+		useActionStateMock.mockReturnValue([
+			{ error: 'Você já avaliou este pedido.' },
+			jest.fn(),
+			false,
+		]);
+
+		render(
+			<RatingCard
+				orderId="order-1"
+				currentUserId="client-1"
+				initialRatings={[]}
+			/>,
+		);
+
+		expect(
+			screen.getByText('Você já avaliou este pedido.'),
+		).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/shared/ratings/rating-card.tsx
+++ b/apps/web/src/shared/ratings/rating-card.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Star } from 'lucide-react';
+import { useActionState, useState } from 'react';
+import { getButtonClassName } from '@/shared/ui/components/button';
+import {
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+} from '@/shared/ui/components/card';
+import {
+	type SubmitRatingActionState,
+	submitRatingAction,
+} from './rating-actions';
+import type { RatingOutput } from './rating-contracts';
+
+type RatingCardProps = {
+	orderId: string;
+	currentUserId: string;
+	initialRatings: RatingOutput[];
+};
+
+const Stars = ({ score }: { score: number }) => (
+	<div className="flex gap-1" role="img" aria-label={`${score} de 5`}>
+		{[1, 2, 3, 4, 5].map((value) => (
+			<Star
+				key={value}
+				className={`h-4 w-4 ${value <= score ? 'fill-hextech-gold text-hextech-gold' : 'text-white/20'}`}
+			/>
+		))}
+	</div>
+);
+
+export const RatingCard = ({
+	orderId,
+	currentUserId,
+	initialRatings,
+}: RatingCardProps) => {
+	const [state, formAction, isPending] = useActionState<
+		SubmitRatingActionState,
+		FormData
+	>(submitRatingAction.bind(null, orderId), {});
+	const [score, setScore] = useState(0);
+
+	const submitted =
+		state.rating ??
+		initialRatings.find((rating) => rating.fromUserId === currentUserId);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2">
+					<Star className="h-4 w-4 text-hextech-gold" />
+					Avaliação
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				{submitted ? (
+					<div className="space-y-2">
+						<p className="text-[10px] uppercase tracking-widest text-white/40">
+							Você avaliou este pedido
+						</p>
+						<Stars score={submitted.score} />
+						{submitted.comment ? (
+							<p className="text-sm leading-relaxed text-white/70">
+								{submitted.comment}
+							</p>
+						) : null}
+					</div>
+				) : (
+					<form action={formAction} className="space-y-4">
+						<input type="hidden" name="score" value={score} />
+						<div className="flex gap-1">
+							{[1, 2, 3, 4, 5].map((value) => (
+								<button
+									key={value}
+									type="button"
+									onClick={() => setScore(value)}
+									aria-label={`Nota ${value}`}
+									className="p-1"
+								>
+									<Star
+										className={`h-6 w-6 transition-colors ${value <= score ? 'fill-hextech-gold text-hextech-gold' : 'text-white/20 hover:text-white/40'}`}
+									/>
+								</button>
+							))}
+						</div>
+						<textarea
+							name="comment"
+							rows={3}
+							maxLength={2000}
+							placeholder="Comentário (opcional)"
+							className="w-full rounded-sm border border-white/10 bg-white/[0.03] p-3 text-sm text-white placeholder:text-white/30 focus:border-hextech-cyan focus:outline-none"
+						/>
+						<button
+							type="submit"
+							disabled={isPending || score === 0}
+							className={getButtonClassName({
+								size: 'sm',
+								className:
+									'w-full font-black uppercase tracking-widest disabled:opacity-40',
+							})}
+						>
+							{isPending ? 'Enviando' : 'Enviar avaliação'}
+						</button>
+						{state.error ? (
+							<p className="text-[10px] font-bold leading-4 text-danger">
+								{state.error}
+							</p>
+						) : null}
+					</form>
+				)}
+			</CardContent>
+		</Card>
+	);
+};

--- a/apps/web/src/shared/ratings/rating-contracts.ts
+++ b/apps/web/src/shared/ratings/rating-contracts.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const ratingSchema = z.object({
+	id: z.string(),
+	orderId: z.string(),
+	fromUserId: z.string(),
+	toUserId: z.string(),
+	score: z.number().int().min(1).max(5),
+	comment: z.string().nullable(),
+	createdAt: z.string(),
+});
+
+export type RatingOutput = z.infer<typeof ratingSchema>;
+
+export const ratingsSchema = z.array(ratingSchema);
+
+export const submitRatingInputSchema = z.object({
+	orderId: z.string().min(1),
+	score: z.coerce.number().int().min(1).max(5),
+	comment: z.string().trim().min(1).max(2000).optional(),
+});
+
+export type SubmitRatingInput = z.infer<typeof submitRatingInputSchema>;

--- a/packages/database/prisma/migrations/20260624104707_add_dual_ratings_and_order_completed_at/migration.sql
+++ b/packages/database/prisma/migrations/20260624104707_add_dual_ratings_and_order_completed_at/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "ratings_orderId_key";
+
+-- AlterTable
+ALTER TABLE "orders" ADD COLUMN     "completedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "ratings_toUserId_idx" ON "ratings"("toUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ratings_orderId_fromUserId_key" ON "ratings"("orderId", "fromUserId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -152,11 +152,12 @@ model Order {
   payments         Payment[]
   chat             Chat?
   tickets          Ticket[]
-  rating           Rating?
+  ratings          Rating[]
   walletTransactions WalletTransaction[]
   boosterRejections OrderBoosterRejection[]
   adminGovernanceActions AdminGovernanceAction[]
 
+  completedAt      DateTime?
   createdAt        DateTime     @default(now())
   updatedAt        DateTime     @updatedAt
 
@@ -450,7 +451,7 @@ model AdminGovernanceAction {
 
 model Rating {
   id         String   @id @default(cuid())
-  orderId    String   @unique
+  orderId    String
   order      Order    @relation(fields: [orderId], references: [id])
   fromUserId String
   fromUser   User     @relation("RatingsGiven", fields: [fromUserId], references: [id])
@@ -460,6 +461,8 @@ model Rating {
   comment    String?
   createdAt  DateTime @default(now())
 
+  @@unique([orderId, fromUserId])
+  @@index([toUserId])
   @@map("ratings")
 }
 


### PR DESCRIPTION
## Summary

Adds the client↔booster ratings & reputation workflow. `Rating` and `Profile.reputation` existed in the schema but had no module, API, or web flow, and `Rating.orderId @unique` allowed only one rating per order (blocking dual ratings).

Closes: #78

---

## What Changed

- Added `apps/api/src/modules/ratings` module:
  - `Rating` domain entity (score 1–5, no self-rating) + typed `rating.errors.ts`.
  - `submit-rating` and `get-order-ratings` use-cases.
  - `PrismaRatingRepository` implementing both the rating repository and order-lookup ports.
  - `RatingsController` (`POST /ratings`, `GET /ratings/orders/:orderId`) with Zod + `ZodValidationPipe`.
- Modified `Order`: `complete(now)` now stamps `Order.completedAt`; threaded through the entity and `PrismaOrderRepository`.
- Modified `schema.prisma`: dropped `Rating.orderId @unique` for `@@unique([orderId, fromUserId])` (one rating per direction), added `@@index([toUserId])`, `Order.ratings Rating[]`, and `Order.completedAt`. New migration `add_dual_ratings_and_order_completed_at`.
- Mapped the rating domain errors through `api-domain-error.filter.ts` (403/404/400/409).
- Added web rating flow (`apps/web/src/shared/ratings`): `RatingCard` (star + comment) wired into the client and booster completed-order pages via a server action.

---

## Why

Part of epic #71 (hard technical debts). Ratings/reputation were schema-only and the unique constraint conflicted with the required client↔booster dual ratings. This implements the domain rules (who can rate whom and when), a reputation recalculation policy, and the end-to-end flows for both roles.

---

## Implementation Notes

- **Reputation policy:** simple average of received scores, recomputed for the rated user **inside the same transaction** as the rating insert — strongly consistent, no outbox needed.
- **One rating per direction:** enforced by `@@unique([orderId, fromUserId])`; the use-case pre-checks for a friendly error and the repo maps the unique violation (`P2002`) to `RatingAlreadySubmittedError` (409) to stay race-safe.
- **Bounded window:** ratings allowed only while the order is `completed` and within 14 days of `completedAt` (module-level constant; `Order.completedAt` added because `updatedAt` changes on any write).
- **Direction derived server-side:** the rater is identified from the auth token; the counterparty is the other order participant, so the web layer never needs participant IDs.
- **Trade-off:** no stored `ratingsCount` / time-decay and no outbox for recalc — deferred until they measurably matter.

---

## Testing

How this was validated.

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manually tested

Commands run:

```
# api unit + integration
pnpm api test                  -> 344 passed
pnpm api test:integration:db   -> 42 passed  (5 new ratings)
pnpm api test:e2e:db           -> 4 passed   (3 new ratings, full HTTP)
# web
pnpm web test                  -> 122 passed (4 new RatingCard)
# quality gates
pnpm api exec tsc --noEmit -p tsconfig.json   -> clean
pnpm web exec tsc --noEmit -p tsconfig.json   -> clean
pnpm exec biome check <changed paths>         -> clean
```

Notes:
- Ran targeted `biome check` on the changed paths instead of `biome:fix:all` to avoid reformatting unrelated in-progress files in the working tree.
- Playwright (`pnpm web test:e2e`) not run; the rating UI is covered by a jsdom component test and the API flow by an HTTP e2e-db test.

---

## Screenshots (if UI)

Not captured — rating card reuses existing dashboard card/button primitives and pt-BR copy. Covered by `rating-card.spec.tsx`.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated where needed
- [x] Lint and type checks pass
- [x] Documentation updated if required
- [x] No breaking changes

---

## Breaking Changes

None.
