### PR TITLE
feat(api): add expired order-quote cleanup strategy

### DIFF
--- a/apps/api/src/modules/orders/application/logging/order-quote-cleanup-lifecycle.logger.ts
+++ b/apps/api/src/modules/orders/application/logging/order-quote-cleanup-lifecycle.logger.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
+
+type OrderQuoteCleanupLifecycleEvent = {
+	event: 'order_quote_cleanup.lifecycle';
+	operation: 'cleanup_expired_unused';
+	outcome: 'success' | 'error';
+	duration_ms: number;
+	deleted_count: number;
+	expires_before: string;
+	limit: number;
+	error_type?: string;
+	error_message?: string;
+};
+
+@Injectable()
+export class OrderQuoteCleanupLifecycleLogger {
+	constructor(private readonly logger: PinoLogger) {
+		this.logger.setContext(OrderQuoteCleanupLifecycleLogger.name);
+	}
+
+	emit(event: OrderQuoteCleanupLifecycleEvent): void {
+		if (event.outcome === 'error') {
+			this.logger.error(event);
+			return;
+		}
+
+		this.logger.info(event);
+	}
+}
+
+export type OrderQuoteCleanupLifecycleLoggerPort = Pick<
+	OrderQuoteCleanupLifecycleLogger,
+	'emit'
+>;

--- a/apps/api/src/modules/orders/application/ports/order-quote-repository.port.ts
+++ b/apps/api/src/modules/orders/application/ports/order-quote-repository.port.ts
@@ -21,4 +21,8 @@ export interface OrderQuoteRepositoryPort {
 		clientId: string;
 		orderId: string;
 	}): Promise<void>;
+	cleanupExpiredUnused(input: {
+		expiresBefore: Date;
+		limit: number;
+	}): Promise<{ deletedCount: number }>;
 }

--- a/apps/api/src/modules/orders/application/use-cases/cleanup-expired-order-quotes/cleanup-expired-order-quotes.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/cleanup-expired-order-quotes/cleanup-expired-order-quotes.use-case.spec.ts
@@ -1,0 +1,72 @@
+import type { OrderQuoteRepositoryPort } from '@modules/orders/application/ports/order-quote-repository.port';
+import { CleanupExpiredOrderQuotesUseCase } from './cleanup-expired-order-quotes.use-case';
+
+class InMemoryOrderQuoteRepository implements OrderQuoteRepositoryPort {
+	readonly cleanupCalls: Array<{ expiresBefore: Date; limit: number }> = [];
+
+	async create(): Promise<{ id: string }> {
+		return { id: 'quote-1' };
+	}
+
+	async consumeByIdForClient(): Promise<never> {
+		throw new Error('Not used in this test.');
+	}
+
+	async restoreConsumedByIdForClient(): Promise<void> {}
+
+	async cleanupExpiredUnused(input: {
+		expiresBefore: Date;
+		limit: number;
+	}): Promise<{ deletedCount: number }> {
+		this.cleanupCalls.push(input);
+		return { deletedCount: 3 };
+	}
+}
+
+class OrderQuoteCleanupLoggerSpy {
+	readonly events: unknown[] = [];
+
+	emit(event: unknown): void {
+		this.events.push(event);
+	}
+}
+
+describe('CleanupExpiredOrderQuotesUseCase', () => {
+	it('deletes quotes expired before the retention cutoff', async () => {
+		const repository = new InMemoryOrderQuoteRepository();
+		const useCase = new CleanupExpiredOrderQuotesUseCase(repository);
+		const now = new Date('2026-06-12T12:00:00.000Z');
+
+		await expect(useCase.execute({ now, limit: 500 })).resolves.toEqual({
+			deletedCount: 3,
+			expiresBefore: '2026-06-05T12:00:00.000Z',
+		});
+		expect(repository.cleanupCalls).toEqual([
+			{
+				expiresBefore: new Date('2026-06-05T12:00:00.000Z'),
+				limit: 500,
+			},
+		]);
+	});
+
+	it('emits a cleanup lifecycle event', async () => {
+		const repository = new InMemoryOrderQuoteRepository();
+		const logger = new OrderQuoteCleanupLoggerSpy();
+		const useCase = new CleanupExpiredOrderQuotesUseCase(repository, logger);
+		const now = new Date('2026-06-12T12:00:00.000Z');
+
+		await useCase.execute({ now, limit: 500 });
+
+		expect(logger.events).toEqual([
+			expect.objectContaining({
+				event: 'order_quote_cleanup.lifecycle',
+				operation: 'cleanup_expired_unused',
+				outcome: 'success',
+				deleted_count: 3,
+				expires_before: '2026-06-05T12:00:00.000Z',
+				limit: 500,
+				duration_ms: expect.any(Number),
+			}),
+		]);
+	});
+});

