### PR TITLE
feat(admin): create users with password setup

### DIFF
--- a/admin-user-creation-notes.md
+++ b/admin-user-creation-notes.md
@@ -1,0 +1,85 @@
+# Admin User Creation Notes
+
+Remember to create a new branch to start working on. 
+
+## Current Understanding
+
+- Admins need a panel flow to create users without setting a password.
+- The admin creation form should collect only basic user info:
+  - username
+  - email
+  - role: `CLIENT`, `ADMIN`, or `BOOSTER`
+- After creation, the created user should receive an email link that lets them set their own password.
+- Until the created user completes that email/password activation flow, the admin panel should show the account as inactive.
+- The admin user list should show important user data, at minimum:
+  - username
+  - email
+  - role
+  - activation status
+  - blocked status
+  - created date
+- The action must be auditable.
+- The action must emit structured lifecycle logs.
+
+## Existing Repo Facts
+
+- Roles already exist as `CLIENT`, `BOOSTER`, and `ADMIN`.
+- `users` already has:
+  - `isActive`
+  - `emailConfirmedAt`
+  - `emailConfirmationTokenHash`
+  - `emailConfirmationTokenExpiresAt`
+  - `createdAt`
+  - `role`
+  - `isBlocked`
+- There is already an email confirmation flow for public signup.
+- Admin user listing already returns `createdAt`, `role`, `isActive`, and `isBlocked`.
+- There is already an `admin_governance_actions` table used for admin audit actions.
+- Ponytail read: prefer extending the existing user activation/email confirmation and admin governance paths instead of adding a separate audit table unless the new action needs fields the existing table cannot represent.
+
+## Likely Smallest Implementation Shape
+
+- Add an admin-only API endpoint to create a user.
+- Reuse the existing email confirmation token mechanism as the activation link, unless the product really needs a separate "reset password" token.
+- Store the user as inactive until the link is completed.
+- Record an admin governance action like `USER_CREATE`.
+- Add one structured lifecycle log event for the admin-created-user workflow.
+- Add the admin panel form and wire it to the new endpoint.
+- Extend the admin user table only if the current fields are not enough visually.
+
+## Open Questions
+
+1. Should the email link be the existing email confirmation flow, or must it be a separate "set/reset password" flow?
+	R: It must be a new set/reset password. Try to match the aspect of confirmation flow, if needed create a source of truth of design of emails.
+2. Since admins do not set a password, should the database allow `users.password` to be nullable, or should we store a random unusable hash until activation?
+	R: It should be nullable. And nullable should not mean that a hacker log in with email and null password and pass through.
+3. What exact "basic info" should admins enter besides username, email, and role?
+	R: I really don't know. But you don't need to create anything: It's literally just the basic, username email and role. If our database needs something different, please ask to me.
+4. For `BOOSTER` users, should admin creation also create or require any booster-specific profile/invite data?
+	R: Simple option.
+5. Can admins create other `ADMIN` users directly, or should that require an extra confirmation/reason?
+	R: No confrimation/reason.
+6. Should duplicate email/username behave exactly like public signup errors?
+	R: Yes, the API should clearly return duplication exception and the UI should clearly say that we already has a username/email like that. (if email and username isn't unique; it should be).
+7. What should happen if the activation email fails to send after the user is created: keep the inactive user, roll back creation, or allow resend from admin panel?
+	R: The e-mail should only happen if the user is successfuly created; if the email fails, it should create, and allow re-send from admin-panel.
+8. Should admins be able to resend the activation/set-password email for inactive users?
+	R: Yes. Inactive isn't a kind of bad sign. It's just: Ok this user is off OR this user hasn't confirmed yet.
+9. Should the admin audit record require a human-entered reason for user creation, or is actor/action/target/timestamp enough?
+	R: actor/action/target/timestamp enough?
+10. Do you want the audit visible in the admin UI now, or only persisted for investigation/logging?
+	R: only persisted by investigation/logging.
+11. Should inactive users be unable to log in because `isActive = false` only, or should there be a clearer status label like `PENDING_ACTIVATION`?
+	R: Ohh okay, that is a great question. Maybe my earlier questions overlap with that, so keep with this one: It must ha inactive and pending_activation, both should not let user log in, and show the same generic error (something like isn't possible to log in, please try again).
+	It's important to be direct.
+12. What email copy/language should be used: Portuguese only, English only, or follow the current app language?
+	R: portuguese.
+
+## Verification To Run Later
+
+- `pnpm biome:fix:all`
+- API typecheck for touched package
+- Web typecheck/build for touched package
+- Targeted API tests for admin user creation
+- Targeted web tests for admin panel create-user flow
+- Database-backed test if the Prisma schema changes

--- a/apps/api/src/common/http/api-domain-error.filter.ts
+++ b/apps/api/src/common/http/api-domain-error.filter.ts
@@ -10,7 +10,10 @@ import {
 import {
 	AdminGovernanceReasonRequiredError,
 	AdminOrderNotFoundError,
+	AdminUserEmailAlreadyInUseError,
 	AdminUserNotFoundError,
+	AdminUsernameAlreadyInUseError,
+	AdminUserPasswordSetupUnavailableError,
 } from '@modules/admin/domain/admin.errors';
 import {
 	AuthenticationRequiredError,
@@ -95,6 +98,7 @@ import {
 	UserEmailAlreadyInUseError,
 	UserEmailConfirmationTokenInvalidError,
 	UsernameAlreadyInUseError,
+	UserPasswordResetTokenInvalidError,
 } from '@modules/users/domain/user.errors';
 import {
 	WalletInsufficientWithdrawableBalanceError,
@@ -193,7 +197,11 @@ export function mapApiDomainErrorToHttpException(
 			WalletInvalidAmountError,
 			WalletInsufficientWithdrawableBalanceError,
 			UserEmailConfirmationTokenInvalidError,
+			UserPasswordResetTokenInvalidError,
 			AdminGovernanceReasonRequiredError,
+			AdminUserEmailAlreadyInUseError,
+			AdminUsernameAlreadyInUseError,
+			AdminUserPasswordSetupUnavailableError,
 			TicketInvalidStatusTransitionError,
 			TicketMessageOperationInvalidError,
 			TicketOrderAccessDeniedError,

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -1,9 +1,13 @@
+import { EmailModule } from '@app/common/email/email.module';
 import { PrismaModule } from '@app/common/prisma/prisma.module';
+import { AdminUserLifecycleLogger } from '@modules/admin/application/logging/admin-user-lifecycle.logger';
 import { ADMIN_DASHBOARD_READER_KEY } from '@modules/admin/application/ports/admin-dashboard-reader.port';
 import { ADMIN_GOVERNANCE_REPOSITORY_KEY } from '@modules/admin/application/ports/admin-governance.repository';
 import { BlockAdminUserUseCase } from '@modules/admin/application/use-cases/block-admin-user/block-admin-user.use-case';
+import { CreateAdminUserUseCase } from '@modules/admin/application/use-cases/create-admin-user/create-admin-user.use-case';
 import { ForceCancelAdminOrderUseCase } from '@modules/admin/application/use-cases/force-cancel-admin-order/force-cancel-admin-order.use-case';
 import { GetAdminDashboardUseCase } from '@modules/admin/application/use-cases/get-admin-dashboard/get-admin-dashboard.use-case';
+import { ResendAdminUserPasswordSetupUseCase } from '@modules/admin/application/use-cases/resend-admin-user-password-setup/resend-admin-user-password-setup.use-case';
 import { UnblockAdminUserUseCase } from '@modules/admin/application/use-cases/unblock-admin-user/unblock-admin-user.use-case';
 import { PrismaAdminDashboardReader } from '@modules/admin/infrastructure/repositories/prisma-admin-dashboard.reader';
 import { PrismaAdminGovernanceRepository } from '@modules/admin/infrastructure/repositories/prisma-admin-governance.repository';
@@ -14,7 +18,7 @@ import { UsersModule } from '@modules/users/users.module';
 import { Module } from '@nestjs/common';
 
 @Module({
-	imports: [PrismaModule, AuthModule, OrdersModule, UsersModule],
+	imports: [PrismaModule, AuthModule, OrdersModule, UsersModule, EmailModule],
 	controllers: [AdminController],
 	providers: [
 		PrismaAdminDashboardReader,
@@ -34,6 +38,9 @@ import { Module } from '@nestjs/common';
 			inject: [PrismaAdminGovernanceRepository],
 		},
 		GetAdminDashboardUseCase,
+		AdminUserLifecycleLogger,
+		CreateAdminUserUseCase,
+		ResendAdminUserPasswordSetupUseCase,
 		BlockAdminUserUseCase,
 		UnblockAdminUserUseCase,
 		ForceCancelAdminOrderUseCase,

--- a/apps/api/src/modules/admin/application/logging/admin-user-lifecycle.logger.ts
+++ b/apps/api/src/modules/admin/application/logging/admin-user-lifecycle.logger.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
+
+export type AdminUserLifecycleLogEvent = {
+	event: 'admin_user.lifecycle';
+	operation: 'create' | 'resend_password_setup';
+	outcome?: 'success' | 'error' | 'skipped';
+	duration_ms?: number;
+	admin_user_id?: string;
+	target_user_id?: string;
+	target_user_role?: string;
+	target_user_status_before?: string;
+	target_user_status_after?: string;
+	email_sent?: boolean;
+	side_effects?: string[];
+	error_type?: string;
+	error_message?: string;
+};
+
+export function markAdminUserLifecycleLogError(
+	event: AdminUserLifecycleLogEvent,
+	error: unknown,
+): void {
+	event.outcome = 'error';
+	event.error_type =
+		error instanceof Error ? error.constructor.name : typeof error;
+	event.error_message =
+		error instanceof Error ? error.message : 'Unknown error';
+}
+
+@Injectable()
+export class AdminUserLifecycleLogger {
+	constructor(private readonly logger: PinoLogger) {
+		this.logger.setContext(AdminUserLifecycleLogger.name);
+	}
+
+	emit(event: AdminUserLifecycleLogEvent, startedAt: number): void {
+		event.duration_ms = Date.now() - startedAt;
+
+		if (event.outcome === 'error') this.logger.error(event);
+		else this.logger.info(event);
+	}
+}

--- a/apps/api/src/modules/admin/application/ports/admin-dashboard-reader.port.ts
+++ b/apps/api/src/modules/admin/application/ports/admin-dashboard-reader.port.ts
@@ -17,6 +17,7 @@ export type AdminUserSnapshot = {
 	role: Role;
 	isActive: boolean;
 	isBlocked: boolean;
+	activationStatus: 'ACTIVE' | 'PENDING_ACTIVATION' | 'INACTIVE';
 	createdAt: Date;
 };
 

--- a/apps/api/src/modules/admin/application/ports/admin-governance.repository.ts
+++ b/apps/api/src/modules/admin/application/ports/admin-governance.repository.ts
@@ -6,6 +6,7 @@ export const ADMIN_GOVERNANCE_REPOSITORY_KEY = Symbol(
 );
 
 export type AdminGovernanceActionType =
+	| 'USER_CREATE'
 	| 'USER_BLOCK'
 	| 'USER_UNBLOCK'
 	| 'ORDER_FORCE_CANCEL';

--- a/apps/api/src/modules/admin/application/use-cases/create-admin-user/create-admin-user.use-case.spec.ts
+++ b/apps/api/src/modules/admin/application/use-cases/create-admin-user/create-admin-user.use-case.spec.ts
@@ -1,0 +1,168 @@
+import type { EmailSenderPort } from '@app/common/email/ports/email-sender.port';
+import type { AppSettingsService } from '@app/common/settings/app-settings.service';
+import type { AdminUserLifecycleLogger } from '@modules/admin/application/logging/admin-user-lifecycle.logger';
+import type {
+	AdminGovernanceActionInput,
+	AdminGovernanceRepositoryPort,
+} from '@modules/admin/application/ports/admin-governance.repository';
+import { CreateAdminUserUseCase } from '@modules/admin/application/use-cases/create-admin-user/create-admin-user.use-case';
+import type { Order } from '@modules/orders/domain/order.entity';
+import type { EmailConfirmationTokenServicePort } from '@modules/users/application/ports/email-confirmation-token.port';
+import type { UserRepositoryPort } from '@modules/users/application/ports/user-repository.port';
+import type { User } from '@modules/users/domain/user.entity';
+import { User as UserEntity } from '@modules/users/domain/user.entity';
+import { Role } from '@packages/auth/roles/role';
+
+class InMemoryUserRepository implements UserRepositoryPort {
+	private readonly users = new Map<string, User>();
+	private nextId = 1;
+
+	async findById(id: string): Promise<User | null> {
+		return this.users.get(id) ?? null;
+	}
+
+	async findByEmail(email: string): Promise<User | null> {
+		return (
+			[...this.users.values()].find((user) => user.email === email) ?? null
+		);
+	}
+
+	async findByUsername(username: string): Promise<User | null> {
+		return (
+			[...this.users.values()].find((user) => user.username === username) ??
+			null
+		);
+	}
+
+	async findByEmailConfirmationTokenHash(): Promise<User | null> {
+		return null;
+	}
+
+	async findByPasswordResetTokenHash(tokenHash: string): Promise<User | null> {
+		return (
+			[...this.users.values()].find(
+				(user) => user.passwordResetTokenHash === tokenHash,
+			) ?? null
+		);
+	}
+
+	async create(user: User): Promise<User> {
+		const createdUser = UserEntity.rehydrate({
+			id: `user-${this.nextId++}`,
+			username: user.username,
+			email: user.email,
+			passwordHash: user.passwordHash,
+			role: user.role,
+			isActive: user.isActive,
+			isBlocked: user.isBlocked,
+			emailConfirmedAt: user.emailConfirmedAt,
+			emailConfirmationTokenHash: user.emailConfirmationTokenHash,
+			emailConfirmationTokenExpiresAt: user.emailConfirmationTokenExpiresAt,
+			passwordResetTokenHash: user.passwordResetTokenHash,
+			passwordResetTokenExpiresAt: user.passwordResetTokenExpiresAt,
+			createdAt: new Date('2026-06-26T10:00:00.000Z'),
+			updatedAt: new Date('2026-06-26T10:00:00.000Z'),
+		});
+		this.users.set(createdUser.id, createdUser);
+		return createdUser;
+	}
+
+	async save(user: User): Promise<void> {
+		this.users.set(user.id, user);
+	}
+}
+
+class AdminGovernanceRepositoryStub implements AdminGovernanceRepositoryPort {
+	actions: AdminGovernanceActionInput[] = [];
+
+	constructor(private readonly users: InMemoryUserRepository) {}
+
+	findUserById(userId: string): Promise<User | null> {
+		return this.users.findById(userId);
+	}
+
+	saveUser(user: User): Promise<void> {
+		return this.users.save(user);
+	}
+
+	findOrderById(): Promise<Order | null> {
+		return Promise.resolve(null);
+	}
+
+	saveOrder(): Promise<void> {
+		return Promise.resolve();
+	}
+
+	recordAction(action: AdminGovernanceActionInput): Promise<void> {
+		this.actions.push(action);
+		return Promise.resolve();
+	}
+}
+
+const appSettings = {
+	webAppUrl: 'https://app.elonew.com',
+	emailConfirmationTokenTtlMinutes: 30,
+} as unknown as AppSettingsService;
+
+const lifecycleLogger = {
+	emit: jest.fn(),
+} as unknown as AdminUserLifecycleLogger;
+
+describe('CreateAdminUserUseCase', () => {
+	it('creates a pending user, records audit, and sends setup email', async () => {
+		const users = new InMemoryUserRepository();
+		const governance = new AdminGovernanceRepositoryStub(users);
+		const emailSender: EmailSenderPort = {
+			send: jest.fn().mockResolvedValue(undefined),
+		};
+		const tokenService: EmailConfirmationTokenServicePort = {
+			generate: jest.fn().mockReturnValue({
+				rawToken: 'raw-token',
+				tokenHash: 'hashed-token',
+				expiresAt: new Date('2026-06-26T10:30:00.000Z'),
+			}),
+			hash: jest.fn(),
+		};
+		const useCase = new CreateAdminUserUseCase(
+			users,
+			governance,
+			tokenService,
+			emailSender,
+			appSettings,
+			lifecycleLogger,
+		);
+		const now = new Date('2026-06-26T10:00:00.000Z');
+
+		const result = await useCase.execute({
+			adminUserId: 'admin-1',
+			username: 'booster',
+			email: 'Booster@Example.com',
+			role: Role.BOOSTER,
+			now,
+		});
+
+		const createdUser = await users.findById(result.id);
+		expect(createdUser?.email).toBe('booster@example.com');
+		expect(createdUser?.role).toBe(Role.BOOSTER);
+		expect(createdUser?.isActive).toBe(false);
+		expect(createdUser?.emailConfirmedAt).toBeNull();
+		expect(createdUser?.passwordHash).toBeNull();
+		expect(createdUser?.passwordResetTokenHash).toBe('hashed-token');
+		expect(governance.actions).toEqual([
+			{
+				adminUserId: 'admin-1',
+				actionType: 'USER_CREATE',
+				reason: 'admin_user_create',
+				targetUserId: result.id,
+				createdAt: now,
+			},
+		]);
+		expect(emailSender.send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				to: 'booster@example.com',
+				subject: 'Defina sua senha na EloNew',
+			}),
+		);
+		expect(result.passwordSetupEmailSent).toBe(true);
+	});
+});

--- a/apps/api/src/modules/admin/application/use-cases/create-admin-user/create-admin-user.use-case.ts
+++ b/apps/api/src/modules/admin/application/use-cases/create-admin-user/create-admin-user.use-case.ts
@@ -1,0 +1,188 @@
+import {
+	EMAIL_SENDER_KEY,
+	type EmailSenderPort,
+} from '@app/common/email/ports/email-sender.port';
+import { AppSettingsService } from '@app/common/settings/app-settings.service';
+import {
+	type AdminUserLifecycleLogEvent,
+	AdminUserLifecycleLogger,
+	markAdminUserLifecycleLogError,
+} from '@modules/admin/application/logging/admin-user-lifecycle.logger';
+import {
+	ADMIN_GOVERNANCE_REPOSITORY_KEY,
+	type AdminGovernanceRepositoryPort,
+} from '@modules/admin/application/ports/admin-governance.repository';
+import {
+	AdminUserEmailAlreadyInUseError,
+	AdminUsernameAlreadyInUseError,
+} from '@modules/admin/domain/admin.errors';
+import { buildPasswordSetupEmail } from '@modules/users/application/emails/build-password-setup-email';
+import {
+	EMAIL_CONFIRMATION_TOKEN_SERVICE_KEY,
+	type EmailConfirmationTokenServicePort,
+} from '@modules/users/application/ports/email-confirmation-token.port';
+import {
+	USER_REPOSITORY_KEY,
+	type UserRepositoryPort,
+} from '@modules/users/application/ports/user-repository.port';
+import { User } from '@modules/users/domain/user.entity';
+import {
+	UserEmailAlreadyInUseError,
+	UsernameAlreadyInUseError,
+} from '@modules/users/domain/user.errors';
+import { Inject, Injectable } from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+
+type CreateAdminUserInput = {
+	adminUserId: string;
+	username: string;
+	email: string;
+	role: Role;
+	now: Date;
+};
+
+type CreateAdminUserOutput = {
+	id: string;
+	username: string;
+	email: string;
+	role: Role;
+	isActive: boolean;
+	emailConfirmedAt: Date | null;
+	passwordSetupEmailSent: boolean;
+};
+
+@Injectable()
+export class CreateAdminUserUseCase {
+	constructor(
+		@Inject(USER_REPOSITORY_KEY)
+		private readonly userRepository: UserRepositoryPort,
+		@Inject(ADMIN_GOVERNANCE_REPOSITORY_KEY)
+		private readonly governanceRepository: AdminGovernanceRepositoryPort,
+		@Inject(EMAIL_CONFIRMATION_TOKEN_SERVICE_KEY)
+		private readonly tokenService: EmailConfirmationTokenServicePort,
+		@Inject(EMAIL_SENDER_KEY)
+		private readonly emailSender: EmailSenderPort,
+		private readonly appSettings: AppSettingsService,
+		private readonly lifecycleLogger: AdminUserLifecycleLogger,
+	) {}
+
+	async execute(input: CreateAdminUserInput): Promise<CreateAdminUserOutput> {
+		const startedAt = Date.now();
+		const event: AdminUserLifecycleLogEvent = {
+			event: 'admin_user.lifecycle',
+			operation: 'create',
+			admin_user_id: input.adminUserId,
+			target_user_role: input.role,
+			target_user_status_after: 'PENDING_ACTIVATION',
+			side_effects: [],
+		};
+
+		try {
+			const normalizedEmail = input.email.trim().toLowerCase();
+			await this.assertUniqueUser(input.username, normalizedEmail);
+			const token = this.tokenService.generate();
+			const user = await this.createUser({
+				username: input.username,
+				email: normalizedEmail,
+				role: input.role,
+				tokenHash: token.tokenHash,
+				tokenExpiresAt: token.expiresAt,
+			});
+			event.target_user_id = user.id;
+			event.side_effects?.push('user_created');
+
+			await this.governanceRepository.recordAction({
+				adminUserId: input.adminUserId,
+				actionType: 'USER_CREATE',
+				targetUserId: user.id,
+				reason: 'admin_user_create',
+				createdAt: input.now,
+			});
+			event.side_effects?.push('audit_recorded');
+
+			const emailSent = await this.sendPasswordSetupEmail({
+				email: user.email,
+				username: user.username,
+				token: token.rawToken,
+			});
+			event.email_sent = emailSent;
+			if (emailSent) event.side_effects?.push('password_setup_email_sent');
+			event.outcome = 'success';
+
+			return {
+				id: user.id,
+				username: user.username,
+				email: user.email,
+				role: user.role,
+				isActive: user.isActive,
+				emailConfirmedAt: user.emailConfirmedAt,
+				passwordSetupEmailSent: emailSent,
+			};
+		} catch (error) {
+			markAdminUserLifecycleLogError(event, error);
+			throw error;
+		} finally {
+			this.lifecycleLogger.emit(event, startedAt);
+		}
+	}
+
+	private async assertUniqueUser(
+		username: string,
+		email: string,
+	): Promise<void> {
+		if (await this.userRepository.findByEmail(email))
+			throw new AdminUserEmailAlreadyInUseError();
+		if (await this.userRepository.findByUsername(username))
+			throw new AdminUsernameAlreadyInUseError();
+	}
+
+	private async createUser(input: {
+		username: string;
+		email: string;
+		role: Role;
+		tokenHash: string;
+		tokenExpiresAt: Date;
+	}): Promise<User> {
+		try {
+			return await this.userRepository.create(
+				User.createPendingFromAdmin({
+					username: input.username,
+					email: input.email,
+					role: input.role,
+					passwordResetTokenHash: input.tokenHash,
+					passwordResetTokenExpiresAt: input.tokenExpiresAt,
+				}),
+			);
+		} catch (error) {
+			if (error instanceof UserEmailAlreadyInUseError)
+				throw new AdminUserEmailAlreadyInUseError();
+			if (error instanceof UsernameAlreadyInUseError)
+				throw new AdminUsernameAlreadyInUseError();
+			throw error;
+		}
+	}
+
+	private buildSetupUrl(token: string): string {
+		const url = new URL('/users/set-password', this.appSettings.webAppUrl);
+		url.searchParams.set('token', token);
+		return url.toString();
+	}
+
+	private async sendPasswordSetupEmail(input: {
+		email: string;
+		username: string;
+		token: string;
+	}): Promise<boolean> {
+		try {
+			const email = buildPasswordSetupEmail({
+				username: input.username,
+				setupUrl: this.buildSetupUrl(input.token),
+				expiresInMinutes: this.appSettings.emailConfirmationTokenTtlMinutes,
+			});
+			await this.emailSender.send({ to: input.email, ...email });
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}

--- a/apps/api/src/modules/admin/application/use-cases/get-admin-dashboard/get-admin-dashboard.use-case.spec.ts
+++ b/apps/api/src/modules/admin/application/use-cases/get-admin-dashboard/get-admin-dashboard.use-case.spec.ts
@@ -24,6 +24,7 @@ class AdminDashboardReaderStub implements AdminDashboardReaderPort {
 			role: Role.CLIENT,
 			isActive: true,
 			isBlocked: false,
+			activationStatus: 'ACTIVE',
 			createdAt: new Date('2026-05-01T00:00:00.000Z'),
 		},
 	];

--- a/apps/api/src/modules/admin/application/use-cases/resend-admin-user-password-setup/resend-admin-user-password-setup.use-case.ts
+++ b/apps/api/src/modules/admin/application/use-cases/resend-admin-user-password-setup/resend-admin-user-password-setup.use-case.ts
@@ -1,0 +1,120 @@
+import {
+	EMAIL_SENDER_KEY,
+	type EmailSenderPort,
+} from '@app/common/email/ports/email-sender.port';
+import { AppSettingsService } from '@app/common/settings/app-settings.service';
+import {
+	type AdminUserLifecycleLogEvent,
+	AdminUserLifecycleLogger,
+	markAdminUserLifecycleLogError,
+} from '@modules/admin/application/logging/admin-user-lifecycle.logger';
+import {
+	ADMIN_GOVERNANCE_REPOSITORY_KEY,
+	type AdminGovernanceRepositoryPort,
+} from '@modules/admin/application/ports/admin-governance.repository';
+import {
+	AdminUserNotFoundError,
+	AdminUserPasswordSetupUnavailableError,
+} from '@modules/admin/domain/admin.errors';
+import { buildPasswordSetupEmail } from '@modules/users/application/emails/build-password-setup-email';
+import {
+	EMAIL_CONFIRMATION_TOKEN_SERVICE_KEY,
+	type EmailConfirmationTokenServicePort,
+} from '@modules/users/application/ports/email-confirmation-token.port';
+import { Inject, Injectable } from '@nestjs/common';
+
+type ResendAdminUserPasswordSetupInput = {
+	adminUserId: string;
+	targetUserId: string;
+	now: Date;
+};
+
+@Injectable()
+export class ResendAdminUserPasswordSetupUseCase {
+	constructor(
+		@Inject(ADMIN_GOVERNANCE_REPOSITORY_KEY)
+		private readonly governanceRepository: AdminGovernanceRepositoryPort,
+		@Inject(EMAIL_CONFIRMATION_TOKEN_SERVICE_KEY)
+		private readonly tokenService: EmailConfirmationTokenServicePort,
+		@Inject(EMAIL_SENDER_KEY)
+		private readonly emailSender: EmailSenderPort,
+		private readonly appSettings: AppSettingsService,
+		private readonly lifecycleLogger: AdminUserLifecycleLogger,
+	) {}
+
+	async execute(
+		input: ResendAdminUserPasswordSetupInput,
+	): Promise<{ passwordSetupEmailSent: boolean }> {
+		const startedAt = Date.now();
+		const event: AdminUserLifecycleLogEvent = {
+			event: 'admin_user.lifecycle',
+			operation: 'resend_password_setup',
+			admin_user_id: input.adminUserId,
+			target_user_id: input.targetUserId,
+			target_user_status_before: 'PENDING_ACTIVATION',
+			target_user_status_after: 'PENDING_ACTIVATION',
+			side_effects: [],
+		};
+
+		try {
+			const user = await this.governanceRepository.findUserById(
+				input.targetUserId,
+			);
+			if (!user) throw new AdminUserNotFoundError();
+			event.target_user_role = user.role;
+
+			if (user.isActive || user.emailConfirmedAt !== null)
+				throw new AdminUserPasswordSetupUnavailableError();
+
+			const token = this.tokenService.generate();
+			await this.governanceRepository.saveUser(
+				user.issuePasswordReset({
+					tokenHash: token.tokenHash,
+					expiresAt: token.expiresAt,
+					issuedAt: input.now,
+				}),
+			);
+			event.side_effects?.push('password_setup_token_refreshed');
+
+			const emailSent = await this.sendPasswordSetupEmail({
+				email: user.email,
+				username: user.username,
+				token: token.rawToken,
+			});
+			event.email_sent = emailSent;
+			if (emailSent) event.side_effects?.push('password_setup_email_sent');
+			event.outcome = 'success';
+
+			return { passwordSetupEmailSent: emailSent };
+		} catch (error) {
+			markAdminUserLifecycleLogError(event, error);
+			throw error;
+		} finally {
+			this.lifecycleLogger.emit(event, startedAt);
+		}
+	}
+
+	private buildSetupUrl(token: string): string {
+		const url = new URL('/users/set-password', this.appSettings.webAppUrl);
+		url.searchParams.set('token', token);
+		return url.toString();
+	}
+
+	private async sendPasswordSetupEmail(input: {
+		email: string;
+		username: string;
+		token: string;
+	}): Promise<boolean> {
+		try {
+			const email = buildPasswordSetupEmail({
+				username: input.username,
+				setupUrl: this.buildSetupUrl(input.token),
+				expiresInMinutes: this.appSettings.emailConfirmationTokenTtlMinutes,
+			});
+			await this.emailSender.send({ to: input.email, ...email });
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}

--- a/apps/api/src/modules/admin/domain/admin.errors.ts
+++ b/apps/api/src/modules/admin/domain/admin.errors.ts
@@ -15,3 +15,21 @@ export class AdminGovernanceReasonRequiredError extends Error {
 		super('Admin governance reason is required.');
 	}
 }
+
+export class AdminUserEmailAlreadyInUseError extends Error {
+	constructor() {
+		super('User email is already in use.');
+	}
+}
+
+export class AdminUsernameAlreadyInUseError extends Error {
+	constructor() {
+		super('Username is already in use.');
+	}
+}
+
+export class AdminUserPasswordSetupUnavailableError extends Error {
+	constructor() {
+		super('Password setup is unavailable for this user.');
+	}
+}

--- a/apps/api/src/modules/admin/infrastructure/repositories/prisma-admin-dashboard.reader.ts
+++ b/apps/api/src/modules/admin/infrastructure/repositories/prisma-admin-dashboard.reader.ts
@@ -18,6 +18,7 @@ type AdminUserRecord = {
 	role: string;
 	isActive: boolean;
 	isBlocked: boolean;
+	emailConfirmedAt: Date | null;
 	createdAt: Date;
 };
 
@@ -66,6 +67,7 @@ type AdminDashboardPrismaClient = {
 				role: true;
 				isActive: true;
 				isBlocked: true;
+				emailConfirmedAt: true;
 				createdAt: true;
 			};
 			orderBy: { createdAt: 'desc' };
@@ -181,6 +183,7 @@ export class PrismaAdminDashboardReader {
 				role: true,
 				isActive: true,
 				isBlocked: true,
+				emailConfirmedAt: true,
 				createdAt: true,
 			},
 			orderBy: { createdAt: 'desc' },
@@ -190,6 +193,7 @@ export class PrismaAdminDashboardReader {
 		return records.map((record) => ({
 			...record,
 			role: ensurePersistedEnum(Role, record.role, 'user role'),
+			activationStatus: getActivationStatus(record),
 		}));
 	}
 
@@ -269,3 +273,12 @@ export class PrismaAdminDashboardReader {
 		return this.prisma as unknown as AdminDashboardPrismaClient;
 	}
 }
+
+const getActivationStatus = (record: {
+	isActive: boolean;
+	emailConfirmedAt: Date | null;
+}): AdminUserSnapshot['activationStatus'] => {
+	if (record.isActive) return 'ACTIVE';
+	if (!record.emailConfirmedAt) return 'PENDING_ACTIVATION';
+	return 'INACTIVE';
+};

--- a/apps/api/src/modules/admin/presentation/admin.controller.ts
+++ b/apps/api/src/modules/admin/presentation/admin.controller.ts
@@ -1,7 +1,9 @@
 import { ZodValidationPipe } from '@app/common/http/zod-validation.pipe';
 import { BlockAdminUserUseCase } from '@modules/admin/application/use-cases/block-admin-user/block-admin-user.use-case';
+import { CreateAdminUserUseCase } from '@modules/admin/application/use-cases/create-admin-user/create-admin-user.use-case';
 import { ForceCancelAdminOrderUseCase } from '@modules/admin/application/use-cases/force-cancel-admin-order/force-cancel-admin-order.use-case';
 import { GetAdminDashboardUseCase } from '@modules/admin/application/use-cases/get-admin-dashboard/get-admin-dashboard.use-case';
+import { ResendAdminUserPasswordSetupUseCase } from '@modules/admin/application/use-cases/resend-admin-user-password-setup/resend-admin-user-password-setup.use-case';
 import { UnblockAdminUserUseCase } from '@modules/admin/application/use-cases/unblock-admin-user/unblock-admin-user.use-case';
 import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
 import { CurrentUser } from '@modules/auth/presentation/decorators/current-user.decorator';
@@ -20,9 +22,11 @@ import {
 } from '@nestjs/common';
 import { Role } from '@packages/auth/roles/role';
 import {
+	type AdminCreateUserSchemaInput,
 	type AdminIdParamSchemaInput,
 	type AdminListQuerySchemaInput,
 	type AdminReasonSchemaInput,
+	adminCreateUserSchema,
 	adminIdParamSchema,
 	adminListQuerySchema,
 	adminReasonSchema,
@@ -34,6 +38,8 @@ import {
 export class AdminController {
 	constructor(
 		private readonly dashboard: GetAdminDashboardUseCase,
+		private readonly createUser: CreateAdminUserUseCase,
+		private readonly resendPasswordSetup: ResendAdminUserPasswordSetupUseCase,
 		private readonly blockUser: BlockAdminUserUseCase,
 		private readonly unblockUser: UnblockAdminUserUseCase,
 		private readonly forceCancelOrder: ForceCancelAdminOrderUseCase,
@@ -51,6 +57,35 @@ export class AdminController {
 		@CurrentUser() _currentUser: AuthenticatedUser,
 	) {
 		return await this.dashboard.listUsers(query);
+	}
+
+	@Post('users')
+	async create(
+		@Body(new ZodValidationPipe(adminCreateUserSchema))
+		body: AdminCreateUserSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.createUser.execute({
+			adminUserId: currentUser.id,
+			username: body.username,
+			email: body.email,
+			role: body.role as Role,
+			now: new Date(),
+		});
+	}
+
+	@Post('users/:userId/resend-password-setup')
+	@HttpCode(200)
+	async resendSetupEmail(
+		@Param('userId', new ZodValidationPipe(adminIdParamSchema))
+		userId: AdminIdParamSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.resendPasswordSetup.execute({
+			adminUserId: currentUser.id,
+			targetUserId: userId,
+			now: new Date(),
+		});
 	}
 
 	@Post('users/:userId/block')

--- a/apps/api/src/modules/admin/presentation/admin.request-schemas.ts
+++ b/apps/api/src/modules/admin/presentation/admin.request-schemas.ts
@@ -9,6 +9,18 @@ export const adminIdParamSchema = z.string().trim().min(1);
 
 export type AdminIdParamSchemaInput = z.infer<typeof adminIdParamSchema>;
 
+export const adminCreateUserSchema = z.object({
+	username: z.string().trim().min(1),
+	email: z
+		.string()
+		.trim()
+		.email()
+		.transform((value) => value.toLowerCase()),
+	role: z.enum(['CLIENT', 'BOOSTER', 'ADMIN']),
+});
+
+export type AdminCreateUserSchemaInput = z.infer<typeof adminCreateUserSchema>;
+
 export const adminListQuerySchema = z.object({
 	limit: z.coerce.number().int().min(1).max(100).default(25),
 	query: z.string().trim().min(1).max(120).optional(),

--- a/apps/api/src/modules/auth/application/use-cases/login/login.use-case.spec.ts
+++ b/apps/api/src/modules/auth/application/use-cases/login/login.use-case.spec.ts
@@ -45,6 +45,14 @@ class InMemoryUserRepository implements UserRepositoryPort {
 		);
 	}
 
+	async findByPasswordResetTokenHash(tokenHash: string): Promise<User | null> {
+		return (
+			[...this.users.values()].find(
+				(user) => user.passwordResetTokenHash === tokenHash,
+			) ?? null
+		);
+	}
+
 	async create(user: User): Promise<User> {
 		const createdUser = User.rehydrate({
 			id: `user-${this.nextId++}`,
@@ -57,6 +65,8 @@ class InMemoryUserRepository implements UserRepositoryPort {
 			emailConfirmedAt: user.emailConfirmedAt,
 			emailConfirmationTokenHash: user.emailConfirmationTokenHash,
 			emailConfirmationTokenExpiresAt: user.emailConfirmationTokenExpiresAt,
+			passwordResetTokenHash: user.passwordResetTokenHash,
+			passwordResetTokenExpiresAt: user.passwordResetTokenExpiresAt,
 			createdAt: new Date('2026-03-17T00:00:00.000Z'),
 			updatedAt: new Date('2026-03-17T00:00:00.000Z'),
 		});
@@ -225,6 +235,47 @@ describe('LoginUseCase', () => {
 				password: 'Secret123456!',
 			}),
 		).rejects.toBeInstanceOf(AuthUserInactiveError);
+	});
+
+	it('rejects pending users without a password hash before verifying password', async () => {
+		const users = new InMemoryUserRepository();
+		await users.create(
+			User.createPendingFromAdmin({
+				username: 'summoner1',
+				email: 'summoner1@example.com',
+				role: Role.CLIENT,
+				passwordResetTokenHash: 'token-hash',
+				passwordResetTokenExpiresAt: new Date('2026-03-18T00:00:00.000Z'),
+			}),
+		);
+		const passwordHasher: PasswordHasherPort = {
+			hash: jest.fn(),
+			verify: jest.fn(),
+		};
+		const authSessions = new InMemoryAuthSessionRepository();
+		const accessTokenService: AccessTokenServicePort = {
+			sign: jest.fn(),
+			verify: jest.fn(),
+		};
+		const refreshTokenService: RefreshTokenServicePort = {
+			generate: jest.fn(),
+			hash: jest.fn(),
+		};
+		const useCase = new LoginUseCase(
+			users,
+			passwordHasher,
+			authSessions,
+			accessTokenService,
+			refreshTokenService,
+		);
+
+		await expect(
+			useCase.execute({
+				email: 'summoner1@example.com',
+				password: 'Secret123456!',
+			}),
+		).rejects.toBeInstanceOf(AuthInvalidCredentialsError);
+		expect(passwordHasher.verify).not.toHaveBeenCalled();
 	});
 
 	it('rejects blocked users', async () => {

--- a/apps/api/src/modules/auth/application/use-cases/login/login.use-case.ts
+++ b/apps/api/src/modules/auth/application/use-cases/login/login.use-case.ts
@@ -61,6 +61,7 @@ export class LoginUseCase {
 		const user = await this.userRepository.findByEmail(normalizedEmail);
 		if (!user) throw new AuthInvalidCredentialsError();
 
+		if (!user.passwordHash) throw new AuthInvalidCredentialsError();
 		const passwordMatches = await this.passwordHasher.verify(
 			input.password,
 			user.passwordHash,

--- a/apps/api/src/modules/auth/application/use-cases/refresh-session/refresh-session.use-case.spec.ts
+++ b/apps/api/src/modules/auth/application/use-cases/refresh-session/refresh-session.use-case.spec.ts
@@ -32,6 +32,10 @@ class InMemoryUserRepository implements UserRepositoryPort {
 		return null;
 	}
 
+	async findByPasswordResetTokenHash(): Promise<User | null> {
+		return null;
+	}
+
 	async create(user: User): Promise<User> {
 		this.users.set(user.id, user);
 		return user;

--- a/apps/api/src/modules/users/application/emails/build-password-setup-email.ts
+++ b/apps/api/src/modules/users/application/emails/build-password-setup-email.ts
@@ -1,0 +1,102 @@
+import type { SendEmailInput } from '@app/common/email/ports/email-sender.port';
+
+type PasswordSetupEmailInput = {
+	username: string;
+	setupUrl: string;
+	expiresInMinutes: number;
+};
+
+type PasswordSetupEmailContent = Pick<
+	SendEmailInput,
+	'subject' | 'html' | 'text'
+>;
+
+const BRAND_NAME = 'EloNew';
+const ACCENT_COLOR = '#0ea5e9';
+const BACKGROUND_COLOR = '#09090b';
+const SURFACE_COLOR = '#0d0d0f';
+const TEXT_COLOR = '#ffffff';
+const MUTED_TEXT_COLOR = 'rgba(255,255,255,0.55)';
+
+export const buildPasswordSetupEmail = (
+	input: PasswordSetupEmailInput,
+): PasswordSetupEmailContent => {
+	const username = escapeHtml(input.username);
+	const setupUrl = escapeHtml(input.setupUrl);
+
+	const html = `
+<!doctype html>
+<html lang="pt-BR">
+	<body style="margin:0;padding:0;background-color:${BACKGROUND_COLOR};">
+		<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${BACKGROUND_COLOR};padding:32px 16px;">
+			<tr>
+				<td align="center">
+					<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background-color:${SURFACE_COLOR};border:1px solid rgba(255,255,255,0.08);border-radius:12px;overflow:hidden;">
+						<tr>
+							<td style="height:4px;background:linear-gradient(90deg,transparent,${ACCENT_COLOR},transparent);"></td>
+						</tr>
+						<tr>
+							<td style="padding:40px 40px 8px;font-family:Arial,Helvetica,sans-serif;">
+								<p style="margin:0;color:${ACCENT_COLOR};font-size:12px;font-weight:bold;letter-spacing:4px;text-transform:uppercase;">${BRAND_NAME}</p>
+								<h1 style="margin:16px 0 0;color:${TEXT_COLOR};font-size:22px;font-weight:bold;letter-spacing:1px;">Defina sua senha</h1>
+							</td>
+						</tr>
+						<tr>
+							<td style="padding:16px 40px 0;font-family:Arial,Helvetica,sans-serif;">
+								<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:14px;line-height:1.6;">
+									Olá, <strong style="color:${TEXT_COLOR};">${username}</strong>. Sua conta na ${BRAND_NAME} foi criada por um administrador. Clique no botão abaixo para definir sua senha e ativar seu acesso.
+								</p>
+							</td>
+						</tr>
+						<tr>
+							<td align="center" style="padding:32px 40px;">
+								<a href="${setupUrl}" style="display:inline-block;background-color:${ACCENT_COLOR};color:${BACKGROUND_COLOR};font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:bold;letter-spacing:2px;text-transform:uppercase;text-decoration:none;padding:14px 32px;border-radius:8px;">Definir senha</a>
+							</td>
+						</tr>
+						<tr>
+							<td style="padding:0 40px 8px;font-family:Arial,Helvetica,sans-serif;">
+								<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:12px;line-height:1.6;">
+									Se o botão não funcionar, copie e cole este link no seu navegador:
+								</p>
+								<p style="margin:8px 0 0;word-break:break-all;">
+									<a href="${setupUrl}" style="color:${ACCENT_COLOR};font-size:12px;text-decoration:none;">${setupUrl}</a>
+								</p>
+							</td>
+						</tr>
+						<tr>
+							<td style="padding:24px 40px 40px;font-family:Arial,Helvetica,sans-serif;border-top:1px solid rgba(255,255,255,0.06);">
+								<p style="margin:0;color:rgba(255,255,255,0.35);font-size:11px;line-height:1.6;">
+									Este link expira em ${input.expiresInMinutes} minutos. Se você não esperava este acesso, ignore este e-mail.
+								</p>
+							</td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+	</body>
+</html>`;
+
+	const text = [
+		`Olá, ${input.username}.`,
+		'',
+		`Defina sua senha na ${BRAND_NAME} acessando o link abaixo:`,
+		input.setupUrl,
+		'',
+		`Este link expira em ${input.expiresInMinutes} minutos. Se você não esperava este acesso, ignore este e-mail.`,
+	].join('\n');
+
+	return {
+		subject: `Defina sua senha na ${BRAND_NAME}`,
+		html,
+		text,
+	};
+};
+
+const escapeHtml = (value: string) =>
+	value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#039;');

--- a/apps/api/src/modules/users/application/ports/user-repository.port.ts
+++ b/apps/api/src/modules/users/application/ports/user-repository.port.ts
@@ -7,6 +7,7 @@ export interface UserRepositoryPort {
 	findByEmail(email: string): Promise<User | null>;
 	findByUsername(username: string): Promise<User | null>;
 	findByEmailConfirmationTokenHash(tokenHash: string): Promise<User | null>;
+	findByPasswordResetTokenHash(tokenHash: string): Promise<User | null>;
 	create(user: User): Promise<User>;
 	save(user: User): Promise<void>;
 }

--- a/apps/api/src/modules/users/application/use-cases/confirm-email/confirm-email.use-case.spec.ts
+++ b/apps/api/src/modules/users/application/use-cases/confirm-email/confirm-email.use-case.spec.ts
@@ -35,6 +35,14 @@ class InMemoryUserRepository implements UserRepositoryPort {
 		);
 	}
 
+	async findByPasswordResetTokenHash(tokenHash: string): Promise<User | null> {
+		return (
+			[...this.users.values()].find(
+				(user) => user.passwordResetTokenHash === tokenHash,
+			) ?? null
+		);
+	}
+
 	async create(user: User): Promise<User> {
 		const createdUser = User.rehydrate({
 			id: `user-${this.nextId++}`,
@@ -46,6 +54,8 @@ class InMemoryUserRepository implements UserRepositoryPort {
 			emailConfirmedAt: user.emailConfirmedAt,
 			emailConfirmationTokenHash: user.emailConfirmationTokenHash,
 			emailConfirmationTokenExpiresAt: user.emailConfirmationTokenExpiresAt,
+			passwordResetTokenHash: user.passwordResetTokenHash,
+			passwordResetTokenExpiresAt: user.passwordResetTokenExpiresAt,
 			createdAt: new Date('2026-03-11T00:00:00.000Z'),
 			updatedAt: new Date('2026-03-11T00:00:00.000Z'),
 		});

--- a/apps/api/src/modules/users/application/use-cases/set-password/set-password.use-case.spec.ts
+++ b/apps/api/src/modules/users/application/use-cases/set-password/set-password.use-case.spec.ts
@@ -1,0 +1,128 @@
+import type { EmailConfirmationTokenServicePort } from '@modules/users/application/ports/email-confirmation-token.port';
+import type { PasswordHasherPort } from '@modules/users/application/ports/password-hasher.port';
+import type { UserRepositoryPort } from '@modules/users/application/ports/user-repository.port';
+import { SetPasswordUseCase } from '@modules/users/application/use-cases/set-password/set-password.use-case';
+import { User } from '@modules/users/domain/user.entity';
+import { UserPasswordResetTokenInvalidError } from '@modules/users/domain/user.errors';
+import { Role } from '@packages/auth/roles/role';
+
+class InMemoryUserRepository implements UserRepositoryPort {
+	private readonly users = new Map<string, User>();
+	private nextId = 1;
+
+	async findById(id: string): Promise<User | null> {
+		return this.users.get(id) ?? null;
+	}
+
+	async findByEmail(): Promise<User | null> {
+		return null;
+	}
+
+	async findByUsername(): Promise<User | null> {
+		return null;
+	}
+
+	async findByEmailConfirmationTokenHash(): Promise<User | null> {
+		return null;
+	}
+
+	async findByPasswordResetTokenHash(tokenHash: string): Promise<User | null> {
+		return (
+			[...this.users.values()].find(
+				(user) => user.passwordResetTokenHash === tokenHash,
+			) ?? null
+		);
+	}
+
+	async create(user: User): Promise<User> {
+		const createdUser = User.rehydrate({
+			id: `user-${this.nextId++}`,
+			username: user.username,
+			email: user.email,
+			passwordHash: user.passwordHash,
+			role: user.role,
+			isActive: user.isActive,
+			isBlocked: user.isBlocked,
+			emailConfirmedAt: user.emailConfirmedAt,
+			emailConfirmationTokenHash: user.emailConfirmationTokenHash,
+			emailConfirmationTokenExpiresAt: user.emailConfirmationTokenExpiresAt,
+			passwordResetTokenHash: user.passwordResetTokenHash,
+			passwordResetTokenExpiresAt: user.passwordResetTokenExpiresAt,
+			createdAt: new Date('2026-06-26T10:00:00.000Z'),
+			updatedAt: new Date('2026-06-26T10:00:00.000Z'),
+		});
+		this.users.set(createdUser.id, createdUser);
+		return createdUser;
+	}
+
+	async save(user: User): Promise<void> {
+		this.users.set(user.id, user);
+	}
+}
+
+describe('SetPasswordUseCase', () => {
+	it('sets the password and activates a pending admin-created user', async () => {
+		const users = new InMemoryUserRepository();
+		const pendingUser = await users.create(
+			User.createPendingFromAdmin({
+				username: 'booster',
+				email: 'booster@example.com',
+				role: Role.BOOSTER,
+				passwordResetTokenHash: 'hashed-token',
+				passwordResetTokenExpiresAt: new Date(Date.now() + 60_000),
+			}),
+		);
+		const passwordHasher: PasswordHasherPort = {
+			hash: jest.fn().mockResolvedValue('new-hash'),
+			verify: jest.fn(),
+		};
+		const tokenService: EmailConfirmationTokenServicePort = {
+			generate: jest.fn(),
+			hash: jest.fn().mockReturnValue('hashed-token'),
+		};
+		const useCase = new SetPasswordUseCase(users, passwordHasher, tokenService);
+
+		await expect(
+			useCase.execute({
+				token: 'raw-token',
+				password: 'new-password-123',
+			}),
+		).resolves.toEqual({ ok: true });
+
+		const activatedUser = await users.findById(pendingUser.id);
+		expect(activatedUser?.passwordHash).toBe('new-hash');
+		expect(activatedUser?.isActive).toBe(true);
+		expect(activatedUser?.emailConfirmedAt).toBeInstanceOf(Date);
+		expect(activatedUser?.passwordResetTokenHash).toBeNull();
+	});
+
+	it('rejects an expired password setup token', async () => {
+		const users = new InMemoryUserRepository();
+		await users.create(
+			User.createPendingFromAdmin({
+				username: 'booster',
+				email: 'booster@example.com',
+				role: Role.BOOSTER,
+				passwordResetTokenHash: 'hashed-token',
+				passwordResetTokenExpiresAt: new Date(Date.now() - 60_000),
+			}),
+		);
+		const passwordHasher: PasswordHasherPort = {
+			hash: jest.fn(),
+			verify: jest.fn(),
+		};
+		const tokenService: EmailConfirmationTokenServicePort = {
+			generate: jest.fn(),
+			hash: jest.fn().mockReturnValue('hashed-token'),
+		};
+		const useCase = new SetPasswordUseCase(users, passwordHasher, tokenService);
+
+		await expect(
+			useCase.execute({
+				token: 'raw-token',
+				password: 'new-password-123',
+			}),
+		).rejects.toThrow(UserPasswordResetTokenInvalidError);
+		expect(passwordHasher.hash).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/modules/users/application/use-cases/set-password/set-password.use-case.ts
+++ b/apps/api/src/modules/users/application/use-cases/set-password/set-password.use-case.ts
@@ -1,0 +1,45 @@
+import {
+	EMAIL_CONFIRMATION_TOKEN_SERVICE_KEY,
+	type EmailConfirmationTokenServicePort,
+} from '@modules/users/application/ports/email-confirmation-token.port';
+import {
+	PASSWORD_HASHER_KEY,
+	type PasswordHasherPort,
+} from '@modules/users/application/ports/password-hasher.port';
+import {
+	USER_REPOSITORY_KEY,
+	type UserRepositoryPort,
+} from '@modules/users/application/ports/user-repository.port';
+import { UserPasswordResetTokenInvalidError } from '@modules/users/domain/user.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+type SetPasswordInput = {
+	token: string;
+	password: string;
+};
+
+@Injectable()
+export class SetPasswordUseCase {
+	constructor(
+		@Inject(USER_REPOSITORY_KEY)
+		private readonly userRepository: UserRepositoryPort,
+		@Inject(PASSWORD_HASHER_KEY)
+		private readonly passwordHasher: PasswordHasherPort,
+		@Inject(EMAIL_CONFIRMATION_TOKEN_SERVICE_KEY)
+		private readonly tokenService: EmailConfirmationTokenServicePort,
+	) {}
+
+	async execute(input: SetPasswordInput): Promise<{ ok: true }> {
+		const tokenHash = this.tokenService.hash(input.token);
+		const user =
+			await this.userRepository.findByPasswordResetTokenHash(tokenHash);
+		const now = new Date();
+		if (!user || !user.canSetPassword(now))
+			throw new UserPasswordResetTokenInvalidError();
+
+		const passwordHash = await this.passwordHasher.hash(input.password);
+		await this.userRepository.save(user.setPassword(passwordHash, now));
+
+		return { ok: true };
+	}
+}

--- a/apps/api/src/modules/users/application/use-cases/sign-up/sign-up.use-case.spec.ts
+++ b/apps/api/src/modules/users/application/use-cases/sign-up/sign-up.use-case.spec.ts
@@ -47,6 +47,14 @@ class InMemoryUserRepository implements UserRepositoryPort {
 		);
 	}
 
+	async findByPasswordResetTokenHash(tokenHash: string): Promise<User | null> {
+		return (
+			[...this.users.values()].find(
+				(user) => user.passwordResetTokenHash === tokenHash,
+			) ?? null
+		);
+	}
+
 	async create(user: User): Promise<User> {
 		const createdUser = User.rehydrate({
 			id: `user-${this.nextId++}`,
@@ -58,6 +66,8 @@ class InMemoryUserRepository implements UserRepositoryPort {
 			emailConfirmedAt: user.emailConfirmedAt,
 			emailConfirmationTokenHash: user.emailConfirmationTokenHash,
 			emailConfirmationTokenExpiresAt: user.emailConfirmationTokenExpiresAt,
+			passwordResetTokenHash: user.passwordResetTokenHash,
+			passwordResetTokenExpiresAt: user.passwordResetTokenExpiresAt,
 			createdAt: new Date('2026-03-11T00:00:00.000Z'),
 			updatedAt: new Date('2026-03-11T00:00:00.000Z'),
 		});

--- a/apps/api/src/modules/users/domain/user.entity.ts
+++ b/apps/api/src/modules/users/domain/user.entity.ts
@@ -8,17 +8,27 @@ type CreatePendingUserInput = {
 	emailConfirmationTokenExpiresAt: Date;
 };
 
+type CreatePendingAdminUserInput = {
+	username: string;
+	email: string;
+	role: Role;
+	passwordResetTokenHash: string;
+	passwordResetTokenExpiresAt: Date;
+};
+
 type RehydrateUserInput = {
 	id: string;
 	username: string;
 	email: string;
-	passwordHash: string;
+	passwordHash: string | null;
 	role: Role;
 	isActive: boolean;
 	isBlocked?: boolean;
 	emailConfirmedAt: Date | null;
 	emailConfirmationTokenHash: string | null;
 	emailConfirmationTokenExpiresAt: Date | null;
+	passwordResetTokenHash?: string | null;
+	passwordResetTokenExpiresAt?: Date | null;
 	createdAt: Date;
 	updatedAt: Date;
 };
@@ -28,13 +38,15 @@ export class User {
 		public readonly id: string,
 		public readonly username: string,
 		public readonly email: string,
-		public readonly passwordHash: string,
+		public readonly passwordHash: string | null,
 		public readonly role: Role,
 		public readonly isActive: boolean,
 		public readonly isBlocked: boolean,
 		public readonly emailConfirmedAt: Date | null,
 		public readonly emailConfirmationTokenHash: string | null,
 		public readonly emailConfirmationTokenExpiresAt: Date | null,
+		public readonly passwordResetTokenHash: string | null,
+		public readonly passwordResetTokenExpiresAt: Date | null,
 		public readonly createdAt: Date,
 		public readonly updatedAt: Date,
 	) {}
@@ -51,6 +63,27 @@ export class User {
 			null,
 			input.emailConfirmationTokenHash,
 			input.emailConfirmationTokenExpiresAt,
+			null,
+			null,
+			new Date(),
+			new Date(),
+		);
+	}
+
+	static createPendingFromAdmin(input: CreatePendingAdminUserInput): User {
+		return new User(
+			'',
+			input.username,
+			input.email,
+			null,
+			input.role,
+			false,
+			false,
+			null,
+			null,
+			null,
+			input.passwordResetTokenHash ?? null,
+			input.passwordResetTokenExpiresAt ?? null,
 			new Date(),
 			new Date(),
 		);
@@ -68,6 +101,8 @@ export class User {
 			input.emailConfirmedAt,
 			input.emailConfirmationTokenHash,
 			input.emailConfirmationTokenExpiresAt,
+			input.passwordResetTokenHash ?? null,
+			input.passwordResetTokenExpiresAt ?? null,
 			input.createdAt,
 			input.updatedAt,
 		);
@@ -94,8 +129,62 @@ export class User {
 			confirmedAt,
 			null,
 			null,
+			this.passwordResetTokenHash,
+			this.passwordResetTokenExpiresAt,
 			this.createdAt,
 			confirmedAt,
+		);
+	}
+
+	canSetPassword(referenceDate: Date): boolean {
+		return (
+			!this.isActive &&
+			this.emailConfirmedAt === null &&
+			this.passwordResetTokenHash !== null &&
+			this.passwordResetTokenExpiresAt !== null &&
+			this.passwordResetTokenExpiresAt >= referenceDate
+		);
+	}
+
+	setPassword(passwordHash: string, confirmedAt: Date): User {
+		return new User(
+			this.id,
+			this.username,
+			this.email,
+			passwordHash,
+			this.role,
+			true,
+			this.isBlocked,
+			confirmedAt,
+			null,
+			null,
+			null,
+			null,
+			this.createdAt,
+			confirmedAt,
+		);
+	}
+
+	issuePasswordReset(input: {
+		tokenHash: string;
+		expiresAt: Date;
+		issuedAt: Date;
+	}): User {
+		return new User(
+			this.id,
+			this.username,
+			this.email,
+			this.passwordHash,
+			this.role,
+			this.isActive,
+			this.isBlocked,
+			this.emailConfirmedAt,
+			this.emailConfirmationTokenHash,
+			this.emailConfirmationTokenExpiresAt,
+			input.tokenHash,
+			input.expiresAt,
+			this.createdAt,
+			input.issuedAt,
 		);
 	}
 
@@ -111,6 +200,8 @@ export class User {
 			this.emailConfirmedAt,
 			this.emailConfirmationTokenHash,
 			this.emailConfirmationTokenExpiresAt,
+			this.passwordResetTokenHash,
+			this.passwordResetTokenExpiresAt,
 			this.createdAt,
 			new Date(),
 		);
@@ -128,6 +219,8 @@ export class User {
 			this.emailConfirmedAt,
 			this.emailConfirmationTokenHash,
 			this.emailConfirmationTokenExpiresAt,
+			this.passwordResetTokenHash,
+			this.passwordResetTokenExpiresAt,
 			this.createdAt,
 			new Date(),
 		);

--- a/apps/api/src/modules/users/domain/user.errors.ts
+++ b/apps/api/src/modules/users/domain/user.errors.ts
@@ -15,3 +15,9 @@ export class UserEmailConfirmationTokenInvalidError extends Error {
 		super('Invalid confirmation token.');
 	}
 }
+
+export class UserPasswordResetTokenInvalidError extends Error {
+	constructor() {
+		super('Invalid password reset token.');
+	}
+}

--- a/apps/api/src/modules/users/infrastructure/repositories/prisma-user.repository.ts
+++ b/apps/api/src/modules/users/infrastructure/repositories/prisma-user.repository.ts
@@ -13,13 +13,15 @@ type UserRecord = {
 	id: string;
 	username: string;
 	email: string;
-	password: string;
+	password: string | null;
 	role: string;
 	isActive: boolean;
 	isBlocked: boolean;
 	emailConfirmedAt: Date | null;
 	emailConfirmationTokenHash: string | null;
 	emailConfirmationTokenExpiresAt: Date | null;
+	passwordResetTokenHash: string | null;
+	passwordResetTokenExpiresAt: Date | null;
 	createdAt: Date;
 	updatedAt: Date;
 };
@@ -30,19 +32,22 @@ type UserDelegate = {
 			| { id: string }
 			| { email: string }
 			| { username: string }
-			| { emailConfirmationTokenHash: string };
+			| { emailConfirmationTokenHash: string }
+			| { passwordResetTokenHash: string };
 	}): Promise<UserRecord | null>;
 	create(args: {
 		data: {
 			username: string;
 			email: string;
-			password: string;
+			password: string | null;
 			role: string;
 			isActive: boolean;
 			isBlocked: boolean;
 			emailConfirmedAt: Date | null;
 			emailConfirmationTokenHash: string | null;
 			emailConfirmationTokenExpiresAt: Date | null;
+			passwordResetTokenHash: string | null;
+			passwordResetTokenExpiresAt: Date | null;
 		};
 	}): Promise<UserRecord>;
 	update(args: {
@@ -50,13 +55,15 @@ type UserDelegate = {
 		data: {
 			username: string;
 			email: string;
-			password: string;
+			password: string | null;
 			role: string;
 			isActive: boolean;
 			isBlocked: boolean;
 			emailConfirmedAt: Date | null;
 			emailConfirmationTokenHash: string | null;
 			emailConfirmationTokenExpiresAt: Date | null;
+			passwordResetTokenHash: string | null;
+			passwordResetTokenExpiresAt: Date | null;
 		};
 	}): Promise<UserRecord>;
 };
@@ -107,6 +114,15 @@ export class PrismaUserRepository implements UserRepositoryPort {
 		return this.mapUserFromRecord(record);
 	}
 
+	async findByPasswordResetTokenHash(tokenHash: string): Promise<User | null> {
+		const record = await this.getDelegate().findUnique({
+			where: { passwordResetTokenHash: tokenHash },
+		});
+		if (!record) return null;
+
+		return this.mapUserFromRecord(record);
+	}
+
 	async create(user: User): Promise<User> {
 		try {
 			const record = await this.getDelegate().create({
@@ -147,6 +163,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
 			emailConfirmedAt: record.emailConfirmedAt,
 			emailConfirmationTokenHash: record.emailConfirmationTokenHash,
 			emailConfirmationTokenExpiresAt: record.emailConfirmationTokenExpiresAt,
+			passwordResetTokenHash: record.passwordResetTokenHash,
+			passwordResetTokenExpiresAt: record.passwordResetTokenExpiresAt,
 			createdAt: record.createdAt,
 			updatedAt: record.updatedAt,
 		});
@@ -163,6 +181,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
 			emailConfirmedAt: user.emailConfirmedAt,
 			emailConfirmationTokenHash: user.emailConfirmationTokenHash,
 			emailConfirmationTokenExpiresAt: user.emailConfirmationTokenExpiresAt,
+			passwordResetTokenHash: user.passwordResetTokenHash,
+			passwordResetTokenExpiresAt: user.passwordResetTokenExpiresAt,
 		};
 	}
 

--- a/apps/api/src/modules/users/presentation/users.controller.ts
+++ b/apps/api/src/modules/users/presentation/users.controller.ts
@@ -1,11 +1,14 @@
 import { ZodValidationPipe } from '@app/common/http/zod-validation.pipe';
 import { AppSettingsService } from '@app/common/settings/app-settings.service';
 import { ConfirmEmailUseCase } from '@modules/users/application/use-cases/confirm-email/confirm-email.use-case';
+import { SetPasswordUseCase } from '@modules/users/application/use-cases/set-password/set-password.use-case';
 import { SignUpUseCase } from '@modules/users/application/use-cases/sign-up/sign-up.use-case';
 import {
 	type ConfirmEmailSchemaInput,
 	confirmEmailSchema,
+	type SetPasswordSchemaInput,
 	type SignUpSchemaInput,
+	setPasswordSchema,
 	signUpSchema,
 } from '@modules/users/presentation/users.request-schemas';
 import { UsersThrottlerGuard } from '@modules/users/presentation/users-throttler.guard';
@@ -17,6 +20,7 @@ export class UsersController {
 	constructor(
 		private readonly signUpUseCase: SignUpUseCase,
 		private readonly confirmEmailUseCase: ConfirmEmailUseCase,
+		private readonly setPasswordUseCase: SetPasswordUseCase,
 		private readonly appSettings: AppSettingsService,
 	) {}
 
@@ -51,6 +55,17 @@ export class UsersController {
 	) {
 		return this.confirmEmailUseCase.execute({
 			token: body.token,
+		});
+	}
+
+	@Post('set-password')
+	setPassword(
+		@Body(new ZodValidationPipe(setPasswordSchema))
+		body: SetPasswordSchemaInput,
+	) {
+		return this.setPasswordUseCase.execute({
+			token: body.token,
+			password: body.password,
 		});
 	}
 }

--- a/apps/api/src/modules/users/presentation/users.request-schemas.ts
+++ b/apps/api/src/modules/users/presentation/users.request-schemas.ts
@@ -17,3 +17,10 @@ export const confirmEmailSchema = z.object({
 });
 
 export type ConfirmEmailSchemaInput = z.infer<typeof confirmEmailSchema>;
+
+export const setPasswordSchema = z.object({
+	token: z.string().trim().min(1),
+	password: z.string().min(12).max(128),
+});
+
+export type SetPasswordSchemaInput = z.infer<typeof setPasswordSchema>;

--- a/apps/api/src/modules/users/users.module.ts
+++ b/apps/api/src/modules/users/users.module.ts
@@ -5,6 +5,7 @@ import { EMAIL_CONFIRMATION_TOKEN_SERVICE_KEY } from '@modules/users/application
 import { PASSWORD_HASHER_KEY } from '@modules/users/application/ports/password-hasher.port';
 import { USER_REPOSITORY_KEY } from '@modules/users/application/ports/user-repository.port';
 import { ConfirmEmailUseCase } from '@modules/users/application/use-cases/confirm-email/confirm-email.use-case';
+import { SetPasswordUseCase } from '@modules/users/application/use-cases/set-password/set-password.use-case';
 import { SignUpUseCase } from '@modules/users/application/use-cases/sign-up/sign-up.use-case';
 import { PrismaUserRepository } from '@modules/users/infrastructure/repositories/prisma-user.repository';
 import { Argon2PasswordHasher } from '@modules/users/infrastructure/security/argon2-password-hasher';
@@ -44,7 +45,12 @@ import { Module } from '@nestjs/common';
 		},
 		SignUpUseCase,
 		ConfirmEmailUseCase,
+		SetPasswordUseCase,
 	],
-	exports: [USER_REPOSITORY_KEY, PASSWORD_HASHER_KEY],
+	exports: [
+		USER_REPOSITORY_KEY,
+		PASSWORD_HASHER_KEY,
+		EMAIL_CONFIRMATION_TOKEN_SERVICE_KEY,
+	],
 })
 export class UsersModule {}

--- a/apps/api/test/admin.e2e-spec.ts
+++ b/apps/api/test/admin.e2e-spec.ts
@@ -1,4 +1,7 @@
-import type { AdminDashboardReaderPort } from '@modules/admin/application/ports/admin-dashboard-reader.port';
+import type {
+	AdminDashboardReaderPort,
+	AdminUserSnapshot,
+} from '@modules/admin/application/ports/admin-dashboard-reader.port';
 import { ADMIN_DASHBOARD_READER_KEY } from '@modules/admin/application/ports/admin-dashboard-reader.port';
 import type { AdminGovernanceRepositoryPort } from '@modules/admin/application/ports/admin-governance.repository';
 import { ADMIN_GOVERNANCE_REPOSITORY_KEY } from '@modules/admin/application/ports/admin-governance.repository';
@@ -25,7 +28,7 @@ describe('Admin dashboard (e2e)', () => {
 			};
 		}
 
-		async listUsers() {
+		async listUsers(): Promise<AdminUserSnapshot[]> {
 			return [
 				{
 					id: 'user-1',
@@ -34,6 +37,7 @@ describe('Admin dashboard (e2e)', () => {
 					role: Role.CLIENT,
 					isActive: true,
 					isBlocked: false,
+					activationStatus: 'ACTIVE',
 					createdAt: new Date('2026-04-10T10:00:00.000Z'),
 				},
 			];

--- a/apps/api/test/support/in-memory/users/in-memory-user.repository.ts
+++ b/apps/api/test/support/in-memory/users/in-memory-user.repository.ts
@@ -30,6 +30,14 @@ export class InMemoryUserRepository implements UserRepositoryPort {
 		);
 	}
 
+	findByPasswordResetTokenHash(tokenHash: string): Promise<User | null> {
+		return Promise.resolve(
+			[...this.users.values()].find(
+				(user) => user.passwordResetTokenHash === tokenHash,
+			) ?? null,
+		);
+	}
+
 	create(user: User): Promise<User> {
 		const createdUser = User.rehydrate({
 			id: `user-${this.nextId++}`,
@@ -42,6 +50,8 @@ export class InMemoryUserRepository implements UserRepositoryPort {
 			emailConfirmedAt: user.emailConfirmedAt,
 			emailConfirmationTokenHash: user.emailConfirmationTokenHash,
 			emailConfirmationTokenExpiresAt: user.emailConfirmationTokenExpiresAt,
+			passwordResetTokenHash: user.passwordResetTokenHash,
+			passwordResetTokenExpiresAt: user.passwordResetTokenExpiresAt,
 			createdAt: new Date(),
 			updatedAt: new Date(),
 		});

--- a/apps/web/src/app/(auth)/users/set-password/page.tsx
+++ b/apps/web/src/app/(auth)/users/set-password/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { SetPasswordForm } from '@/modules/auth/presentation/set-password-form';
+import { getButtonClassName } from '@/shared/ui/components/button';
+
+type SetPasswordPageProps = {
+	searchParams: Promise<{ token?: string }>;
+};
+
+export default async function SetPasswordPage({
+	searchParams,
+}: SetPasswordPageProps) {
+	const { token } = await searchParams;
+
+	if (!token) {
+		return (
+			<div className="text-center space-y-6 py-8">
+				<h1 className="text-xl font-black uppercase tracking-[0.22em] text-white">
+					Link inválido
+				</h1>
+				<p className="text-[10px] uppercase tracking-widest leading-relaxed text-white/40">
+					Solicite um novo e-mail de acesso para definir sua senha.
+				</p>
+				<Link
+					href="/login"
+					className={getButtonClassName({
+						variant: 'outline',
+						size: 'md',
+						className:
+							'w-full text-[10px] font-black uppercase tracking-[0.2em]',
+					})}
+				>
+					Voltar para o login
+				</Link>
+			</div>
+		);
+	}
+
+	return <SetPasswordForm token={token} />;
+}

--- a/apps/web/src/modules/admin-dashboard/actions/admin-actions.ts
+++ b/apps/web/src/modules/admin-dashboard/actions/admin-actions.ts
@@ -11,6 +11,7 @@ import { getAuthSession } from '@/shared/auth/session';
 import type { ListChatMessagesResponseOutput } from '@/shared/chat/chat-contracts';
 import { assertSameOriginRequest } from '@/shared/security/origin';
 import type {
+	AdminCreateUserInput,
 	AdminDashboardOutput,
 	AdminGovernanceInput,
 	AdminMetricsOutput,
@@ -18,9 +19,13 @@ import type {
 	AdminSupportTicketOutput,
 	AdminUserOutput,
 } from '../server/admin-contracts';
-import { adminGovernanceInputSchema } from '../server/admin-contracts';
+import {
+	adminCreateUserInputSchema,
+	adminGovernanceInputSchema,
+} from '../server/admin-contracts';
 import {
 	blockAdminUser,
+	createAdminUser,
 	forceCancelAdminOrder,
 	getAdminDashboard as getAdminDashboardFromApi,
 	getAdminMetrics as getAdminMetricsFromApi,
@@ -28,6 +33,7 @@ import {
 	getAdminOrders as getAdminOrdersFromApi,
 	getAdminSupportTickets as getAdminSupportTicketsFromApi,
 	getAdminUsers as getAdminUsersFromApi,
+	resendAdminUserPasswordSetup,
 	unblockAdminUser,
 } from '../server/admin-service';
 
@@ -35,6 +41,8 @@ export type AdminGovernanceActionState = {
 	error?: string;
 	success?: boolean;
 };
+
+export type AdminCreateUserActionState = AdminGovernanceActionState;
 
 const getAdminSessionOrRedirect = async () => {
 	const session = await getAuthSession();
@@ -53,6 +61,13 @@ const parseGovernanceForm = (formData: FormData) =>
 		targetId: formData.get('targetId'),
 		reason: formData.get('reason'),
 	}) satisfies AdminGovernanceInput;
+
+const parseCreateUserForm = (formData: FormData) =>
+	adminCreateUserInputSchema.parse({
+		username: formData.get('username'),
+		email: formData.get('email'),
+		role: formData.get('role'),
+	}) satisfies AdminCreateUserInput;
 
 export const getAdminDashboard = async (): Promise<AdminDashboardOutput> => {
 	await getAdminSessionOrRedirect();
@@ -134,6 +149,38 @@ export const blockAdminUserAction = async (
 		await blockAdminUser(parseGovernanceForm(formData), api.request);
 		revalidatePath('/admin');
 		revalidatePath('/admin/users');
+		return { success: true };
+	} catch (error) {
+		return { error: getAuthErrorMessage(error) };
+	}
+};
+
+export const createAdminUserAction = async (
+	_state: AdminCreateUserActionState,
+	formData: FormData,
+): Promise<AdminCreateUserActionState> => {
+	try {
+		await assertSameOriginRequest();
+		await getAdminSessionOrRedirect();
+		await createAdminUser(parseCreateUserForm(formData), api.request);
+		revalidatePath('/admin');
+		revalidatePath('/admin/users');
+		return { success: true };
+	} catch (error) {
+		return { error: getAuthErrorMessage(error) };
+	}
+};
+
+export const resendAdminUserPasswordSetupAction = async (
+	_state: AdminGovernanceActionState,
+	formData: FormData,
+): Promise<AdminGovernanceActionState> => {
+	try {
+		await assertSameOriginRequest();
+		await getAdminSessionOrRedirect();
+		const targetId = String(formData.get('targetId') ?? '').trim();
+		if (!targetId) return { error: 'Usuário inválido.' };
+		await resendAdminUserPasswordSetup(targetId, api.request);
 		return { success: true };
 	} catch (error) {
 		return { error: getAuthErrorMessage(error) };

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-create-user-form.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-create-user-form.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { UserPlus } from 'lucide-react';
+import { useActionState, useEffect, useRef } from 'react';
+import { getButtonClassName } from '@/shared/ui/components/button';
+import { fieldSurface } from '@/shared/ui/styles/classes';
+import { cn } from '@/shared/ui/utils/cn';
+import {
+	type AdminCreateUserActionState,
+	createAdminUserAction,
+} from '../../actions/admin-actions';
+
+const roleOptions = [
+	{ value: 'CLIENT', label: 'Cliente' },
+	{ value: 'BOOSTER', label: 'Booster' },
+	{ value: 'ADMIN', label: 'Admin' },
+] as const;
+
+export const AdminCreateUserForm = () => {
+	const [state, formAction, pending] = useActionState<
+		AdminCreateUserActionState,
+		FormData
+	>(createAdminUserAction, {});
+	const formRef = useRef<HTMLFormElement>(null);
+
+	useEffect(() => {
+		if (state.success) formRef.current?.reset();
+	}, [state.success]);
+
+	return (
+		<form
+			ref={formRef}
+			action={formAction}
+			className="grid gap-3 rounded-sm border border-white/10 bg-white/[0.02] p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_160px_auto]"
+		>
+			<label className="grid gap-2">
+				<span className="text-[10px] font-black uppercase tracking-widest text-white/35">
+					Usuário
+				</span>
+				<input
+					name="username"
+					className={cn(fieldSurface, 'bg-black/20')}
+					placeholder="nome de usuário"
+					required
+				/>
+			</label>
+			<label className="grid gap-2">
+				<span className="text-[10px] font-black uppercase tracking-widest text-white/35">
+					E-mail
+				</span>
+				<input
+					name="email"
+					type="email"
+					className={cn(fieldSurface, 'bg-black/20')}
+					placeholder="usuario@email.com"
+					required
+				/>
+			</label>
+			<label className="grid gap-2">
+				<span className="text-[10px] font-black uppercase tracking-widest text-white/35">
+					Perfil
+				</span>
+				<select
+					name="role"
+					className={cn(fieldSurface, 'bg-black/20')}
+					defaultValue="CLIENT"
+				>
+					{roleOptions.map((option) => (
+						<option key={option.value} value={option.value}>
+							{option.label}
+						</option>
+					))}
+				</select>
+			</label>
+			<div className="grid content-end gap-2">
+				<button
+					type="submit"
+					disabled={pending}
+					className={getButtonClassName({
+						size: 'md',
+						variant: 'secondary',
+						className: 'min-h-11 gap-2',
+					})}
+				>
+					<UserPlus className="h-4 w-4" />
+					{pending ? 'Criando' : 'Criar'}
+				</button>
+			</div>
+			<p className="min-h-4 text-[10px] font-medium text-red-300 md:col-span-4">
+				{state.error ?? (state.success ? 'Usuário criado.' : '')}
+			</p>
+		</form>
+	);
+};

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx
@@ -15,7 +15,9 @@ jest.mock('@/shared/dashboard/dashboard-entrance', () => ({
 
 jest.mock('../../actions/admin-actions', () => ({
 	blockAdminUserAction: jest.fn(),
+	createAdminUserAction: jest.fn(),
 	forceCancelAdminOrderAction: jest.fn(),
+	resendAdminUserPasswordSetupAction: jest.fn(),
 	unblockAdminUserAction: jest.fn(),
 }));
 
@@ -53,6 +55,7 @@ describe('admin dashboard pages', () => {
 						role: 'CLIENT',
 						isActive: true,
 						isBlocked: false,
+						activationStatus: 'ACTIVE',
 						createdAt: '2026-05-01T00:00:00.000Z',
 					},
 				]}

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.tsx
@@ -48,7 +48,9 @@ import type {
 	AdminSupportTicketOutput,
 	AdminUserOutput,
 } from '../../server/admin-contracts';
+import { AdminCreateUserForm } from './admin-create-user-form';
 import { AdminGovernanceForm } from './admin-governance-form';
+import { AdminResendPasswordSetupForm } from './admin-resend-password-setup-form';
 
 type AdminDashboardPageProps = {
 	metrics: AdminMetricsOutput;
@@ -75,6 +77,21 @@ const roleLabels: Record<string, string> = {
 	ADMIN: 'ADMIN',
 	BOOSTER: 'BOOSTER',
 	CLIENT: 'CLIENTE',
+};
+
+const activationLabels: Record<AdminUserOutput['activationStatus'], string> = {
+	ACTIVE: 'ATIVO',
+	PENDING_ACTIVATION: 'PENDENTE',
+	INACTIVE: 'INATIVO',
+};
+
+const activationVariants: Record<
+	AdminUserOutput['activationStatus'],
+	'success' | 'warning' | 'outline'
+> = {
+	ACTIVE: 'success',
+	PENDING_ACTIVATION: 'warning',
+	INACTIVE: 'outline',
 };
 
 const metricItems = (metrics: AdminMetricsOutput) => [
@@ -134,21 +151,28 @@ const AdminUserCard = ({ user }: { user: AdminUserOutput }) => (
 			<Badge>{roleLabels[user.role] ?? user.role}</Badge>
 		</div>
 		<div className="mt-4 grid grid-cols-2 gap-3 border-white/5 border-t pt-3">
-			<Badge variant={user.isActive ? 'success' : 'outline'}>
-				{user.isActive ? 'ATIVO' : 'INATIVO'}
+			<Badge variant={activationVariants[user.activationStatus]}>
+				{activationLabels[user.activationStatus]}
 			</Badge>
 			<Badge variant={user.isBlocked ? 'error' : 'success'}>
 				{user.isBlocked ? 'BLOQUEADO' : 'LIBERADO'}
 			</Badge>
 		</div>
 		<div className="mt-4">
-			<AdminGovernanceForm
-				action={user.isBlocked ? unblockAdminUserAction : blockAdminUserAction}
-				targetId={user.id}
-				label={user.isBlocked ? 'Desbloquear' : 'Bloquear'}
-				placeholder="Motivo obrigatório da auditoria"
-				tone={user.isBlocked ? 'neutral' : 'danger'}
-			/>
+			<div className="grid gap-3">
+				{user.activationStatus === 'PENDING_ACTIVATION' ? (
+					<AdminResendPasswordSetupForm userId={user.id} />
+				) : null}
+				<AdminGovernanceForm
+					action={
+						user.isBlocked ? unblockAdminUserAction : blockAdminUserAction
+					}
+					targetId={user.id}
+					label={user.isBlocked ? 'Desbloquear' : 'Bloquear'}
+					placeholder="Motivo obrigatório da auditoria"
+					tone={user.isBlocked ? 'neutral' : 'danger'}
+				/>
+			</div>
 		</div>
 	</article>
 );
@@ -472,10 +496,11 @@ export const AdminUsersPage = ({ users }: AdminUsersPageProps) => {
 						value={formatMetricCount(blockedUsers)}
 					/>
 				</div>
+				<AdminCreateUserForm />
 			</section>
 			<DashboardTableSection
 				isEmpty={users.length === 0}
-				colSpan={5}
+				colSpan={6}
 				mobileContent={users.map((user) => (
 					<AdminUserCard key={user.id} user={user} />
 				))}
@@ -492,6 +517,7 @@ export const AdminUsersPage = ({ users }: AdminUsersPageProps) => {
 						<TableHead>Usuário</TableHead>
 						<TableHead>Perfil</TableHead>
 						<TableHead>Conta</TableHead>
+						<TableHead>Criado em</TableHead>
 						<TableHead>Bloqueio</TableHead>
 						<TableHead className="text-right">Admin</TableHead>
 					</TableRow>
@@ -511,9 +537,12 @@ export const AdminUsersPage = ({ users }: AdminUsersPageProps) => {
 								<Badge>{roleLabels[user.role] ?? user.role}</Badge>
 							</TableCell>
 							<TableCell>
-								<Badge variant={user.isActive ? 'success' : 'outline'}>
-									{user.isActive ? 'ATIVO' : 'INATIVO'}
+								<Badge variant={activationVariants[user.activationStatus]}>
+									{activationLabels[user.activationStatus]}
 								</Badge>
+							</TableCell>
+							<TableCell className="text-xs text-white/45">
+								{formatDateTime(user.createdAt)}
 							</TableCell>
 							<TableCell>
 								<Badge variant={user.isBlocked ? 'error' : 'success'}>
@@ -521,17 +550,22 @@ export const AdminUsersPage = ({ users }: AdminUsersPageProps) => {
 								</Badge>
 							</TableCell>
 							<TableCell className="min-w-[240px] text-right">
-								<AdminGovernanceForm
-									action={
-										user.isBlocked
-											? unblockAdminUserAction
-											: blockAdminUserAction
-									}
-									targetId={user.id}
-									label={user.isBlocked ? 'Desbloquear' : 'Bloquear'}
-									placeholder="Motivo obrigatório da auditoria"
-									tone={user.isBlocked ? 'neutral' : 'danger'}
-								/>
+								<div className="grid justify-items-end gap-3">
+									{user.activationStatus === 'PENDING_ACTIVATION' ? (
+										<AdminResendPasswordSetupForm userId={user.id} />
+									) : null}
+									<AdminGovernanceForm
+										action={
+											user.isBlocked
+												? unblockAdminUserAction
+												: blockAdminUserAction
+										}
+										targetId={user.id}
+										label={user.isBlocked ? 'Desbloquear' : 'Bloquear'}
+										placeholder="Motivo obrigatório da auditoria"
+										tone={user.isBlocked ? 'neutral' : 'danger'}
+									/>
+								</div>
 							</TableCell>
 						</TableRow>
 					))}

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-resend-password-setup-form.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-resend-password-setup-form.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { MailPlus } from 'lucide-react';
+import { useActionState } from 'react';
+import { getButtonClassName } from '@/shared/ui/components/button';
+import {
+	type AdminGovernanceActionState,
+	resendAdminUserPasswordSetupAction,
+} from '../../actions/admin-actions';
+
+export const AdminResendPasswordSetupForm = ({
+	userId,
+}: {
+	userId: string;
+}) => {
+	const [state, formAction, pending] = useActionState<
+		AdminGovernanceActionState,
+		FormData
+	>(resendAdminUserPasswordSetupAction, {});
+
+	return (
+		<form action={formAction} className="grid justify-items-end gap-1">
+			<input type="hidden" name="targetId" value={userId} />
+			<button
+				type="submit"
+				disabled={pending}
+				className={getButtonClassName({
+					variant: 'outline',
+					size: 'sm',
+					className: 'ml-auto w-fit gap-2',
+				})}
+			>
+				<MailPlus className="h-3.5 w-3.5" />
+				{pending ? 'Reenviando' : 'Reenviar acesso'}
+			</button>
+			<p className="min-h-4 text-right text-[10px] text-white/35">
+				{state.error ?? (state.success ? 'E-mail enviado.' : '')}
+			</p>
+		</form>
+	);
+};

--- a/apps/web/src/modules/admin-dashboard/server/admin-contracts.ts
+++ b/apps/web/src/modules/admin-dashboard/server/admin-contracts.ts
@@ -5,6 +5,12 @@ export {
 
 import { z } from 'zod';
 
+export const adminCreateUserInputSchema = z.object({
+	username: z.string().trim().min(1, 'Informe o nome de usuário.'),
+	email: z.string().trim().email('Informe um e-mail válido.'),
+	role: z.enum(['CLIENT', 'BOOSTER', 'ADMIN']),
+});
+
 export const adminMetricsSchema = z.object({
 	revenueTotal: z.number(),
 	ordersTotal: z.number().int().nonnegative(),
@@ -19,6 +25,7 @@ export const adminUserSchema = z.object({
 	role: z.string(),
 	isActive: z.boolean(),
 	isBlocked: z.boolean(),
+	activationStatus: z.enum(['ACTIVE', 'PENDING_ACTIVATION', 'INACTIVE']),
 	createdAt: z.string(),
 });
 
@@ -58,6 +65,7 @@ export const adminDashboardSchema = z.object({
 });
 
 export type AdminMetricsOutput = z.infer<typeof adminMetricsSchema>;
+export type AdminCreateUserInput = z.infer<typeof adminCreateUserInputSchema>;
 export type AdminUserOutput = z.infer<typeof adminUserSchema>;
 export type AdminOrderOutput = z.infer<typeof adminOrderSchema>;
 export type AdminSupportTicketOutput = z.infer<typeof adminSupportTicketSchema>;

--- a/apps/web/src/modules/admin-dashboard/server/admin-service.spec.ts
+++ b/apps/web/src/modules/admin-dashboard/server/admin-service.spec.ts
@@ -29,6 +29,7 @@ describe('admin service', () => {
 						role: 'CLIENT',
 						isActive: true,
 						isBlocked: false,
+						activationStatus: 'ACTIVE',
 						createdAt: '2026-04-10T10:00:00.000Z',
 					},
 				] as T;

--- a/apps/web/src/modules/admin-dashboard/server/admin-service.ts
+++ b/apps/web/src/modules/admin-dashboard/server/admin-service.ts
@@ -7,6 +7,7 @@ import {
 	type AdminOrderOutput,
 	type AdminSupportTicketOutput,
 	type AdminUserOutput,
+	adminCreateUserInputSchema,
 	adminDashboardSchema,
 	adminGovernanceInputSchema,
 	adminMetricsSchema,
@@ -138,6 +139,31 @@ export const getAdminDashboard = async (
 	]);
 
 	return adminDashboardSchema.parse({ metrics, users, orders, tickets });
+};
+
+export const createAdminUser = async (
+	input: unknown,
+	apiRequest: AuthenticatedApiRequest,
+): Promise<void> => {
+	const body = adminCreateUserInputSchema.parse(input);
+	await apiRequest('/admin/users', {
+		auth: true,
+		method: 'POST',
+		body: JSON.stringify(body),
+	});
+};
+
+export const resendAdminUserPasswordSetup = async (
+	targetId: string,
+	apiRequest: AuthenticatedApiRequest,
+): Promise<void> => {
+	await apiRequest(
+		`/admin/users/${encodeURIComponent(targetId)}/resend-password-setup`,
+		{
+			auth: true,
+			method: 'POST',
+		},
+	);
 };
 
 export const blockAdminUser = async (

--- a/apps/web/src/modules/auth/actions/auth-actions.ts
+++ b/apps/web/src/modules/auth/actions/auth-actions.ts
@@ -14,8 +14,16 @@ import {
 	loginFormSchema,
 	type RegisterFormInput,
 	registerFormSchema,
+	type SetPasswordFormInput,
+	setPasswordFormSchema,
 } from '../model/auth-schemas';
-import { confirmEmail, login, logout, register } from '../server/auth-service';
+import {
+	confirmEmail,
+	login,
+	logout,
+	register,
+	setPassword,
+} from '../server/auth-service';
 
 export type AuthActionState = {
 	error?: string;
@@ -101,6 +109,25 @@ export const confirmEmailAction = async (
 	try {
 		await assertSameOriginRequest();
 		await confirmEmail(trimmedToken);
+		return { success: true };
+	} catch (error) {
+		return {
+			error: getAuthErrorMessage(error, 'confirmEmail'),
+		};
+	}
+};
+
+export const setPasswordAction = async (
+	input: SetPasswordFormInput,
+): Promise<AuthActionState> => {
+	const parsed = setPasswordFormSchema.safeParse(input);
+	if (!parsed.success) {
+		return { error: parsed.error.issues[0]?.message ?? 'Dados inválidos.' };
+	}
+
+	try {
+		await assertSameOriginRequest();
+		await setPassword(parsed.data);
 		return { success: true };
 	} catch (error) {
 		return {

--- a/apps/web/src/modules/auth/model/auth-schemas.ts
+++ b/apps/web/src/modules/auth/model/auth-schemas.ts
@@ -14,5 +14,11 @@ export const registerFormSchema = z.object({
 		.refine((accepted) => accepted, 'Aceite os termos para continuar.'),
 });
 
+export const setPasswordFormSchema = z.object({
+	token: z.string().trim().min(1, 'Token inválido.'),
+	password: z.string().min(12, 'A senha deve ter pelo menos 12 caracteres.'),
+});
+
 export type LoginFormInput = z.infer<typeof loginFormSchema>;
 export type RegisterFormInput = z.infer<typeof registerFormSchema>;
+export type SetPasswordFormInput = z.infer<typeof setPasswordFormSchema>;

--- a/apps/web/src/modules/auth/presentation/set-password-form.tsx
+++ b/apps/web/src/modules/auth/presentation/set-password-form.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { KeyRound } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { setPasswordAction } from '../actions/auth-actions';
+import type { SetPasswordFormInput } from '../model/auth-schemas';
+import { AuthErrorText, AuthField, AuthSuccessText } from './auth-form-fields';
+
+export const SetPasswordForm = ({ token }: { token: string }) => {
+	const router = useRouter();
+	const [error, setError] = useState<string | null>(null);
+	const [success, setSuccess] = useState(false);
+	const [isPending, startTransition] = useTransition();
+	const form = useForm<SetPasswordFormInput>({
+		defaultValues: {
+			token,
+			password: '',
+		},
+	});
+
+	const onSubmit = form.handleSubmit((values) => {
+		setError(null);
+		startTransition(async () => {
+			const result = await setPasswordAction(values);
+			if (result.error) {
+				setError(result.error);
+				return;
+			}
+			setSuccess(true);
+			window.setTimeout(() => router.push('/login'), 1500);
+		});
+	});
+
+	return (
+		<form onSubmit={onSubmit} className="space-y-5">
+			<input type="hidden" {...form.register('token')} />
+			<div className="space-y-2 text-center">
+				<h1 className="text-xl font-black uppercase tracking-[0.22em] text-white">
+					Definir senha
+				</h1>
+				<p className="text-[10px] uppercase tracking-widest leading-relaxed text-white/40">
+					Crie sua senha para ativar o acesso.
+				</p>
+			</div>
+			<AuthField
+				id="password"
+				type="password"
+				label="Senha"
+				icon={KeyRound}
+				autoComplete="new-password"
+				error={form.formState.errors.password?.message}
+				{...form.register('password')}
+			/>
+			{error ? <AuthErrorText>{error}</AuthErrorText> : null}
+			{success ? (
+				<AuthSuccessText>Senha definida. Redirecionando...</AuthSuccessText>
+			) : null}
+			<button
+				type="submit"
+				disabled={isPending || success}
+				className="w-full rounded-sm bg-hextech-cyan px-4 py-3 text-[10px] font-black uppercase tracking-[0.2em] text-background transition-colors hover:bg-white disabled:opacity-60"
+			>
+				{isPending ? 'Salvando' : 'Ativar conta'}
+			</button>
+		</form>
+	);
+};

--- a/apps/web/src/modules/auth/server/auth-service.ts
+++ b/apps/web/src/modules/auth/server/auth-service.ts
@@ -40,6 +40,16 @@ export const confirmEmail = async (token: string) => {
 	});
 };
 
+export const setPassword = async (input: {
+	token: string;
+	password: string;
+}) => {
+	await api.request('/users/set-password', {
+		method: 'POST',
+		body: JSON.stringify(input),
+	});
+};
+
 export const logout = async () => {
 	const session = await getAuthSession();
 

--- a/apps/web/src/shared/api-client-management/user-messages.ts
+++ b/apps/web/src/shared/api-client-management/user-messages.ts
@@ -4,12 +4,17 @@ const apiErrorMap: Record<string, string> = {
 	'User email is already in use.': 'Este e-mail já está sendo utilizado.',
 	'Username is already in use.':
 		'Este nome de usuário já está sendo utilizado.',
-	'Invalid credentials.': 'E-mail ou senha incorretos.',
-	'Account is inactive.': 'Sua conta está inativa.',
+	'Invalid credentials.':
+		'Não foi possível entrar. Confira seus dados e tente novamente.',
+	'Account is inactive.':
+		'Não foi possível entrar. Confira seus dados e tente novamente.',
 	'Account is blocked.': 'Sua conta está bloqueada.',
 	'Invalid confirmation token.': 'Token de confirmação inválido.',
+	'Invalid password reset token.': 'Token de definição de senha inválido.',
 	'Authentication required.': 'Autenticação necessária.',
 	'Insufficient permissions.': 'Permissões insuficientes.',
+	'Password setup is unavailable for this user.':
+		'Este usuário não pode receber e-mail de definição de senha.',
 	'Registration is unavailable.':
 		'O cadastro está temporariamente indisponível.',
 };

--- a/packages/database/prisma/migrations/20260626160000_add_admin_user_password_setup/migration.sql
+++ b/packages/database/prisma/migrations/20260626160000_add_admin_user_password_setup/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "users" ALTER COLUMN "password" DROP NOT NULL;
+
+ALTER TABLE "users"
+ADD COLUMN "passwordResetTokenHash" TEXT,
+ADD COLUMN "passwordResetTokenExpiresAt" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX "users_passwordResetTokenHash_key" ON "users"("passwordResetTokenHash");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -78,13 +78,15 @@ model User {
   id               String    @id @default(cuid())
   username         String    @unique
   email            String    @unique
-  password         String
+  password         String?
   role             Role      @default(CLIENT)
   isActive         Boolean   @default(false)
   isBlocked        Boolean   @default(false)
   emailConfirmedAt DateTime?
   emailConfirmationTokenHash String? @unique
   emailConfirmationTokenExpiresAt DateTime?
+  passwordResetTokenHash String? @unique
+  passwordResetTokenExpiresAt DateTime?
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
 


### PR DESCRIPTION
## Summary

Adds admin-created users with password setup activation, derived admin user statuses, resend setup email, persisted audit records, and structured lifecycle logs.

Closes:

## Verification

```text
pnpm biome:fix:all
pnpm --filter api exec tsc --noEmit -p tsconfig.json
pnpm --filter api exec jest src/modules/users/application/use-cases/set-password/set-password.use-case.spec.ts src/modules/admin/application/use-cases/create-admin-user/create-admin-user.use-case.spec.ts src/modules/auth/application/use-cases/login/login.use-case.spec.ts src/modules/admin/application/use-cases/get-admin-dashboard/get-admin-dashboard.use-case.spec.ts --runInBand
pnpm --filter api test:e2e -- admin.e2e-spec.ts
pnpm --filter web test -- src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx src/modules/admin-dashboard/server/admin-service.spec.ts
pnpm --filter web build
pnpm db:validate
pnpm db:generate
pnpm --filter api test:integration:db -- users.db.integration.spec.ts
git diff --check
```

Skipped checks and remaining risk:

Full repo test matrix not run; targeted affected API, web, build, and DB-backed checks passed.

## Screenshots

Not captured.

## Breaking Changes

None.