--- a/apps/api/src/modules/orders/application/use-cases/cleanup-expired-order-quotes/cleanup-expired-order-quotes.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/cleanup-expired-order-quotes/cleanup-expired-order-quotes.use-case.ts
@@ -1,0 +1,83 @@
+import {
+	OrderQuoteCleanupLifecycleLogger,
+	type OrderQuoteCleanupLifecycleLoggerPort,
+} from '@modules/orders/application/logging/order-quote-cleanup-lifecycle.logger';
+import {
+	ORDER_QUOTE_REPOSITORY_KEY,
+	type OrderQuoteRepositoryPort,
+} from '@modules/orders/application/ports/order-quote-repository.port';
+import { Inject, Injectable, Optional } from '@nestjs/common';
+
+const ORDER_QUOTE_CLEANUP_RETENTION_DAYS = 7;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+type CleanupExpiredOrderQuotesInput = {
+	now: Date;
+	limit: number;
+};
+
+type CleanupExpiredOrderQuotesOutput = {
+	deletedCount: number;
+	expiresBefore: string;
+};
+
+@Injectable()
+export class CleanupExpiredOrderQuotesUseCase {
+	constructor(
+		@Inject(ORDER_QUOTE_REPOSITORY_KEY)
+		private readonly orderQuoteRepository: OrderQuoteRepositoryPort,
+		@Optional()
+		@Inject(OrderQuoteCleanupLifecycleLogger)
+		private readonly lifecycleLogger?: OrderQuoteCleanupLifecycleLoggerPort,
+	) {}
+
+	async execute(
+		input: CleanupExpiredOrderQuotesInput,
+	): Promise<CleanupExpiredOrderQuotesOutput> {
+		const startedAt = Date.now();
+		const expiresBefore = new Date(
+			input.now.getTime() - ORDER_QUOTE_CLEANUP_RETENTION_DAYS * DAY_IN_MS,
+		);
+		let deletedCount = 0;
+		let outcome: 'success' | 'error' = 'success';
+
+		try {
+			const result = await this.orderQuoteRepository.cleanupExpiredUnused({
+				expiresBefore,
+				limit: input.limit,
+			});
+			deletedCount = result.deletedCount;
+
+			return {
+				deletedCount,
+				expiresBefore: expiresBefore.toISOString(),
+			};
+		} catch (error) {
+			outcome = 'error';
+			this.lifecycleLogger?.emit({
+				event: 'order_quote_cleanup.lifecycle',
+				operation: 'cleanup_expired_unused',
+				outcome: 'error',
+				duration_ms: Date.now() - startedAt,
+				deleted_count: deletedCount,
+				expires_before: expiresBefore.toISOString(),
+				limit: input.limit,
+				error_type: error instanceof Error ? error.constructor.name : 'Error',
+				error_message: error instanceof Error ? error.message : String(error),
+			});
+			throw error;
+		} finally {
+			if (outcome === 'success') {
+				this.lifecycleLogger?.emit({
+					event: 'order_quote_cleanup.lifecycle',
+					operation: 'cleanup_expired_unused',
+					outcome,
+					duration_ms: Date.now() - startedAt,
+					deleted_count: deletedCount,
+					expires_before: expiresBefore.toISOString(),
+					limit: input.limit,
+				});
+			}
+		}
+	}
+}

--- a/apps/api/src/modules/orders/application/use-cases/create-order-quote/create-order-quote.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/create-order-quote/create-order-quote.use-case.spec.ts
@@ -32,6 +32,10 @@ class InMemoryOrderQuoteRepository implements OrderQuoteRepositoryPort {
 	}
 
 	async restoreConsumedByIdForClient(): Promise<void> {}
+
+	async cleanupExpiredUnused(): Promise<{ deletedCount: number }> {
+		return { deletedCount: 0 };
+	}
 }
 
 class OrderCouponServiceStub implements OrderCouponService {

--- a/apps/api/src/modules/orders/infrastructure/repositories/in-memory-order-checkout.repository.spec.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/in-memory-order-checkout.repository.spec.ts
@@ -136,6 +136,10 @@ class InMemoryOrderQuoteRepository implements OrderQuoteRepositoryPort {
 		quote.orderId = null;
 	}
 
+	async cleanupExpiredUnused(): Promise<{ deletedCount: number }> {
+		return { deletedCount: 0 };
+	}
+
 	insert(quote: StoredQuote): void {
 		this.quotes.set(quote.id, quote);
 	}

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-order-quote.repository.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-order-quote.repository.ts
@@ -140,6 +140,33 @@ export class PrismaOrderQuoteRepository implements OrderQuoteRepositoryPort {
 		});
 	}
 
+	async cleanupExpiredUnused(input: {
+		expiresBefore: Date;
+		limit: number;
+	}): Promise<{ deletedCount: number }> {
+		const quotes = await this.prisma.orderQuote.findMany({
+			where: {
+				expiresAt: { lt: input.expiresBefore },
+				consumedAt: null,
+				orderId: null,
+			},
+			select: { id: true },
+			orderBy: { expiresAt: 'asc' },
+			take: input.limit,
+		});
+		if (quotes.length === 0) return { deletedCount: 0 };
+
+		const result = await this.prisma.orderQuote.deleteMany({
+			where: {
+				id: { in: quotes.map((quote) => quote.id) },
+				consumedAt: null,
+				orderId: null,
+			},
+		});
+
+		return { deletedCount: result.count };
+	}
+
 	private mapSnapshot(record: OrderQuoteRecord): OrderQuoteSnapshot {
 		return {
 			couponId: record.couponId,

--- a/apps/api/src/modules/orders/orders.module.ts
+++ b/apps/api/src/modules/orders/orders.module.ts
@@ -1,6 +1,8 @@
+import { LoggingModule } from '@app/common/logging/logging.module';
 import { PrismaModule } from '@app/common/prisma/prisma.module';
 import { AuthModule } from '@modules/auth/auth.module';
 import { ChatModule } from '@modules/chat/chat.module';
+import { OrderQuoteCleanupLifecycleLogger } from '@modules/orders/application/logging/order-quote-cleanup-lifecycle.logger';
 import { BOOSTER_ORDER_READER_KEY } from '@modules/orders/application/ports/booster-order-reader.port';
 import { BOOSTER_USER_READER_KEY } from '@modules/orders/application/ports/booster-user-reader.port';
 import { CLIENT_ORDER_READER_KEY } from '@modules/orders/application/ports/client-order-reader.port';
@@ -18,6 +20,7 @@ import { ORDER_PRICING_SERVICE_KEY } from '@modules/orders/application/services/
 import { AcceptOrderUseCase } from '@modules/orders/application/use-cases/accept-order/accept-order.use-case';
 import { ActivateOrderPricingVersionUseCase } from '@modules/orders/application/use-cases/activate-order-pricing-version/activate-order-pricing-version.use-case';
 import { CancelOrderUseCase } from '@modules/orders/application/use-cases/cancel-order/cancel-order.use-case';
+import { CleanupExpiredOrderQuotesUseCase } from '@modules/orders/application/use-cases/cleanup-expired-order-quotes/cleanup-expired-order-quotes.use-case';
 import { ClearOrderCredentialsUseCase } from '@modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case';
 import { CompleteOrderUseCase } from '@modules/orders/application/use-cases/complete-order/complete-order.use-case';
 import { CreateOrderUseCase } from '@modules/orders/application/use-cases/create-order/create-order.use-case';
@@ -50,7 +53,7 @@ import { WalletModule } from '@modules/wallet/wallet.module';
 import { Module } from '@nestjs/common';
 
 @Module({
-	imports: [PrismaModule, AuthModule, ChatModule, WalletModule],
+	imports: [PrismaModule, AuthModule, ChatModule, WalletModule, LoggingModule],
 	controllers: [
 		OrdersEventsController,
 		OrdersController,
@@ -63,6 +66,7 @@ import { Module } from '@nestjs/common';
 		PrismaOrderPricingVersionRepository,
 		PrismaOrderRepository,
 		PrismaOrderQuoteRepository,
+		OrderQuoteCleanupLifecycleLogger,
 		InMemoryOrderEventBus,
 		OrderCredentialsCipherService,
 		{
@@ -160,6 +164,7 @@ import { Module } from '@nestjs/common';
 		AcceptOrderUseCase,
 		RejectOrderUseCase,
 		CancelOrderUseCase,
+		CleanupExpiredOrderQuotesUseCase,
 		ClearOrderCredentialsUseCase,
 		CompleteOrderUseCase,
 		SaveOrderCredentialsUseCase,

--- a/apps/api/src/modules/orders/presentation/orders.controller.ts
+++ b/apps/api/src/modules/orders/presentation/orders.controller.ts
@@ -2,10 +2,12 @@ import { ZodValidationPipe } from '@app/common/http/zod-validation.pipe';
 import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
 import { CurrentUser } from '@modules/auth/presentation/decorators/current-user.decorator';
 import { Roles } from '@modules/auth/presentation/decorators/roles.decorator';
+import { InternalApiKeyGuard } from '@modules/auth/presentation/guards/internal-api-key.guard';
 import { JwtAuthGuard } from '@modules/auth/presentation/guards/jwt-auth.guard';
 import { RolesGuard } from '@modules/auth/presentation/guards/roles.guard';
 import { AcceptOrderUseCase } from '@modules/orders/application/use-cases/accept-order/accept-order.use-case';
 import { CancelOrderUseCase } from '@modules/orders/application/use-cases/cancel-order/cancel-order.use-case';
+import { CleanupExpiredOrderQuotesUseCase } from '@modules/orders/application/use-cases/cleanup-expired-order-quotes/cleanup-expired-order-quotes.use-case';
 import { CompleteOrderUseCase } from '@modules/orders/application/use-cases/complete-order/complete-order.use-case';
 import { CreateOrderUseCase } from '@modules/orders/application/use-cases/create-order/create-order.use-case';
 import { CreateOrderQuoteUseCase } from '@modules/orders/application/use-cases/create-order-quote/create-order-quote.use-case';
@@ -36,6 +38,8 @@ import {
 	createOrderQuoteSchema,
 } from '@packages/shared/orders/create-order-quote.schema';
 import {
+	type CleanupExpiredOrderQuotesSchemaInput,
+	cleanupExpiredOrderQuotesSchema,
 	type ListBoosterOrdersQuerySchemaInput,
 	type ListClientOrdersQuerySchemaInput,
 	listBoosterOrdersQuerySchema,
@@ -61,6 +65,7 @@ export class OrdersController {
 		private readonly cancelOrderUseCase: CancelOrderUseCase,
 		private readonly completeOrderUseCase: CompleteOrderUseCase,
 		private readonly saveOrderCredentialsUseCase: SaveOrderCredentialsUseCase,
+		private readonly cleanupExpiredOrderQuotesUseCase: CleanupExpiredOrderQuotesUseCase,
 	) {}
 
 	@Post('quote/preview')
@@ -146,6 +151,19 @@ export class OrdersController {
 			boosterId: body.boosterId,
 			quoteId: body.quoteId,
 			now: new Date(),
+		});
+	}
+
+	@Post('internal/quotes/cleanup-expired')
+	@UseGuards(InternalApiKeyGuard)
+	@HttpCode(200)
+	async cleanupExpiredQuotes(
+		@Body(new ZodValidationPipe(cleanupExpiredOrderQuotesSchema))
+		body: CleanupExpiredOrderQuotesSchemaInput,
+	): Promise<{ deletedCount: number; expiresBefore: string }> {
+		return await this.cleanupExpiredOrderQuotesUseCase.execute({
+			now: new Date(body.now),
+			limit: body.limit,
 		});
 	}
 

--- a/apps/api/src/modules/orders/presentation/orders.request-schemas.ts
+++ b/apps/api/src/modules/orders/presentation/orders.request-schemas.ts
@@ -20,6 +20,15 @@ export type ListBoosterOrdersQuerySchemaInput = z.infer<
 	typeof listBoosterOrdersQuerySchema
 >;
 
+export const cleanupExpiredOrderQuotesSchema = z.object({
+	now: z.string().datetime({ offset: true }),
+	limit: z.coerce.number().int().min(1).max(5000).default(500),
+});
+
+export type CleanupExpiredOrderQuotesSchemaInput = z.infer<
+	typeof cleanupExpiredOrderQuotesSchema
+>;
+
 export const saveOrderCredentialsSchema = z.object({
 	login: z.string().trim().min(1),
 	summonerName: z.string().trim().min(1),

--- a/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
+++ b/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
@@ -5,6 +5,10 @@ import {
 	type OrderPricingVersionRepositoryPort,
 } from '@modules/orders/application/ports/order-pricing-version-repository.port';
 import {
+	ORDER_QUOTE_REPOSITORY_KEY,
+	type OrderQuoteRepositoryPort,
+} from '@modules/orders/application/ports/order-quote-repository.port';
+import {
 	ORDER_REPOSITORY_KEY,
 	type OrderRepositoryPort,
 } from '@modules/orders/application/ports/order-repository.port';
@@ -34,6 +38,7 @@ describe('Orders module integration (db)', () => {
 	let prisma: PrismaService;
 	let orderRepository: OrderRepositoryPort;
 	let pricingVersions: OrderPricingVersionRepositoryPort;
+	let orderQuoteRepository: OrderQuoteRepositoryPort;
 	let markOrderAsPaidUseCase: MarkOrderAsPaidUseCase;
 	let clientUser: AuthenticatedUser;
 	let boosterUser: AuthenticatedUser;
@@ -107,6 +112,7 @@ describe('Orders module integration (db)', () => {
 		prisma = moduleRef.get(PrismaService);
 		orderRepository = moduleRef.get(ORDER_REPOSITORY_KEY);
 		pricingVersions = moduleRef.get(ORDER_PRICING_VERSION_REPOSITORY_KEY);
+		orderQuoteRepository = moduleRef.get(ORDER_QUOTE_REPOSITORY_KEY);
 		markOrderAsPaidUseCase = moduleRef.get(MarkOrderAsPaidUseCase);
 		await prisma.ticketMessage.deleteMany();
 		await prisma.ticket.deleteMany();
@@ -188,6 +194,119 @@ describe('Orders module integration (db)', () => {
 			totalAmount: 2520,
 			discountAmount: 0,
 		});
+	});
+
+	it('cleans up only expired unused quotes older than the cutoff', async () => {
+		const oldUnusedQuote = await controller.quote(
+			{
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				currentLp: 50,
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
+				server: 'br',
+				desiredQueue: 'solo_duo',
+				lpGain: 20,
+				deadline: '2026-03-31T00:00:00.000Z',
+			},
+			clientUser,
+		);
+		await prisma.orderQuote.update({
+			where: { id: oldUnusedQuote.quoteId },
+			data: { expiresAt: new Date('2026-06-01T00:00:00.000Z') },
+		});
+		const recentExpiredQuote = await controller.quote(
+			{
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				currentLp: 50,
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
+				server: 'br',
+				desiredQueue: 'solo_duo',
+				lpGain: 20,
+				deadline: '2026-03-31T00:00:00.000Z',
+			},
+			clientUser,
+		);
+		await prisma.orderQuote.update({
+			where: { id: recentExpiredQuote.quoteId },
+			data: { expiresAt: new Date('2026-06-10T00:00:00.000Z') },
+		});
+		const linkedOrder = await createQuotedOrder();
+		const linkedQuote = await prisma.orderQuote.findFirstOrThrow({
+			where: { orderId: linkedOrder.id },
+		});
+		await prisma.orderQuote.update({
+			where: { id: linkedQuote.id },
+			data: { expiresAt: new Date('2026-06-01T00:00:00.000Z') },
+		});
+
+		await expect(
+			orderQuoteRepository.cleanupExpiredUnused({
+				expiresBefore: new Date('2026-06-05T00:00:00.000Z'),
+				limit: 500,
+			}),
+		).resolves.toEqual({ deletedCount: 1 });
+
+		await expect(
+			prisma.orderQuote.findUnique({ where: { id: oldUnusedQuote.quoteId } }),
+		).resolves.toBeNull();
+		await expect(
+			prisma.orderQuote.findUnique({
+				where: { id: recentExpiredQuote.quoteId },
+			}),
+		).resolves.toMatchObject({ id: recentExpiredQuote.quoteId });
+		await expect(
+			prisma.orderQuote.findUnique({ where: { id: linkedQuote.id } }),
+		).resolves.toMatchObject({ id: linkedQuote.id, orderId: linkedOrder.id });
+	});
+
+	it('limits expired unused quote cleanup batches', async () => {
+		const firstQuote = await controller.quote(
+			{
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				currentLp: 50,
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
+				server: 'br',
+				desiredQueue: 'solo_duo',
+				lpGain: 20,
+				deadline: '2026-03-31T00:00:00.000Z',
+			},
+			clientUser,
+		);
+		const secondQuote = await controller.quote(
+			{
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				currentLp: 50,
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
+				server: 'br',
+				desiredQueue: 'solo_duo',
+				lpGain: 20,
+				deadline: '2026-03-31T00:00:00.000Z',
+			},
+			clientUser,
+		);
+		await prisma.orderQuote.updateMany({
+			where: { id: { in: [firstQuote.quoteId, secondQuote.quoteId] } },
+			data: { expiresAt: new Date('2026-06-01T00:00:00.000Z') },
+		});
+
+		await expect(
+			orderQuoteRepository.cleanupExpiredUnused({
+				expiresBefore: new Date('2026-06-05T00:00:00.000Z'),
+				limit: 1,
+			}),
+		).resolves.toEqual({ deletedCount: 1 });
+		await expect(prisma.orderQuote.count()).resolves.toBe(1);
 	});
 
 	it('persists a selected booster on create-order', async () => {

--- a/apps/api/test/orders.e2e-spec.ts
+++ b/apps/api/test/orders.e2e-spec.ts
@@ -36,6 +36,8 @@ describe('Orders (e2e)', () => {
 	let chatRepository: InMemoryChatRepository;
 	let pricingVersions: OrderPricingVersionRepositoryPort;
 	let markOrderAsPaidUseCase: MarkOrderAsPaidUseCase;
+	const testInternalApiKey =
+		process.env.INTERNAL_API_KEY ?? 'test-internal-api-key';
 
 	class CouponLookupStub {
 		public coupons = new Map<string, StoredCoupon>();
@@ -203,6 +205,47 @@ describe('Orders (e2e)', () => {
 				totalAmount: 2520,
 				discountAmount: 0,
 			})
+			.execute();
+	});
+
+	it('cleans expired order quotes through the internal endpoint', async () => {
+		await requestHttp(app)
+			.post('/orders/internal/quotes/cleanup-expired')
+			.set('x-internal-api-key', testInternalApiKey)
+			.send({
+				now: '2026-06-12T12:00:00.000Z',
+				limit: 500,
+			})
+			.expect(200, {
+				deletedCount: 0,
+				expiresBefore: '2026-06-05T12:00:00.000Z',
+			})
+			.execute();
+	});
+
+	it('rejects expired quote cleanup without the internal API key', async () => {
+		await requestHttp(app)
+			.post('/orders/internal/quotes/cleanup-expired')
+			.send({
+				now: '2026-06-12T12:00:00.000Z',
+			})
+			.expect(401, {
+				message: 'Internal API key required.',
+				error: 'Unauthorized',
+				statusCode: 401,
+			})
+			.execute();
+	});
+
+	it('validates expired quote cleanup input', async () => {
+		await requestHttp(app)
+			.post('/orders/internal/quotes/cleanup-expired')
+			.set('x-internal-api-key', testInternalApiKey)
+			.send({
+				now: 'not-a-date',
+				limit: 0,
+			})
+			.expect(400)
 			.execute();
 	});
 

--- a/apps/api/test/support/in-memory/orders/in-memory-order-quote.repository.ts
+++ b/apps/api/test/support/in-memory/orders/in-memory-order-quote.repository.ts
@@ -80,4 +80,28 @@ export class InMemoryOrderQuoteRepository implements OrderQuoteRepositoryPort {
 		quote.orderId = null;
 		return Promise.resolve();
 	}
+
+	cleanupExpiredUnused(input: {
+		expiresBefore: Date;
+		limit: number;
+	}): Promise<{ deletedCount: number }> {
+		let deletedCount = 0;
+		const quotes = [...this.quotes.values()]
+			.filter(
+				(quote) =>
+					quote.expiresAt < input.expiresBefore &&
+					!quote.consumedAt &&
+					!quote.orderId,
+			)
+			.sort(
+				(left, right) => left.expiresAt.getTime() - right.expiresAt.getTime(),
+			)
+			.slice(0, input.limit);
+
+		for (const quote of quotes) {
+			if (this.quotes.delete(quote.id)) deletedCount++;
+		}
+
+		return Promise.resolve({ deletedCount });
+	}
 }


### PR DESCRIPTION
## Summary

Adds a bounded cleanup strategy for expired, unused `OrderQuote` records. The quote-based checkout flow persists one-time quotes; expired unused quotes accumulate over time with no retention policy. This deletes only eligible quotes while preserving all orders and any quotes already linked to an order.

Closes: #33

---

## What Changed

- Added `CleanupExpiredOrderQuotesUseCase` (`cleanup-expired-order-quotes/`) that deletes expired, unused quotes older than a retention window and reports the deleted count.
- Added `OrderQuoteCleanupLifecycleLogger` for operational visibility of cleanup runs (outcome, duration, deleted count, retention boundary).
- Extended the order-quote repository port + `PrismaOrderQuoteRepository` with `cleanupExpiredUnused` (quotes not linked to an order only).
- Exposed the cleanup via an internal endpoint in `orders.controller.ts` with a Zod request schema in `orders.request-schemas.ts`.
- Wired the use-case and logger in `orders.module.ts`.

---

## Why

Issue #33: the persisted quote flow (#3) keeps a `orderQuote -> orderId` audit link. Unused quotes that expire must be removable on a bounded retention policy without affecting created orders or consumed quotes, plus clear visibility into cleanup runs.

---

## Implementation Notes

- **Eligibility:** only quotes past the retention window that are **not** linked to an order are deleted; consumed/linked quotes are preserved for auditability.
- **Bounded batch:** cleanup takes a `limit` so runs delete in bounded batches.
- **Observability:** lifecycle logger emits success/error events with deleted count and the `expiresBefore` boundary.
- **Transport:** internal endpoint guarded as an internal API surface; input validated at the boundary with Zod + `ZodValidationPipe`.

---

## Testing

How this was validated.

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manually tested

Commands run (against the dev Postgres):

```
pnpm api exec tsc --noEmit -p tsconfig.json                 -> clean
npx jest cleanup-expired-order-quotes create-order-quote    -> 5 passed
pnpm api test:e2e (orders)                                  -> 33 passed
pnpm api test:integration:db                                -> 37 passed (5 suites)
pnpm biome:fix:all                                          -> no fixes (repo clean)
```

---

## Screenshots (if UI)

N/A — backend only.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated where needed
- [x] Lint and type checks pass
- [ ] Documentation updated if required
- [x] No breaking changes

---

## Breaking Changes

None.
