### PR TITLE
feat: coupon creation and management by admins

### DIFF
--- a/apps/api/src/common/http/api-domain-error.filter.ts
+++ b/apps/api/src/common/http/api-domain-error.filter.ts
@@ -48,6 +48,8 @@ import {
 	OrderNotFoundError,
 } from '@modules/orders/domain/order.errors';
 import {
+	CouponCodeAlreadyExistsError,
+	CouponNotFoundError,
 	OrderCouponDiscountInvalidError,
 	OrderCouponFirstOrderOnlyError,
 	OrderCouponInactiveError,
@@ -172,6 +174,7 @@ export function mapApiDomainErrorToHttpException(
 			NotificationNotFoundError,
 			TicketNotFoundError,
 			RatingOrderNotFoundError,
+			CouponNotFoundError,
 		),
 		mapAsBadRequest(
 			OrderAlreadyExistsError,
@@ -213,6 +216,7 @@ export function mapApiDomainErrorToHttpException(
 		mapAsConflict(OrderPricingVersionActiveConflictError, ChatNotWritableError),
 		mapAsConflict(NotificationReadConflictError),
 		mapAsConflict(RatingAlreadySubmittedError),
+		mapAsConflict(CouponCodeAlreadyExistsError),
 	]);
 }
 

--- a/apps/api/src/modules/orders/application/coupon-eligibility.spec.ts
+++ b/apps/api/src/modules/orders/application/coupon-eligibility.spec.ts
@@ -1,0 +1,98 @@
+import {
+	type CouponEligibilityContext,
+	evaluateCouponEligibility,
+} from '@modules/orders/application/coupon-eligibility';
+import { makeStoredCoupon } from '../../../../test/support/coupons/make-stored-coupon';
+
+function makeContext(
+	overrides: Partial<CouponEligibilityContext> = {},
+): CouponEligibilityContext {
+	return {
+		clientEmail: 'player@example.com',
+		isFirstPaidOrder: true,
+		serviceType: 'elo_boost',
+		desiredQueue: 'solo_duo',
+		rankIndex: 14,
+		selectedExtras: [],
+		subtotal: 10000,
+		...overrides,
+	};
+}
+
+describe('evaluateCouponEligibility', () => {
+	it('passes when no rules are configured', () => {
+		expect(
+			evaluateCouponEligibility(makeStoredCoupon(), makeContext()),
+		).toEqual({ ok: true });
+	});
+
+	it('blocks service types outside the allow list', () => {
+		const coupon = makeStoredCoupon({ allowedServiceTypes: ['coaching'] });
+		expect(
+			evaluateCouponEligibility(
+				coupon,
+				makeContext({ serviceType: 'elo_boost' }),
+			),
+		).toEqual({ ok: false, reason: 'service_type_not_allowed' });
+	});
+
+	it('matches targeted emails case-insensitively', () => {
+		const coupon = makeStoredCoupon({ allowedEmails: ['player@example.com'] });
+		expect(
+			evaluateCouponEligibility(
+				coupon,
+				makeContext({ clientEmail: 'PLAYER@EXAMPLE.COM' }),
+			),
+		).toEqual({ ok: true });
+	});
+
+	it('enforces the subtotal range', () => {
+		const coupon = makeStoredCoupon({ minSubtotal: 5000, maxSubtotal: 8000 });
+		expect(
+			evaluateCouponEligibility(coupon, makeContext({ subtotal: 9000 })),
+		).toEqual({ ok: false, reason: 'subtotal_above_maximum' });
+	});
+
+	it('enforces the rank range', () => {
+		const coupon = makeStoredCoupon({ minRankIndex: 16, maxRankIndex: 24 });
+		expect(
+			evaluateCouponEligibility(coupon, makeContext({ rankIndex: 10 })),
+		).toEqual({ ok: false, reason: 'rank_below_minimum' });
+	});
+
+	it('requires a specific selected extra', () => {
+		const coupon = makeStoredCoupon({ requiredExtra: 'priority_service' });
+		expect(
+			evaluateCouponEligibility(
+				coupon,
+				makeContext({ selectedExtras: ['extra_win'] }),
+			),
+		).toEqual({ ok: false, reason: 'required_extra_missing' });
+		expect(
+			evaluateCouponEligibility(
+				coupon,
+				makeContext({ selectedExtras: ['priority_service'] }),
+			),
+		).toEqual({ ok: true });
+	});
+
+	it('requires a minimum number of extras', () => {
+		const coupon = makeStoredCoupon({ minExtrasCount: 2 });
+		expect(
+			evaluateCouponEligibility(
+				coupon,
+				makeContext({ selectedExtras: ['extra_win'] }),
+			),
+		).toEqual({ ok: false, reason: 'not_enough_extras' });
+	});
+
+	it('blocks first-order coupons for returning buyers', () => {
+		const coupon = makeStoredCoupon({ firstOrderOnly: true });
+		expect(
+			evaluateCouponEligibility(
+				coupon,
+				makeContext({ isFirstPaidOrder: false }),
+			),
+		).toEqual({ ok: false, reason: 'not_first_order' });
+	});
+});

--- a/apps/api/src/modules/orders/application/coupon-eligibility.ts
+++ b/apps/api/src/modules/orders/application/coupon-eligibility.ts
@@ -1,0 +1,72 @@
+import type { StoredCoupon } from '@modules/orders/application/ports/coupon-lookup.port';
+import type { OrderServiceType } from '@packages/shared/orders/service-type';
+
+export type CouponEligibilityContext = {
+	clientEmail: string;
+	isFirstPaidOrder: boolean;
+	serviceType: OrderServiceType;
+	desiredQueue: string;
+	rankIndex: number;
+	selectedExtras: string[];
+	subtotal: number;
+};
+
+export type CouponEligibilityResult =
+	| { ok: true }
+	| { ok: false; reason: string };
+
+export function evaluateCouponEligibility(
+	coupon: StoredCoupon,
+	context: CouponEligibilityContext,
+): CouponEligibilityResult {
+	if (coupon.firstOrderOnly && !context.isFirstPaidOrder)
+		return fail('not_first_order');
+
+	if (
+		coupon.allowedServiceTypes.length > 0 &&
+		!coupon.allowedServiceTypes.includes(context.serviceType)
+	)
+		return fail('service_type_not_allowed');
+
+	if (
+		coupon.allowedQueues.length > 0 &&
+		!coupon.allowedQueues.includes(context.desiredQueue)
+	)
+		return fail('queue_not_allowed');
+
+	if (
+		coupon.allowedEmails.length > 0 &&
+		!coupon.allowedEmails.includes(context.clientEmail.trim().toLowerCase())
+	)
+		return fail('email_not_allowed');
+
+	if (coupon.minSubtotal !== null && context.subtotal < coupon.minSubtotal)
+		return fail('subtotal_below_minimum');
+
+	if (coupon.maxSubtotal !== null && context.subtotal > coupon.maxSubtotal)
+		return fail('subtotal_above_maximum');
+
+	if (coupon.minRankIndex !== null && context.rankIndex < coupon.minRankIndex)
+		return fail('rank_below_minimum');
+
+	if (coupon.maxRankIndex !== null && context.rankIndex > coupon.maxRankIndex)
+		return fail('rank_above_maximum');
+
+	if (
+		coupon.minExtrasCount !== null &&
+		context.selectedExtras.length < coupon.minExtrasCount
+	)
+		return fail('not_enough_extras');
+
+	if (
+		coupon.requiredExtra !== null &&
+		!context.selectedExtras.includes(coupon.requiredExtra)
+	)
+		return fail('required_extra_missing');
+
+	return { ok: true };
+}
+
+function fail(reason: string): CouponEligibilityResult {
+	return { ok: false, reason };
+}

--- a/apps/api/src/modules/orders/application/logging/coupon-lifecycle.logger.ts
+++ b/apps/api/src/modules/orders/application/logging/coupon-lifecycle.logger.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
+
+export type CouponLifecycleLogEvent = {
+	event: 'coupon.lifecycle';
+	operation: 'create' | 'disable' | 'payment_confirmed_usage';
+	outcome?: 'success' | 'error' | 'skipped';
+	duration_ms?: number;
+	admin_user_id?: string;
+	client_id?: string;
+	coupon_id?: string;
+	coupon_code?: string;
+	order_id?: string;
+	discount_amount?: number;
+	first_order_only?: boolean;
+	side_effects?: string[];
+	error_type?: string;
+	error_message?: string;
+};
+
+export function markCouponLifecycleLogError(
+	event: CouponLifecycleLogEvent,
+	error: unknown,
+): void {
+	event.outcome = 'error';
+	event.error_type =
+		error instanceof Error ? error.constructor.name : typeof error;
+	event.error_message =
+		error instanceof Error ? error.message : 'Unknown error';
+}
+
+@Injectable()
+export class CouponLifecycleLogger {
+	constructor(private readonly logger: PinoLogger) {
+		this.logger.setContext(CouponLifecycleLogger.name);
+	}
+
+	emit(event: CouponLifecycleLogEvent, startedAt: number): void {
+		event.duration_ms = Date.now() - startedAt;
+
+		if (event.outcome === 'error') this.logger.error(event);
+		else this.logger.info(event);
+	}
+}

--- a/apps/api/src/modules/orders/application/ports/coupon-admin-repository.port.ts
+++ b/apps/api/src/modules/orders/application/ports/coupon-admin-repository.port.ts
@@ -1,0 +1,54 @@
+import type { StoredCoupon } from '@modules/orders/application/ports/coupon-lookup.port';
+import type { CouponEventType } from '@packages/shared/coupons/coupon';
+import type { OrderServiceType } from '@packages/shared/orders/service-type';
+
+export const COUPON_ADMIN_REPOSITORY_KEY = Symbol(
+	'COUPON_ADMIN_REPOSITORY_KEY',
+);
+
+export type CouponPersistenceInput = {
+	code: string;
+	discountType: 'percentage' | 'fixed';
+	discount: number;
+	firstOrderOnly: boolean;
+	allowedServiceTypes: OrderServiceType[];
+	allowedQueues: string[];
+	allowedEmails: string[];
+	minSubtotal: number | null;
+	maxSubtotal: number | null;
+	minRankIndex: number | null;
+	maxRankIndex: number | null;
+	minExtrasCount: number | null;
+	requiredExtra: string | null;
+	globalUsageLimit: number | null;
+	perUserUsageLimit: number | null;
+};
+
+export type CouponSummary = StoredCoupon & {
+	createdAt: Date;
+	usageCount: number;
+};
+
+export type CouponReport = {
+	couponId: string;
+	code: string;
+	usageCount: number;
+	discountTotalCents: number;
+	revenueCents: number;
+	uniqueClients: number;
+	appliedCount: number;
+	conversionRate: number;
+	eventCounts: Record<CouponEventType, number>;
+};
+
+export interface CouponAdminRepositoryPort {
+	existsByCode(code: string): Promise<boolean>;
+	create(
+		input: CouponPersistenceInput,
+		adminUserId: string,
+	): Promise<{ id: string; code: string }>;
+	list(): Promise<CouponSummary[]>;
+	findById(id: string): Promise<CouponSummary | null>;
+	disable(id: string, adminUserId: string): Promise<boolean>;
+	getReport(couponId: string): Promise<CouponReport | null>;
+}

--- a/apps/api/src/modules/orders/application/ports/coupon-event-recorder.port.ts
+++ b/apps/api/src/modules/orders/application/ports/coupon-event-recorder.port.ts
@@ -1,0 +1,16 @@
+import type { CouponEventType } from '@packages/shared/coupons/coupon';
+
+export const COUPON_EVENT_RECORDER_KEY = Symbol('COUPON_EVENT_RECORDER_KEY');
+
+export type CouponEventInput = {
+	type: CouponEventType;
+	code: string;
+	couponId?: string | null;
+	clientId?: string | null;
+	orderId?: string | null;
+	reason?: string | null;
+};
+
+export interface CouponEventRecorderPort {
+	record(event: CouponEventInput): Promise<void>;
+}

--- a/apps/api/src/modules/orders/application/ports/coupon-lookup.port.ts
+++ b/apps/api/src/modules/orders/application/ports/coupon-lookup.port.ts
@@ -1,3 +1,5 @@
+import type { OrderServiceType } from '@packages/shared/orders/service-type';
+
 export const COUPON_LOOKUP_PORT_KEY = Symbol('COUPON_LOOKUP_PORT_KEY');
 
 export type StoredCoupon = {
@@ -7,9 +9,25 @@ export type StoredCoupon = {
 	discount: number;
 	isActive: boolean;
 	firstOrderOnly: boolean;
+	allowedServiceTypes: OrderServiceType[];
+	allowedQueues: string[];
+	allowedEmails: string[];
+	minSubtotal: number | null;
+	maxSubtotal: number | null;
+	minRankIndex: number | null;
+	maxRankIndex: number | null;
+	minExtrasCount: number | null;
+	requiredExtra: string | null;
+	globalUsageLimit: number | null;
+	perUserUsageLimit: number | null;
 };
 
 export interface CouponLookupPort {
 	findByCode(code: string): Promise<StoredCoupon | null>;
 	findById(id: string): Promise<StoredCoupon | null>;
+	countConfirmedUsage(couponId: string): Promise<number>;
+	countConfirmedUsageForClient(
+		couponId: string,
+		clientId: string,
+	): Promise<number>;
 }

--- a/apps/api/src/modules/orders/application/ports/order-client-reader.port.ts
+++ b/apps/api/src/modules/orders/application/ports/order-client-reader.port.ts
@@ -1,0 +1,6 @@
+export const ORDER_CLIENT_READER_KEY = Symbol('ORDER_CLIENT_READER_KEY');
+
+export interface OrderClientReaderPort {
+	findEmailById(clientId: string): Promise<string | null>;
+	hasPaidOrder(clientId: string): Promise<boolean>;
+}

--- a/apps/api/src/modules/orders/application/ports/order-repository.port.ts
+++ b/apps/api/src/modules/orders/application/ports/order-repository.port.ts
@@ -7,6 +7,7 @@ export interface OrderRepositoryPort {
 	findById(id: string): Promise<Order | null>;
 	findByIdForClient(id: string, clientId: string): Promise<Order | null>;
 	existsForClient?(clientId: string): Promise<boolean>;
+	existsPaidOrderForClient?(clientId: string): Promise<boolean>;
 	save(order: Order): Promise<void>;
 	saveBoosterRejection?(order: Order, boosterId: string): Promise<void>;
 }

--- a/apps/api/src/modules/orders/application/services/order-coupon.service.spec.ts
+++ b/apps/api/src/modules/orders/application/services/order-coupon.service.spec.ts
@@ -1,146 +1,162 @@
-import type { OrderPricingSnapshot } from '@modules/orders/application/order-pricing';
+import type { OrderQuoteRequestDetails } from '@modules/orders/application/order-pricing';
+import type { CouponEventInput } from '@modules/orders/application/ports/coupon-event-recorder.port';
 import type {
 	CouponLookupPort,
 	StoredCoupon,
 } from '@modules/orders/application/ports/coupon-lookup.port';
-import type { OrderRepositoryPort } from '@modules/orders/application/ports/order-repository.port';
+import type { OrderClientReaderPort } from '@modules/orders/application/ports/order-client-reader.port';
 import { ApplyOrderCouponService } from '@modules/orders/application/services/order-coupon.service';
-import { Order } from '@modules/orders/domain/order.entity';
+import { makeStoredCoupon } from '../../../../../test/support/coupons/make-stored-coupon';
 
 class CouponLookupStub implements CouponLookupPort {
 	public coupon: StoredCoupon | null = null;
-	public lastCode: string | null = null;
-	public lastId: string | null = null;
+	public globalUsage = 0;
+	public perUserUsage = 0;
 
-	async findByCode(code: string): Promise<StoredCoupon | null> {
-		this.lastCode = code;
+	async findByCode(): Promise<StoredCoupon | null> {
 		return this.coupon;
 	}
 
-	async findById(id: string): Promise<StoredCoupon | null> {
-		this.lastId = id;
+	async findById(): Promise<StoredCoupon | null> {
 		return this.coupon;
+	}
+
+	async countConfirmedUsage(): Promise<number> {
+		return this.globalUsage;
+	}
+
+	async countConfirmedUsageForClient(): Promise<number> {
+		return this.perUserUsage;
 	}
 }
 
-class OrderRepositoryStub implements OrderRepositoryPort {
-	public hasOrderForClient = false;
-	public checkedClientId: string | null = null;
+class ClientReaderStub implements OrderClientReaderPort {
+	public email: string | null = null;
+	public paid = false;
 
-	async create(): Promise<Order> {
-		throw new Error('not needed in this test');
+	async findEmailById(): Promise<string | null> {
+		return this.email;
 	}
 
-	async findById(): Promise<Order | null> {
-		throw new Error('not needed in this test');
+	async hasPaidOrder(): Promise<boolean> {
+		return this.paid;
 	}
+}
 
-	async findByIdForClient(): Promise<Order | null> {
-		throw new Error('not needed in this test');
+class EventRecorderStub {
+	public events: CouponEventInput[] = [];
+	async record(event: CouponEventInput): Promise<void> {
+		this.events.push(event);
 	}
+}
 
-	async save(): Promise<void> {
-		throw new Error('not needed in this test');
-	}
+function makeRequestDetails(): OrderQuoteRequestDetails {
+	return {
+		serviceType: 'elo_boost',
+		extras: [],
+		currentLeague: 'gold',
+		currentDivision: 'II',
+		currentLp: 50,
+		desiredLeague: 'platinum',
+		desiredDivision: 'IV',
+		server: 'br',
+		desiredQueue: 'solo_duo',
+		lpGain: 20,
+		deadline: new Date('2026-03-31T00:00:00.000Z'),
+	};
+}
 
-	async existsForClient(clientId: string): Promise<boolean> {
-		this.checkedClientId = clientId;
-		return this.hasOrderForClient;
-	}
+function makeService() {
+	const couponLookup = new CouponLookupStub();
+	const clientReader = new ClientReaderStub();
+	const events = new EventRecorderStub();
+	const service = new ApplyOrderCouponService(
+		couponLookup,
+		clientReader,
+		events,
+	);
+	return { service, couponLookup, clientReader, events };
 }
 
 describe('ApplyOrderCouponService', () => {
-	it('applies a percentage coupon to the base quote pricing', async () => {
-		const couponLookup = new CouponLookupStub();
-		couponLookup.coupon = {
-			id: 'coupon-1',
+	it('applies a percentage coupon to the quote subtotal', async () => {
+		const { service, couponLookup } = makeService();
+		couponLookup.coupon = makeStoredCoupon({
 			code: 'WELCOME10',
 			discountType: 'percentage',
 			discount: 10,
-			isActive: true,
-			firstOrderOnly: false,
-		};
-		const orderRepository = new OrderRepositoryStub();
-		const service = new ApplyOrderCouponService(couponLookup, orderRepository);
-		const basePricing: OrderPricingSnapshot = {
-			pricingVersionId: 'pricing-version-1',
-			subtotal: 100,
-			totalAmount: 100,
-			discountAmount: 0,
-			extras: [],
-		};
+		});
 
 		await expect(
 			service.apply({
 				clientId: 'client-1',
 				couponCode: 'WELCOME10',
-				pricing: basePricing,
-			}),
-		).resolves.toEqual({
-			couponId: 'coupon-1',
-			pricing: {
-				pricingVersionId: 'pricing-version-1',
-				subtotal: 100,
-				totalAmount: 90,
-				discountAmount: 10,
-				extras: [],
-			},
-		});
-		expect(couponLookup.lastCode).toBe('WELCOME10');
-		expect(orderRepository.checkedClientId).toBeNull();
-	});
-
-	it('applies a fixed coupon and clamps the total amount at zero', async () => {
-		const couponLookup = new CouponLookupStub();
-		couponLookup.coupon = {
-			id: 'coupon-2',
-			code: 'FLAT200',
-			discountType: 'fixed',
-			discount: 200,
-			isActive: true,
-			firstOrderOnly: false,
-		};
-		const orderRepository = new OrderRepositoryStub();
-		const service = new ApplyOrderCouponService(couponLookup, orderRepository);
-
-		await expect(
-			service.apply({
-				clientId: 'client-1',
-				couponCode: 'FLAT200',
+				requestDetails: makeRequestDetails(),
 				pricing: {
 					pricingVersionId: 'pricing-version-1',
-					subtotal: 100,
-					totalAmount: 100,
+					subtotal: 10000,
+					totalAmount: 10000,
 					discountAmount: 0,
 					extras: [],
 				},
 			}),
 		).resolves.toEqual({
-			couponId: 'coupon-2',
+			couponId: 'coupon-1',
 			pricing: {
 				pricingVersionId: 'pricing-version-1',
-				subtotal: 100,
-				totalAmount: 0,
-				discountAmount: 100,
+				subtotal: 10000,
+				totalAmount: 9000,
+				discountAmount: 1000,
+				extras: [],
+			},
+		});
+	});
+
+	it('keeps the order total at the R$0.50 floor for an oversized fixed discount', async () => {
+		const { service, couponLookup } = makeService();
+		couponLookup.coupon = makeStoredCoupon({
+			code: 'FLAT200',
+			discountType: 'fixed',
+			discount: 200,
+		});
+
+		await expect(
+			service.apply({
+				clientId: 'client-1',
+				couponCode: 'FLAT200',
+				requestDetails: makeRequestDetails(),
+				pricing: {
+					pricingVersionId: 'pricing-version-1',
+					subtotal: 10000,
+					totalAmount: 10000,
+					discountAmount: 0,
+					extras: [],
+				},
+			}),
+		).resolves.toEqual({
+			couponId: 'coupon-1',
+			pricing: {
+				pricingVersionId: 'pricing-version-1',
+				subtotal: 10000,
+				totalAmount: 50,
+				discountAmount: 9950,
 				extras: [],
 			},
 		});
 	});
 
 	it('rejects unknown coupon codes', async () => {
-		const service = new ApplyOrderCouponService(
-			new CouponLookupStub(),
-			new OrderRepositoryStub(),
-		);
+		const { service } = makeService();
 
 		await expect(
 			service.apply({
 				clientId: 'client-1',
 				couponCode: 'MISSING',
+				requestDetails: makeRequestDetails(),
 				pricing: {
 					pricingVersionId: 'pricing-version-1',
-					subtotal: 100,
-					totalAmount: 100,
+					subtotal: 10000,
+					totalAmount: 10000,
 					discountAmount: 0,
 					extras: [],
 				},
@@ -149,28 +165,18 @@ describe('ApplyOrderCouponService', () => {
 	});
 
 	it('rejects inactive coupons', async () => {
-		const couponLookup = new CouponLookupStub();
-		couponLookup.coupon = {
-			id: 'coupon-3',
-			code: 'OFFLINE',
-			discountType: 'percentage',
-			discount: 10,
-			isActive: false,
-			firstOrderOnly: false,
-		};
-		const service = new ApplyOrderCouponService(
-			couponLookup,
-			new OrderRepositoryStub(),
-		);
+		const { service, couponLookup } = makeService();
+		couponLookup.coupon = makeStoredCoupon({ isActive: false });
 
 		await expect(
 			service.apply({
 				clientId: 'client-1',
-				couponCode: 'OFFLINE',
+				couponCode: 'WELCOME10',
+				requestDetails: makeRequestDetails(),
 				pricing: {
 					pricingVersionId: 'pricing-version-1',
-					subtotal: 100,
-					totalAmount: 100,
+					subtotal: 10000,
+					totalAmount: 10000,
 					discountAmount: 0,
 					extras: [],
 				},
@@ -178,33 +184,73 @@ describe('ApplyOrderCouponService', () => {
 		).rejects.toThrow('Coupon is invalid.');
 	});
 
-	it('rejects first-order-only coupons when the client already has an order', async () => {
-		const couponLookup = new CouponLookupStub();
-		couponLookup.coupon = {
-			id: 'coupon-4',
-			code: 'FIRSTONLY',
-			discountType: 'percentage',
-			discount: 10,
-			isActive: true,
-			firstOrderOnly: true,
-		};
-		const orderRepository = new OrderRepositoryStub();
-		orderRepository.hasOrderForClient = true;
-		const service = new ApplyOrderCouponService(couponLookup, orderRepository);
+	it('rejects first-order coupons when the client already has a paid order', async () => {
+		const { service, couponLookup, clientReader } = makeService();
+		couponLookup.coupon = makeStoredCoupon({ firstOrderOnly: true });
+		clientReader.paid = true;
 
 		await expect(
 			service.apply({
 				clientId: 'client-1',
-				couponCode: 'FIRSTONLY',
+				couponCode: 'WELCOME10',
+				requestDetails: makeRequestDetails(),
 				pricing: {
 					pricingVersionId: 'pricing-version-1',
-					subtotal: 100,
-					totalAmount: 100,
+					subtotal: 10000,
+					totalAmount: 10000,
 					discountAmount: 0,
 					extras: [],
 				},
 			}),
 		).rejects.toThrow('Coupon is invalid.');
-		expect(orderRepository.checkedClientId).toBe('client-1');
+	});
+
+	it('rejects coupons that reached the global usage limit', async () => {
+		const { service, couponLookup } = makeService();
+		couponLookup.coupon = makeStoredCoupon({ globalUsageLimit: 5 });
+		couponLookup.globalUsage = 5;
+
+		await expect(
+			service.apply({
+				clientId: 'client-1',
+				couponCode: 'WELCOME10',
+				requestDetails: makeRequestDetails(),
+				pricing: {
+					pricingVersionId: 'pricing-version-1',
+					subtotal: 10000,
+					totalAmount: 10000,
+					discountAmount: 0,
+					extras: [],
+				},
+			}),
+		).rejects.toThrow('Coupon is invalid.');
+	});
+
+	it('records audit events only when emitEvents is set', async () => {
+		const { service, couponLookup, events } = makeService();
+		couponLookup.coupon = makeStoredCoupon();
+
+		await service.apply({
+			clientId: 'client-1',
+			couponCode: 'WELCOME10',
+			requestDetails: makeRequestDetails(),
+			emitEvents: true,
+			pricing: {
+				pricingVersionId: 'pricing-version-1',
+				subtotal: 10000,
+				totalAmount: 10000,
+				discountAmount: 0,
+				extras: [],
+			},
+		});
+
+		expect(events.events).toEqual([
+			{
+				type: 'applied_at_checkout',
+				code: 'WELCOME10',
+				couponId: 'coupon-1',
+				clientId: 'client-1',
+			},
+		]);
 	});
 });

--- a/apps/api/src/modules/orders/application/services/order-coupon.service.ts
+++ b/apps/api/src/modules/orders/application/services/order-coupon.service.ts
@@ -1,81 +1,195 @@
-import type { OrderPricingSnapshot } from '@modules/orders/application/order-pricing';
+import {
+	type CouponEligibilityContext,
+	evaluateCouponEligibility,
+} from '@modules/orders/application/coupon-eligibility';
+import type {
+	OrderPricingSnapshot,
+	OrderQuoteRequestDetails,
+} from '@modules/orders/application/order-pricing';
+import {
+	COUPON_EVENT_RECORDER_KEY,
+	type CouponEventRecorderPort,
+} from '@modules/orders/application/ports/coupon-event-recorder.port';
 import {
 	COUPON_LOOKUP_PORT_KEY,
 	type CouponLookupPort,
+	type StoredCoupon,
 } from '@modules/orders/application/ports/coupon-lookup.port';
 import {
-	ORDER_REPOSITORY_KEY,
-	type OrderRepositoryPort,
-} from '@modules/orders/application/ports/order-repository.port';
+	ORDER_CLIENT_READER_KEY,
+	type OrderClientReaderPort,
+} from '@modules/orders/application/ports/order-client-reader.port';
 import { OrderCouponInvalidError } from '@modules/orders/domain/order-pricing.errors';
 import { Inject, Injectable } from '@nestjs/common';
+import { COUPON_MIN_ORDER_TOTAL_CENTS } from '@packages/shared/coupons/coupon';
 import { Money } from '@packages/shared/money/money';
+import { findOrderRankIndex } from '@packages/shared/orders/order-rank-progression';
 
 export const ORDER_COUPON_SERVICE_KEY = Symbol('ORDER_COUPON_SERVICE_KEY');
 
+export type ApplyOrderCouponInput = {
+	clientId: string;
+	couponCode?: string;
+	pricing: OrderPricingSnapshot;
+	requestDetails: OrderQuoteRequestDetails;
+	emitEvents?: boolean;
+};
+
 export interface OrderCouponService {
-	apply(input: {
-		clientId: string;
-		couponCode?: string;
-		pricing: OrderPricingSnapshot;
-	}): Promise<{
+	apply(input: ApplyOrderCouponInput): Promise<{
 		couponId: string | null;
 		pricing: OrderPricingSnapshot;
 	}>;
 }
+
+type FailureKind =
+	| 'validation_failed'
+	| 'eligibility_failed'
+	| 'usage_limit_failed';
 
 @Injectable()
 export class ApplyOrderCouponService implements OrderCouponService {
 	constructor(
 		@Inject(COUPON_LOOKUP_PORT_KEY)
 		private readonly couponLookup: CouponLookupPort,
-		@Inject(ORDER_REPOSITORY_KEY)
-		private readonly orderRepository: OrderRepositoryPort,
+		@Inject(ORDER_CLIENT_READER_KEY)
+		private readonly clientReader: OrderClientReaderPort,
+		@Inject(COUPON_EVENT_RECORDER_KEY)
+		private readonly events: CouponEventRecorderPort,
 	) {}
 
-	async apply(input: {
-		clientId: string;
-		couponCode?: string;
-		pricing: OrderPricingSnapshot;
-	}): Promise<{
+	async apply(input: ApplyOrderCouponInput): Promise<{
 		couponId: string | null;
 		pricing: OrderPricingSnapshot;
 	}> {
-		if (!input.couponCode) {
-			return {
-				couponId: null,
-				pricing: input.pricing,
-			};
+		if (!input.couponCode) return { couponId: null, pricing: input.pricing };
+
+		const code = input.couponCode.trim().toUpperCase();
+		const coupon = await this.couponLookup.findByCode(code);
+
+		if (!coupon || !coupon.isActive || !this.hasValidDiscount(coupon))
+			return this.reject(input, code, coupon?.id ?? null, 'validation_failed');
+
+		const eligibility = evaluateCouponEligibility(
+			coupon,
+			await this.buildContext(input, coupon),
+		);
+		if (!eligibility.ok)
+			return this.reject(
+				input,
+				code,
+				coupon.id,
+				'eligibility_failed',
+				eligibility.reason,
+			);
+
+		if (!(await this.withinUsageLimits(coupon, input.clientId)))
+			return this.reject(input, code, coupon.id, 'usage_limit_failed');
+
+		const pricing = this.applyDiscount(coupon, input.pricing);
+		if (input.emitEvents)
+			await this.events.record({
+				type: 'applied_at_checkout',
+				code,
+				couponId: coupon.id,
+				clientId: input.clientId,
+			});
+
+		return { couponId: coupon.id, pricing };
+	}
+
+	private hasValidDiscount(coupon: StoredCoupon): boolean {
+		return Number.isFinite(coupon.discount) && coupon.discount > 0;
+	}
+
+	private async buildContext(
+		input: ApplyOrderCouponInput,
+		coupon: StoredCoupon,
+	): Promise<CouponEligibilityContext> {
+		const clientEmail =
+			coupon.allowedEmails.length > 0
+				? ((await this.clientReader.findEmailById(input.clientId)) ?? '')
+				: '';
+		const isFirstPaidOrder = coupon.firstOrderOnly
+			? !(await this.clientReader.hasPaidOrder(input.clientId))
+			: true;
+
+		return {
+			clientEmail,
+			isFirstPaidOrder,
+			serviceType: input.requestDetails.serviceType,
+			desiredQueue: input.requestDetails.desiredQueue,
+			rankIndex: findOrderRankIndex(
+				input.requestDetails.currentLeague,
+				input.requestDetails.currentDivision,
+			),
+			selectedExtras: input.pricing.extras.map((extra) => extra.type),
+			subtotal: input.pricing.subtotal,
+		};
+	}
+
+	// ponytail: usage is counted only at payment confirmation (PM decision), so
+	// this checkout-time check cannot be atomic against concurrent payments — two
+	// near-limit checkouts can both pay and slightly oversubscribe a limit. That
+	// is the accepted trade-off of count-after-payment; the alternative (reserving
+	// a slot at checkout with expiry) was explicitly out of scope. If hard caps
+	// ever become a requirement, enforce a reservation here instead.
+	private async withinUsageLimits(
+		coupon: StoredCoupon,
+		clientId: string,
+	): Promise<boolean> {
+		if (coupon.globalUsageLimit !== null) {
+			const used = await this.couponLookup.countConfirmedUsage(coupon.id);
+			if (used >= coupon.globalUsageLimit) return false;
 		}
+		if (coupon.perUserUsageLimit !== null) {
+			const used = await this.couponLookup.countConfirmedUsageForClient(
+				coupon.id,
+				clientId,
+			);
+			if (used >= coupon.perUserUsageLimit) return false;
+		}
+		return true;
+	}
 
-		const coupon = await this.couponLookup.findByCode(input.couponCode);
-		if (!coupon) throw new OrderCouponInvalidError();
-		if (!coupon.isActive) throw new OrderCouponInvalidError();
-		if (!Number.isFinite(coupon.discount) || coupon.discount < 0)
-			throw new OrderCouponInvalidError();
-		if (
-			coupon.firstOrderOnly &&
-			(await this.orderRepository.existsForClient?.(input.clientId))
-		)
-			throw new OrderCouponInvalidError();
-
-		const subtotal = Money.fromCents(input.pricing.subtotal);
+	private applyDiscount(
+		coupon: StoredCoupon,
+		pricing: OrderPricingSnapshot,
+	): OrderPricingSnapshot {
+		const subtotal = Money.fromCents(pricing.subtotal);
 		const rawDiscount =
 			coupon.discountType === 'percentage'
 				? subtotal.percentage(coupon.discount / 100)
 				: Money.fromDecimal(coupon.discount);
-		const discount = subtotal.min(rawDiscount);
-		const totalAmount = Money.zero().max(subtotal.subtract(discount));
+		const maxDiscount = Money.zero().max(
+			subtotal.subtract(Money.fromCents(COUPON_MIN_ORDER_TOTAL_CENTS)),
+		);
+		const discount = rawDiscount.min(maxDiscount);
 
 		return {
-			couponId: coupon.id,
-			pricing: {
-				pricingVersionId: input.pricing.pricingVersionId,
-				subtotal: input.pricing.subtotal,
-				totalAmount: totalAmount.cents,
-				discountAmount: discount.cents,
-				extras: input.pricing.extras,
-			},
+			pricingVersionId: pricing.pricingVersionId,
+			subtotal: pricing.subtotal,
+			totalAmount: subtotal.subtract(discount).cents,
+			discountAmount: discount.cents,
+			extras: pricing.extras,
 		};
+	}
+
+	private async reject(
+		input: ApplyOrderCouponInput,
+		code: string,
+		couponId: string | null,
+		kind: FailureKind,
+		reason?: string,
+	): Promise<never> {
+		if (input.emitEvents)
+			await this.events.record({
+				type: kind,
+				code,
+				couponId,
+				clientId: input.clientId,
+				reason: reason ?? null,
+			});
+		throw new OrderCouponInvalidError();
 	}
 }

--- a/apps/api/src/modules/orders/application/use-cases/create-coupon/create-coupon.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/create-coupon/create-coupon.use-case.ts
@@ -1,0 +1,106 @@
+import {
+	type CouponLifecycleLogEvent,
+	CouponLifecycleLogger,
+	markCouponLifecycleLogError,
+} from '@modules/orders/application/logging/coupon-lifecycle.logger';
+import {
+	COUPON_ADMIN_REPOSITORY_KEY,
+	type CouponAdminRepositoryPort,
+	type CouponPersistenceInput,
+} from '@modules/orders/application/ports/coupon-admin-repository.port';
+import { CouponCodeAlreadyExistsError } from '@modules/orders/domain/order-pricing.errors';
+import { Inject, Injectable } from '@nestjs/common';
+import {
+	generateCouponCode,
+	normalizeCouponCode,
+} from '@packages/shared/coupons/coupon';
+import type { CreateCouponInput } from '@packages/shared/coupons/create-coupon.schema';
+import { findOrderRankIndex } from '@packages/shared/orders/order-rank-progression';
+
+const MAX_CODE_GENERATION_ATTEMPTS = 10;
+
+type CreateCouponUseCaseInput = CreateCouponInput & {
+	adminUserId: string;
+};
+
+@Injectable()
+export class CreateCouponUseCase {
+	constructor(
+		@Inject(COUPON_ADMIN_REPOSITORY_KEY)
+		private readonly repository: CouponAdminRepositoryPort,
+		private readonly lifecycleLogger: CouponLifecycleLogger,
+	) {}
+
+	async execute(
+		input: CreateCouponUseCaseInput,
+	): Promise<{ id: string; code: string }> {
+		const startedAt = Date.now();
+		const event: CouponLifecycleLogEvent = {
+			event: 'coupon.lifecycle',
+			operation: 'create',
+			admin_user_id: input.adminUserId,
+			first_order_only: input.firstOrderOnly,
+			side_effects: [],
+		};
+
+		try {
+			const code = await this.resolveCode(input.code);
+
+			const persistenceInput: CouponPersistenceInput = {
+				code,
+				discountType: input.discountType,
+				discount: input.discount,
+				firstOrderOnly: input.firstOrderOnly,
+				allowedServiceTypes: input.allowedServiceTypes,
+				allowedQueues: input.allowedQueues,
+				allowedEmails: input.allowedEmails,
+				minSubtotal: input.minSubtotal ?? null,
+				maxSubtotal: input.maxSubtotal ?? null,
+				minRankIndex: input.minRank
+					? findOrderRankIndex(input.minRank.league, input.minRank.division)
+					: null,
+				maxRankIndex: input.maxRank
+					? findOrderRankIndex(input.maxRank.league, input.maxRank.division)
+					: null,
+				minExtrasCount: input.minExtrasCount ?? null,
+				requiredExtra: input.requiredExtra ?? null,
+				globalUsageLimit: input.globalUsageLimit ?? null,
+				perUserUsageLimit: input.perUserUsageLimit ?? null,
+			};
+
+			const created = await this.repository.create(
+				persistenceInput,
+				input.adminUserId,
+			);
+			event.coupon_id = created.id;
+			event.coupon_code = created.code;
+			event.side_effects?.push('coupon_created');
+			event.outcome = 'success';
+			return created;
+		} catch (error) {
+			markCouponLifecycleLogError(event, error);
+			throw error;
+		} finally {
+			this.lifecycleLogger.emit(event, startedAt);
+		}
+	}
+
+	private async resolveCode(code: string | undefined): Promise<string> {
+		if (code) {
+			const normalized = normalizeCouponCode(code);
+			if (await this.repository.existsByCode(normalized))
+				throw new CouponCodeAlreadyExistsError();
+			return normalized;
+		}
+
+		for (
+			let attempt = 0;
+			attempt < MAX_CODE_GENERATION_ATTEMPTS;
+			attempt += 1
+		) {
+			const candidate = generateCouponCode();
+			if (!(await this.repository.existsByCode(candidate))) return candidate;
+		}
+		throw new CouponCodeAlreadyExistsError();
+	}
+}

--- a/apps/api/src/modules/orders/application/use-cases/create-order-quote/create-order-quote.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/create-order-quote/create-order-quote.use-case.ts
@@ -59,6 +59,8 @@ export class CreateOrderQuoteUseCase {
 			clientId: input.clientId,
 			couponCode: input.couponCode,
 			pricing,
+			requestDetails,
+			emitEvents: true,
 		});
 		const quote = await this.orderQuoteRepository.create({
 			clientId: input.clientId,

--- a/apps/api/src/modules/orders/application/use-cases/disable-coupon/disable-coupon.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/disable-coupon/disable-coupon.use-case.ts
@@ -1,0 +1,54 @@
+import {
+	type CouponLifecycleLogEvent,
+	CouponLifecycleLogger,
+	markCouponLifecycleLogError,
+} from '@modules/orders/application/logging/coupon-lifecycle.logger';
+import {
+	COUPON_ADMIN_REPOSITORY_KEY,
+	type CouponAdminRepositoryPort,
+} from '@modules/orders/application/ports/coupon-admin-repository.port';
+import { CouponNotFoundError } from '@modules/orders/domain/order-pricing.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+type DisableCouponInput = {
+	couponId: string;
+	adminUserId: string;
+};
+
+@Injectable()
+export class DisableCouponUseCase {
+	constructor(
+		@Inject(COUPON_ADMIN_REPOSITORY_KEY)
+		private readonly repository: CouponAdminRepositoryPort,
+		private readonly lifecycleLogger: CouponLifecycleLogger,
+	) {}
+
+	async execute(input: DisableCouponInput): Promise<void> {
+		const startedAt = Date.now();
+		const event: CouponLifecycleLogEvent = {
+			event: 'coupon.lifecycle',
+			operation: 'disable',
+			admin_user_id: input.adminUserId,
+			coupon_id: input.couponId,
+			side_effects: [],
+		};
+
+		try {
+			const coupon = await this.repository.findById(input.couponId);
+			if (!coupon) throw new CouponNotFoundError();
+			event.coupon_code = coupon.code;
+
+			const disabled = await this.repository.disable(
+				input.couponId,
+				input.adminUserId,
+			);
+			if (disabled) event.side_effects?.push('coupon_disabled');
+			event.outcome = disabled ? 'success' : 'skipped';
+		} catch (error) {
+			markCouponLifecycleLogError(event, error);
+			throw error;
+		} finally {
+			this.lifecycleLogger.emit(event, startedAt);
+		}
+	}
+}

--- a/apps/api/src/modules/orders/application/use-cases/get-coupon-report/get-coupon-report.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/get-coupon-report/get-coupon-report.use-case.ts
@@ -1,0 +1,21 @@
+import {
+	COUPON_ADMIN_REPOSITORY_KEY,
+	type CouponAdminRepositoryPort,
+	type CouponReport,
+} from '@modules/orders/application/ports/coupon-admin-repository.port';
+import { CouponNotFoundError } from '@modules/orders/domain/order-pricing.errors';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class GetCouponReportUseCase {
+	constructor(
+		@Inject(COUPON_ADMIN_REPOSITORY_KEY)
+		private readonly repository: CouponAdminRepositoryPort,
+	) {}
+
+	async execute(input: { couponId: string }): Promise<CouponReport> {
+		const report = await this.repository.getReport(input.couponId);
+		if (!report) throw new CouponNotFoundError();
+		return report;
+	}
+}

--- a/apps/api/src/modules/orders/application/use-cases/list-coupons/list-coupons.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/list-coupons/list-coupons.use-case.ts
@@ -1,0 +1,18 @@
+import {
+	COUPON_ADMIN_REPOSITORY_KEY,
+	type CouponAdminRepositoryPort,
+	type CouponSummary,
+} from '@modules/orders/application/ports/coupon-admin-repository.port';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ListCouponsUseCase {
+	constructor(
+		@Inject(COUPON_ADMIN_REPOSITORY_KEY)
+		private readonly repository: CouponAdminRepositoryPort,
+	) {}
+
+	async execute(): Promise<CouponSummary[]> {
+		return this.repository.list();
+	}
+}

--- a/apps/api/src/modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case.spec.ts
@@ -1,3 +1,9 @@
+import type { CouponLifecycleLogger } from '@modules/orders/application/logging/coupon-lifecycle.logger';
+import type { CouponEventRecorderPort } from '@modules/orders/application/ports/coupon-event-recorder.port';
+import type {
+	CouponLookupPort,
+	StoredCoupon,
+} from '@modules/orders/application/ports/coupon-lookup.port';
 import type {
 	OrderEvent,
 	OrderEventPublisherPort,
@@ -6,6 +12,21 @@ import type { OrderRepositoryPort } from '@modules/orders/application/ports/orde
 import { MarkOrderAsPaidUseCase } from '@modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case';
 import { Order } from '@modules/orders/domain/order.entity';
 import { OrderNotFoundError } from '@modules/orders/domain/order.errors';
+
+const couponLookupStub: CouponLookupPort = {
+	findByCode: async (): Promise<StoredCoupon | null> => null,
+	findById: async (): Promise<StoredCoupon | null> => null,
+	countConfirmedUsage: async (): Promise<number> => 0,
+	countConfirmedUsageForClient: async (): Promise<number> => 0,
+};
+
+const couponEventsStub: CouponEventRecorderPort = {
+	record: async (): Promise<void> => undefined,
+};
+
+const couponLifecycleLoggerStub = {
+	emit: (): void => undefined,
+} as unknown as CouponLifecycleLogger;
 
 class InMemoryOrderRepository implements OrderRepositoryPort {
 	private readonly orders = new Map<string, Order>();
@@ -47,7 +68,13 @@ describe('MarkOrderAsPaidUseCase', () => {
 		const order = Order.create('order-1');
 		repository.insert(order);
 
-		const useCase = new MarkOrderAsPaidUseCase(repository, eventPublisher);
+		const useCase = new MarkOrderAsPaidUseCase(
+			repository,
+			couponLookupStub,
+			couponEventsStub,
+			couponLifecycleLoggerStub,
+			eventPublisher,
+		);
 		await useCase.execute({ orderId: 'order-1' });
 
 		const savedOrder = await repository.findById('order-1');
@@ -64,7 +91,12 @@ describe('MarkOrderAsPaidUseCase', () => {
 
 	it('throws when order does not exist', async () => {
 		const repository = new InMemoryOrderRepository();
-		const useCase = new MarkOrderAsPaidUseCase(repository);
+		const useCase = new MarkOrderAsPaidUseCase(
+			repository,
+			couponLookupStub,
+			couponEventsStub,
+			couponLifecycleLoggerStub,
+		);
 
 		await expect(useCase.execute({ orderId: 'missing-order' })).rejects.toThrow(
 			OrderNotFoundError,
@@ -76,7 +108,13 @@ describe('MarkOrderAsPaidUseCase', () => {
 		const eventPublisher = new OrderEventPublisherSpy();
 		const order = Order.create('order-2');
 		repository.insert(order);
-		const useCase = new MarkOrderAsPaidUseCase(repository, eventPublisher);
+		const useCase = new MarkOrderAsPaidUseCase(
+			repository,
+			couponLookupStub,
+			couponEventsStub,
+			couponLifecycleLoggerStub,
+			eventPublisher,
+		);
 
 		await useCase.execute({ orderId: 'order-2' });
 

--- a/apps/api/src/modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case.ts
@@ -1,4 +1,17 @@
+import {
+	type CouponLifecycleLogEvent,
+	CouponLifecycleLogger,
+	markCouponLifecycleLogError,
+} from '@modules/orders/application/logging/coupon-lifecycle.logger';
 import { createOrderEvent } from '@modules/orders/application/order-event.factory';
+import {
+	COUPON_EVENT_RECORDER_KEY,
+	type CouponEventRecorderPort,
+} from '@modules/orders/application/ports/coupon-event-recorder.port';
+import {
+	COUPON_LOOKUP_PORT_KEY,
+	type CouponLookupPort,
+} from '@modules/orders/application/ports/coupon-lookup.port';
 import {
 	ORDER_EVENT_PUBLISHER_KEY,
 	type OrderEventPublisherPort,
@@ -7,6 +20,7 @@ import {
 	ORDER_REPOSITORY_KEY,
 	type OrderRepositoryPort,
 } from '@modules/orders/application/ports/order-repository.port';
+import type { Order } from '@modules/orders/domain/order.entity';
 import { OrderNotFoundError } from '@modules/orders/domain/order.errors';
 import { OrderStatus } from '@modules/orders/domain/order-status';
 import { Inject, Injectable, Optional } from '@nestjs/common';
@@ -20,6 +34,11 @@ export class MarkOrderAsPaidUseCase {
 	constructor(
 		@Inject(ORDER_REPOSITORY_KEY)
 		private readonly orderRepository: OrderRepositoryPort,
+		@Inject(COUPON_LOOKUP_PORT_KEY)
+		private readonly couponLookup: CouponLookupPort,
+		@Inject(COUPON_EVENT_RECORDER_KEY)
+		private readonly couponEvents: CouponEventRecorderPort,
+		private readonly couponLifecycleLogger: CouponLifecycleLogger,
 		@Optional()
 		@Inject(ORDER_EVENT_PUBLISHER_KEY)
 		private readonly orderEventPublisher?: OrderEventPublisherPort,
@@ -32,8 +51,48 @@ export class MarkOrderAsPaidUseCase {
 
 		order.confirmPayment();
 		await this.orderRepository.save(order);
+		await this.recordCouponUsage(order);
 		await this.orderEventPublisher?.publish(
 			createOrderEvent('order.paid', order),
 		);
+	}
+
+	private async recordCouponUsage(order: Order): Promise<void> {
+		const couponId = order.couponId;
+		if (!couponId) return;
+
+		const startedAt = Date.now();
+		const event: CouponLifecycleLogEvent = {
+			event: 'coupon.lifecycle',
+			operation: 'payment_confirmed_usage',
+			coupon_id: couponId,
+			client_id: order.clientId ?? undefined,
+			order_id: order.id,
+			discount_amount: order.discountAmount,
+			side_effects: [],
+		};
+
+		try {
+			const coupon = await this.couponLookup.findById(couponId);
+			if (!coupon) {
+				event.outcome = 'skipped';
+				return;
+			}
+			event.coupon_code = coupon.code;
+			await this.couponEvents.record({
+				type: 'confirmed_by_payment',
+				code: coupon.code,
+				couponId,
+				clientId: order.clientId,
+				orderId: order.id,
+			});
+			event.side_effects?.push('coupon_usage_recorded');
+			event.outcome = 'success';
+		} catch (error) {
+			markCouponLifecycleLogError(event, error);
+			throw error;
+		} finally {
+			this.couponLifecycleLogger.emit(event, startedAt);
+		}
 	}
 }

--- a/apps/api/src/modules/orders/application/use-cases/preview-order-quote/preview-order-quote.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/preview-order-quote/preview-order-quote.use-case.ts
@@ -54,6 +54,7 @@ export class PreviewOrderQuoteUseCase {
 			clientId: input.clientId,
 			couponCode: input.couponCode,
 			pricing,
+			requestDetails,
 		});
 
 		return {

--- a/apps/api/src/modules/orders/domain/order-pricing.errors.ts
+++ b/apps/api/src/modules/orders/domain/order-pricing.errors.ts
@@ -64,6 +64,18 @@ export class OrderCouponInvalidError extends Error {
 	}
 }
 
+export class CouponCodeAlreadyExistsError extends Error {
+	constructor() {
+		super('Coupon code is already in use.');
+	}
+}
+
+export class CouponNotFoundError extends Error {
+	constructor() {
+		super('Coupon was not found.');
+	}
+}
+
 export class OrderPricingVersionNotFoundError extends Error {
 	constructor() {
 		super('Pricing version was not found.');

--- a/apps/api/src/modules/orders/infrastructure/repositories/coupon.mapper.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/coupon.mapper.ts
@@ -1,0 +1,30 @@
+import type { StoredCoupon } from '@modules/orders/application/ports/coupon-lookup.port';
+import { mapServiceTypeToDomain } from '@modules/orders/infrastructure/repositories/service-type.mapper';
+import { type Coupon, CouponDiscountType } from '@prisma/client';
+
+export function mapStoredCoupon(record: Coupon): StoredCoupon {
+	return {
+		id: record.id,
+		code: record.code,
+		discountType:
+			record.discountType === CouponDiscountType.PERCENTAGE
+				? 'percentage'
+				: 'fixed',
+		discount: record.discount,
+		isActive: record.isActive,
+		firstOrderOnly: record.firstOrderOnly,
+		allowedServiceTypes: (record.allowedServiceTypes ?? []).map(
+			mapServiceTypeToDomain,
+		),
+		allowedQueues: record.allowedQueues ?? [],
+		allowedEmails: record.allowedEmails ?? [],
+		minSubtotal: record.minSubtotal,
+		maxSubtotal: record.maxSubtotal,
+		minRankIndex: record.minRankIndex,
+		maxRankIndex: record.maxRankIndex,
+		minExtrasCount: record.minExtrasCount,
+		requiredExtra: record.requiredExtra,
+		globalUsageLimit: record.globalUsageLimit,
+		perUserUsageLimit: record.perUserUsageLimit,
+	};
+}

--- a/apps/api/src/modules/orders/infrastructure/repositories/in-memory-order-checkout.repository.spec.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/in-memory-order-checkout.repository.spec.ts
@@ -10,6 +10,8 @@ import {
 	OrderCouponInvalidError,
 	OrderQuoteAlreadyUsedError,
 } from '@modules/orders/domain/order-pricing.errors';
+import { OrderStatus } from '@modules/orders/domain/order-status';
+import { makeStoredCoupon } from '../../../../../test/support/coupons/make-stored-coupon';
 import { InMemoryOrderCheckoutRepository } from '../../../../../test/support/in-memory/orders/in-memory-order-checkout.repository';
 
 class InMemoryOrderRepository implements OrderRepositoryPort {
@@ -56,6 +58,17 @@ class InMemoryOrderRepository implements OrderRepositoryPort {
 			(order) => order.clientId === clientId,
 		);
 	}
+
+	async existsPaidOrderForClient(clientId: string): Promise<boolean> {
+		const paidStatuses = new Set<OrderStatus>([
+			OrderStatus.PENDING_BOOSTER,
+			OrderStatus.IN_PROGRESS,
+			OrderStatus.COMPLETED,
+		]);
+		return Array.from(this.orders.values()).some(
+			(order) => order.clientId === clientId && paidStatuses.has(order.status),
+		);
+	}
 }
 
 class CouponLookupStub implements CouponLookupPort {
@@ -71,6 +84,14 @@ class CouponLookupStub implements CouponLookupPort {
 
 	async findById(id: string): Promise<StoredCoupon | null> {
 		return this.coupons.get(id) ?? null;
+	}
+
+	async countConfirmedUsage(): Promise<number> {
+		return 0;
+	}
+
+	async countConfirmedUsageForClient(): Promise<number> {
+		return 0;
 	}
 
 	insert(coupon: StoredCoupon): void {
@@ -276,16 +297,16 @@ describe('InMemoryOrderCheckoutRepository', () => {
 
 	it('restores the quote when a first-order coupon becomes invalid at checkout', async () => {
 		const orderRepository = new InMemoryOrderRepository();
-		await orderRepository.create(
-			Order.createDraft({
-				id: 'existing-order',
-				clientId: 'client-1',
-				couponId: null,
-				pricingVersionId: 'pricing-version-1',
-				requestDetails: makeQuote().requestDetails,
-				pricing: makeQuote().pricing,
-			}),
-		);
+		const existingOrder = Order.createDraft({
+			id: 'existing-order',
+			clientId: 'client-1',
+			couponId: null,
+			pricingVersionId: 'pricing-version-1',
+			requestDetails: makeQuote().requestDetails,
+			pricing: makeQuote().pricing,
+		});
+		existingOrder.confirmPayment();
+		await orderRepository.save(existingOrder);
 		const quoteRepository = new InMemoryOrderQuoteRepository();
 		quoteRepository.insert({
 			...makeQuote(),
@@ -299,14 +320,15 @@ describe('InMemoryOrderCheckoutRepository', () => {
 			},
 		});
 		const couponLookup = new CouponLookupStub();
-		couponLookup.insert({
-			id: 'coupon-1',
-			code: 'FIRST10',
-			discountType: 'percentage',
-			discount: 10,
-			isActive: true,
-			firstOrderOnly: true,
-		});
+		couponLookup.insert(
+			makeStoredCoupon({
+				id: 'coupon-1',
+				code: 'FIRST10',
+				discountType: 'percentage',
+				discount: 10,
+				firstOrderOnly: true,
+			}),
+		);
 		const repository = new InMemoryOrderCheckoutRepository(
 			orderRepository,
 			quoteRepository,

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-coupon-admin.repository.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-coupon-admin.repository.ts
@@ -1,0 +1,181 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import type {
+	CouponAdminRepositoryPort,
+	CouponPersistenceInput,
+	CouponReport,
+	CouponSummary,
+} from '@modules/orders/application/ports/coupon-admin-repository.port';
+import { mapStoredCoupon } from '@modules/orders/infrastructure/repositories/coupon.mapper';
+import { mapServiceTypeToPersistence } from '@modules/orders/infrastructure/repositories/service-type.mapper';
+import { Injectable } from '@nestjs/common';
+import {
+	type CouponEventType,
+	couponEventTypes,
+} from '@packages/shared/coupons/coupon';
+import { CouponDiscountType, OrderStatus } from '@prisma/client';
+
+const CONFIRMED_ORDER_STATUSES: OrderStatus[] = [
+	OrderStatus.pending_booster,
+	OrderStatus.in_progress,
+	OrderStatus.completed,
+];
+
+@Injectable()
+export class PrismaCouponAdminRepository implements CouponAdminRepositoryPort {
+	constructor(private readonly prisma: PrismaService) {}
+
+	async existsByCode(code: string): Promise<boolean> {
+		const coupon = await this.prisma.coupon.findUnique({
+			where: { code },
+			select: { id: true },
+		});
+		return coupon !== null;
+	}
+
+	async create(
+		input: CouponPersistenceInput,
+		adminUserId: string,
+	): Promise<{ id: string; code: string }> {
+		return this.prisma.$transaction(async (tx) => {
+			const coupon = await tx.coupon.create({
+				data: {
+					code: input.code,
+					discountType:
+						input.discountType === 'percentage'
+							? CouponDiscountType.PERCENTAGE
+							: CouponDiscountType.FIXED,
+					discount: input.discount,
+					firstOrderOnly: input.firstOrderOnly,
+					allowedServiceTypes: input.allowedServiceTypes.map(
+						mapServiceTypeToPersistence,
+					),
+					allowedQueues: input.allowedQueues,
+					allowedEmails: input.allowedEmails,
+					minSubtotal: input.minSubtotal,
+					maxSubtotal: input.maxSubtotal,
+					minRankIndex: input.minRankIndex,
+					maxRankIndex: input.maxRankIndex,
+					minExtrasCount: input.minExtrasCount,
+					requiredExtra: input.requiredExtra,
+					globalUsageLimit: input.globalUsageLimit,
+					perUserUsageLimit: input.perUserUsageLimit,
+				},
+				select: { id: true, code: true },
+			});
+			await tx.couponEvent.create({
+				data: {
+					type: 'created',
+					code: coupon.code,
+					couponId: coupon.id,
+					reason: adminUserId,
+				},
+			});
+			return coupon;
+		});
+	}
+
+	async list(): Promise<CouponSummary[]> {
+		const coupons = await this.prisma.coupon.findMany({
+			orderBy: { createdAt: 'desc' },
+		});
+		const usage = await this.prisma.order.groupBy({
+			by: ['couponId'],
+			where: {
+				couponId: { not: null },
+				status: { in: CONFIRMED_ORDER_STATUSES },
+			},
+			_count: { _all: true },
+		});
+		const usageByCoupon = new Map(
+			usage.map((row) => [row.couponId, row._count._all]),
+		);
+
+		return coupons.map((coupon) => ({
+			...mapStoredCoupon(coupon),
+			createdAt: coupon.createdAt,
+			usageCount: usageByCoupon.get(coupon.id) ?? 0,
+		}));
+	}
+
+	async findById(id: string): Promise<CouponSummary | null> {
+		const coupon = await this.prisma.coupon.findUnique({ where: { id } });
+		if (!coupon) return null;
+		const usageCount = await this.prisma.order.count({
+			where: { couponId: id, status: { in: CONFIRMED_ORDER_STATUSES } },
+		});
+		return {
+			...mapStoredCoupon(coupon),
+			createdAt: coupon.createdAt,
+			usageCount,
+		};
+	}
+
+	async disable(id: string, adminUserId: string): Promise<boolean> {
+		return this.prisma.$transaction(async (tx) => {
+			const result = await tx.coupon.updateMany({
+				where: { id, isActive: true },
+				data: { isActive: false },
+			});
+			if (result.count === 0) return false;
+
+			const coupon = await tx.coupon.findUnique({
+				where: { id },
+				select: { code: true },
+			});
+			await tx.couponEvent.create({
+				data: {
+					type: 'disabled',
+					code: coupon?.code ?? id,
+					couponId: id,
+					reason: adminUserId,
+				},
+			});
+			return true;
+		});
+	}
+
+	async getReport(couponId: string): Promise<CouponReport | null> {
+		const coupon = await this.prisma.coupon.findUnique({
+			where: { id: couponId },
+			select: { id: true, code: true },
+		});
+		if (!coupon) return null;
+
+		const confirmed = await this.prisma.order.aggregate({
+			where: { couponId, status: { in: CONFIRMED_ORDER_STATUSES } },
+			_sum: { discountAmount: true, totalAmount: true },
+			_count: { _all: true },
+		});
+		const distinctClients = await this.prisma.order.findMany({
+			where: { couponId, status: { in: CONFIRMED_ORDER_STATUSES } },
+			select: { clientId: true },
+			distinct: ['clientId'],
+		});
+		const eventGroups = await this.prisma.couponEvent.groupBy({
+			by: ['type'],
+			where: { couponId },
+			_count: { _all: true },
+		});
+
+		const eventCounts = Object.fromEntries(
+			couponEventTypes.map((type) => [type, 0]),
+		) as CouponReport['eventCounts'];
+		for (const group of eventGroups)
+			eventCounts[group.type as CouponEventType] = group._count._all;
+
+		const usageCount = confirmed._count._all;
+		const appliedCount = eventCounts.applied_at_checkout;
+
+		return {
+			couponId: coupon.id,
+			code: coupon.code,
+			usageCount,
+			discountTotalCents: confirmed._sum.discountAmount ?? 0,
+			revenueCents: confirmed._sum.totalAmount ?? 0,
+			uniqueClients: distinctClients.length,
+			appliedCount,
+			conversionRate: appliedCount > 0 ? usageCount / appliedCount : 0,
+			eventCounts,
+		};
+	}
+}

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-coupon-event-recorder.repository.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-coupon-event-recorder.repository.ts
@@ -1,0 +1,42 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import type {
+	CouponEventInput,
+	CouponEventRecorderPort,
+} from '@modules/orders/application/ports/coupon-event-recorder.port';
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
+
+@Injectable()
+export class PrismaCouponEventRecorder implements CouponEventRecorderPort {
+	constructor(
+		private readonly prisma: PrismaService,
+		private readonly logger: PinoLogger,
+	) {
+		this.logger.setContext(PrismaCouponEventRecorder.name);
+	}
+
+	async record(event: CouponEventInput): Promise<void> {
+		try {
+			await this.prisma.couponEvent.create({
+				data: {
+					type: event.type,
+					code: event.code,
+					couponId: event.couponId ?? null,
+					clientId: event.clientId ?? null,
+					orderId: event.orderId ?? null,
+					reason: event.reason ?? null,
+				},
+			});
+		} catch (error) {
+			this.logger.error({
+				event: 'coupon.event_record',
+				outcome: 'error',
+				coupon_event_type: event.type,
+				coupon_id: event.couponId ?? null,
+				error_type:
+					error instanceof Error ? error.constructor.name : typeof error,
+				error_message: error instanceof Error ? error.message : 'Unknown error',
+			});
+		}
+	}
+}

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-coupon-lookup.repository.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-coupon-lookup.repository.ts
@@ -3,51 +3,42 @@ import type {
 	CouponLookupPort,
 	StoredCoupon,
 } from '@modules/orders/application/ports/coupon-lookup.port';
+import { mapStoredCoupon } from '@modules/orders/infrastructure/repositories/coupon.mapper';
 import { Injectable } from '@nestjs/common';
-import { CouponDiscountType } from '@prisma/client';
+import { OrderStatus } from '@prisma/client';
 
-type CouponRecord = {
-	id: string;
-	code: string;
-	discountType: CouponDiscountType;
-	discount: number;
-	isActive: boolean;
-	firstOrderOnly: boolean;
-};
+const CONFIRMED_ORDER_STATUSES: OrderStatus[] = [
+	OrderStatus.pending_booster,
+	OrderStatus.in_progress,
+	OrderStatus.completed,
+];
 
 @Injectable()
 export class PrismaCouponLookupRepository implements CouponLookupPort {
 	constructor(private readonly prisma: PrismaService) {}
 
 	async findByCode(code: string): Promise<StoredCoupon | null> {
-		const coupon = await this.prisma.coupon.findUnique({
-			where: { code },
-		});
-		if (!coupon) return null;
-
-		return this.mapCoupon(coupon);
+		const coupon = await this.prisma.coupon.findUnique({ where: { code } });
+		return coupon ? mapStoredCoupon(coupon) : null;
 	}
 
 	async findById(id: string): Promise<StoredCoupon | null> {
-		const coupon = await this.prisma.coupon.findUnique({
-			where: { id },
-		});
-		if (!coupon) return null;
-
-		return this.mapCoupon(coupon);
+		const coupon = await this.prisma.coupon.findUnique({ where: { id } });
+		return coupon ? mapStoredCoupon(coupon) : null;
 	}
 
-	private mapCoupon(record: CouponRecord): StoredCoupon {
-		return {
-			id: record.id,
-			code: record.code,
-			discountType:
-				record.discountType === CouponDiscountType.PERCENTAGE
-					? 'percentage'
-					: 'fixed',
-			discount: record.discount,
-			isActive: record.isActive,
-			firstOrderOnly: record.firstOrderOnly,
-		};
+	async countConfirmedUsage(couponId: string): Promise<number> {
+		return this.prisma.order.count({
+			where: { couponId, status: { in: CONFIRMED_ORDER_STATUSES } },
+		});
+	}
+
+	async countConfirmedUsageForClient(
+		couponId: string,
+		clientId: string,
+	): Promise<number> {
+		return this.prisma.order.count({
+			where: { couponId, clientId, status: { in: CONFIRMED_ORDER_STATUSES } },
+		});
 	}
 }

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-order-checkout.repository.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-order-checkout.repository.ts
@@ -105,7 +105,7 @@ type OrderQuoteDelegate = {
 
 type OrderDelegate = {
 	findFirst(args: {
-		where: { clientId: string };
+		where: { clientId: string; status?: { in: OrderStatus[] } };
 		select: { id: true };
 	}): Promise<{ id: string } | null>;
 	create(args: {
@@ -312,22 +312,23 @@ export class PrismaOrderCheckoutRepository implements OrderCheckoutPort {
 		const coupon = await client.coupon.findUnique({
 			where: { id: input.couponId },
 		});
-		if (!coupon) throw new OrderCouponInvalidError();
-		if (!coupon.isActive) throw new OrderCouponInvalidError();
-		if (!Number.isFinite(coupon.discount) || coupon.discount < 0)
-			throw new OrderCouponInvalidError();
-		if (coupon.discountType !== CouponDiscountType.PERCENTAGE) {
-			if (coupon.discountType !== CouponDiscountType.FIXED)
-				throw new OrderCouponInvalidError();
-		}
-		if (!coupon.firstOrderOnly) return;
+		if (!coupon || !coupon.firstOrderOnly) return;
 
 		await client.$queryRaw<{ id: string }[]>(
 			Prisma.sql`SELECT id FROM "users" WHERE id = ${input.clientId} FOR UPDATE`,
 		);
 
 		const existingOrder = await client.order.findFirst({
-			where: { clientId: input.clientId },
+			where: {
+				clientId: input.clientId,
+				status: {
+					in: [
+						OrderStatus.PENDING_BOOSTER,
+						OrderStatus.IN_PROGRESS,
+						OrderStatus.COMPLETED,
+					],
+				},
+			},
 			select: { id: true },
 		});
 		if (existingOrder) throw new OrderCouponInvalidError();

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-order-client-reader.repository.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-order-client-reader.repository.ts
@@ -1,0 +1,34 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import type { OrderClientReaderPort } from '@modules/orders/application/ports/order-client-reader.port';
+import { Injectable } from '@nestjs/common';
+import { OrderStatus } from '@prisma/client';
+
+@Injectable()
+export class PrismaOrderClientReader implements OrderClientReaderPort {
+	constructor(private readonly prisma: PrismaService) {}
+
+	async findEmailById(clientId: string): Promise<string | null> {
+		const user = await this.prisma.user.findUnique({
+			where: { id: clientId },
+			select: { email: true },
+		});
+		return user?.email ?? null;
+	}
+
+	async hasPaidOrder(clientId: string): Promise<boolean> {
+		const order = await this.prisma.order.findFirst({
+			where: {
+				clientId,
+				status: {
+					in: [
+						OrderStatus.pending_booster,
+						OrderStatus.in_progress,
+						OrderStatus.completed,
+					],
+				},
+			},
+			select: { id: true },
+		});
+		return order !== null;
+	}
+}

--- a/apps/api/src/modules/orders/infrastructure/repositories/service-type.mapper.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/service-type.mapper.ts
@@ -1,0 +1,32 @@
+import type { OrderServiceType } from '@packages/shared/orders/service-type';
+import { ServiceType } from '@prisma/client';
+
+export function mapServiceTypeToDomain(
+	serviceType: ServiceType,
+): OrderServiceType {
+	switch (serviceType) {
+		case ServiceType.ELO_BOOST:
+			return 'elo_boost';
+		case ServiceType.DUO_BOOST:
+			return 'duo_boost';
+		case ServiceType.MD5:
+			return 'md5';
+		case ServiceType.COACHING:
+			return 'coaching';
+	}
+}
+
+export function mapServiceTypeToPersistence(
+	serviceType: OrderServiceType,
+): ServiceType {
+	switch (serviceType) {
+		case 'elo_boost':
+			return ServiceType.ELO_BOOST;
+		case 'duo_boost':
+			return ServiceType.DUO_BOOST;
+		case 'md5':
+			return ServiceType.MD5;
+		case 'coaching':
+			return ServiceType.COACHING;
+	}
+}

--- a/apps/api/src/modules/orders/orders.module.ts
+++ b/apps/api/src/modules/orders/orders.module.ts
@@ -2,12 +2,16 @@ import { LoggingModule } from '@app/common/logging/logging.module';
 import { PrismaModule } from '@app/common/prisma/prisma.module';
 import { AuthModule } from '@modules/auth/auth.module';
 import { ChatModule } from '@modules/chat/chat.module';
+import { CouponLifecycleLogger } from '@modules/orders/application/logging/coupon-lifecycle.logger';
 import { OrderQuoteCleanupLifecycleLogger } from '@modules/orders/application/logging/order-quote-cleanup-lifecycle.logger';
 import { BOOSTER_ORDER_READER_KEY } from '@modules/orders/application/ports/booster-order-reader.port';
 import { BOOSTER_USER_READER_KEY } from '@modules/orders/application/ports/booster-user-reader.port';
 import { CLIENT_ORDER_READER_KEY } from '@modules/orders/application/ports/client-order-reader.port';
+import { COUPON_ADMIN_REPOSITORY_KEY } from '@modules/orders/application/ports/coupon-admin-repository.port';
+import { COUPON_EVENT_RECORDER_KEY } from '@modules/orders/application/ports/coupon-event-recorder.port';
 import { COUPON_LOOKUP_PORT_KEY } from '@modules/orders/application/ports/coupon-lookup.port';
 import { ORDER_CHECKOUT_PORT_KEY } from '@modules/orders/application/ports/order-checkout.port';
+import { ORDER_CLIENT_READER_KEY } from '@modules/orders/application/ports/order-client-reader.port';
 import { ORDER_EVENT_PUBLISHER_KEY } from '@modules/orders/application/ports/order-event-publisher.port';
 import { ORDER_PRICING_VERSION_REPOSITORY_KEY } from '@modules/orders/application/ports/order-pricing-version-repository.port';
 import { ORDER_QUOTE_REPOSITORY_KEY } from '@modules/orders/application/ports/order-quote-repository.port';
@@ -23,14 +27,18 @@ import { CancelOrderUseCase } from '@modules/orders/application/use-cases/cancel
 import { CleanupExpiredOrderQuotesUseCase } from '@modules/orders/application/use-cases/cleanup-expired-order-quotes/cleanup-expired-order-quotes.use-case';
 import { ClearOrderCredentialsUseCase } from '@modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case';
 import { CompleteOrderUseCase } from '@modules/orders/application/use-cases/complete-order/complete-order.use-case';
+import { CreateCouponUseCase } from '@modules/orders/application/use-cases/create-coupon/create-coupon.use-case';
 import { CreateOrderUseCase } from '@modules/orders/application/use-cases/create-order/create-order.use-case';
 import { CreateOrderPricingVersionUseCase } from '@modules/orders/application/use-cases/create-order-pricing-version/create-order-pricing-version.use-case';
 import { CreateOrderQuoteUseCase } from '@modules/orders/application/use-cases/create-order-quote/create-order-quote.use-case';
+import { DisableCouponUseCase } from '@modules/orders/application/use-cases/disable-coupon/disable-coupon.use-case';
+import { GetCouponReportUseCase } from '@modules/orders/application/use-cases/get-coupon-report/get-coupon-report.use-case';
 import { GetOrderUseCase } from '@modules/orders/application/use-cases/get-order/get-order.use-case';
 import { GetOrderPricingVersionUseCase } from '@modules/orders/application/use-cases/get-order-pricing-version/get-order-pricing-version.use-case';
 import { ListBoosterQueueUseCase } from '@modules/orders/application/use-cases/list-booster-queue/list-booster-queue.use-case';
 import { ListBoosterWorkUseCase } from '@modules/orders/application/use-cases/list-booster-work/list-booster-work.use-case';
 import { ListClientOrdersUseCase } from '@modules/orders/application/use-cases/list-client-orders/list-client-orders.use-case';
+import { ListCouponsUseCase } from '@modules/orders/application/use-cases/list-coupons/list-coupons.use-case';
 import { ListOrderPricingVersionsUseCase } from '@modules/orders/application/use-cases/list-order-pricing-versions/list-order-pricing-versions.use-case';
 import { MarkOrderAsPaidUseCase } from '@modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case';
 import { PreviewOrderQuoteUseCase } from '@modules/orders/application/use-cases/preview-order-quote/preview-order-quote.use-case';
@@ -40,12 +48,16 @@ import { UpdateOrderPricingVersionUseCase } from '@modules/orders/application/us
 import { InMemoryOrderEventBus } from '@modules/orders/infrastructure/events/in-memory-order-event-bus';
 import { VersionedOrderPricingService } from '@modules/orders/infrastructure/pricing/versioned-order-pricing.service';
 import { PrismaBoosterUserReader } from '@modules/orders/infrastructure/repositories/prisma-booster-user.reader';
+import { PrismaCouponAdminRepository } from '@modules/orders/infrastructure/repositories/prisma-coupon-admin.repository';
+import { PrismaCouponEventRecorder } from '@modules/orders/infrastructure/repositories/prisma-coupon-event-recorder.repository';
 import { PrismaCouponLookupRepository } from '@modules/orders/infrastructure/repositories/prisma-coupon-lookup.repository';
 import { PrismaOrderRepository } from '@modules/orders/infrastructure/repositories/prisma-order.repository';
 import { PrismaOrderCheckoutRepository } from '@modules/orders/infrastructure/repositories/prisma-order-checkout.repository';
+import { PrismaOrderClientReader } from '@modules/orders/infrastructure/repositories/prisma-order-client-reader.repository';
 import { PrismaOrderPricingVersionRepository } from '@modules/orders/infrastructure/repositories/prisma-order-pricing-version.repository';
 import { PrismaOrderQuoteRepository } from '@modules/orders/infrastructure/repositories/prisma-order-quote.repository';
 import { OrderCredentialsCipherService } from '@modules/orders/infrastructure/security/order-credentials-cipher.service';
+import { CouponsAdminController } from '@modules/orders/presentation/coupons-admin.controller';
 import { OrdersController } from '@modules/orders/presentation/orders.controller';
 import { OrdersEventsController } from '@modules/orders/presentation/orders-events.controller';
 import { OrdersPricingAdminController } from '@modules/orders/presentation/orders-pricing-admin.controller';
@@ -58,15 +70,20 @@ import { Module } from '@nestjs/common';
 		OrdersEventsController,
 		OrdersController,
 		OrdersPricingAdminController,
+		CouponsAdminController,
 	],
 	providers: [
 		PrismaBoosterUserReader,
 		PrismaCouponLookupRepository,
+		PrismaCouponAdminRepository,
+		PrismaCouponEventRecorder,
+		PrismaOrderClientReader,
 		PrismaOrderCheckoutRepository,
 		PrismaOrderPricingVersionRepository,
 		PrismaOrderRepository,
 		PrismaOrderQuoteRepository,
 		OrderQuoteCleanupLifecycleLogger,
+		CouponLifecycleLogger,
 		InMemoryOrderEventBus,
 		OrderCredentialsCipherService,
 		{
@@ -82,6 +99,27 @@ import { Module } from '@nestjs/common';
 				couponLookupRepository: PrismaCouponLookupRepository,
 			): PrismaCouponLookupRepository => couponLookupRepository,
 			inject: [PrismaCouponLookupRepository],
+		},
+		{
+			provide: COUPON_ADMIN_REPOSITORY_KEY,
+			useFactory: (
+				couponAdminRepository: PrismaCouponAdminRepository,
+			): PrismaCouponAdminRepository => couponAdminRepository,
+			inject: [PrismaCouponAdminRepository],
+		},
+		{
+			provide: COUPON_EVENT_RECORDER_KEY,
+			useFactory: (
+				couponEventRecorder: PrismaCouponEventRecorder,
+			): PrismaCouponEventRecorder => couponEventRecorder,
+			inject: [PrismaCouponEventRecorder],
+		},
+		{
+			provide: ORDER_CLIENT_READER_KEY,
+			useFactory: (
+				orderClientReader: PrismaOrderClientReader,
+			): PrismaOrderClientReader => orderClientReader,
+			inject: [PrismaOrderClientReader],
 		},
 		ApplyOrderCouponService,
 		{
@@ -149,6 +187,10 @@ import { Module } from '@nestjs/common';
 			inject: [PrismaOrderQuoteRepository],
 		},
 		CreateOrderQuoteUseCase,
+		CreateCouponUseCase,
+		ListCouponsUseCase,
+		DisableCouponUseCase,
+		GetCouponReportUseCase,
 		CreateOrderPricingVersionUseCase,
 		CreateOrderUseCase,
 		ListOrderPricingVersionsUseCase,

--- a/apps/api/src/modules/orders/presentation/coupons-admin.controller.ts
+++ b/apps/api/src/modules/orders/presentation/coupons-admin.controller.ts
@@ -1,0 +1,78 @@
+import { ZodValidationPipe } from '@app/common/http/zod-validation.pipe';
+import type { AuthenticatedUser } from '@modules/auth/application/authenticated-user';
+import { CurrentUser } from '@modules/auth/presentation/decorators/current-user.decorator';
+import { Roles } from '@modules/auth/presentation/decorators/roles.decorator';
+import { JwtAuthGuard } from '@modules/auth/presentation/guards/jwt-auth.guard';
+import { RolesGuard } from '@modules/auth/presentation/guards/roles.guard';
+import { CreateCouponUseCase } from '@modules/orders/application/use-cases/create-coupon/create-coupon.use-case';
+import { DisableCouponUseCase } from '@modules/orders/application/use-cases/disable-coupon/disable-coupon.use-case';
+import { GetCouponReportUseCase } from '@modules/orders/application/use-cases/get-coupon-report/get-coupon-report.use-case';
+import { ListCouponsUseCase } from '@modules/orders/application/use-cases/list-coupons/list-coupons.use-case';
+import {
+	Body,
+	Controller,
+	Get,
+	HttpCode,
+	Param,
+	Post,
+	UseGuards,
+} from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
+import {
+	type CouponIdParamSchemaInput,
+	type CreateCouponSchemaInput,
+	couponIdParamSchema,
+	createCouponSchema,
+} from './coupons-admin.request-schemas';
+
+@Controller('admin/coupons')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN)
+export class CouponsAdminController {
+	constructor(
+		private readonly createCoupon: CreateCouponUseCase,
+		private readonly listCoupons: ListCouponsUseCase,
+		private readonly disableCoupon: DisableCouponUseCase,
+		private readonly getCouponReport: GetCouponReportUseCase,
+	) {}
+
+	@Post()
+	async create(
+		@Body(new ZodValidationPipe(createCouponSchema))
+		body: CreateCouponSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		return await this.createCoupon.execute({
+			...body,
+			adminUserId: currentUser.id,
+		});
+	}
+
+	@Get()
+	async list(@CurrentUser() _currentUser: AuthenticatedUser) {
+		return await this.listCoupons.execute();
+	}
+
+	@Post(':couponId/disable')
+	@HttpCode(200)
+	async disable(
+		@Param('couponId', new ZodValidationPipe(couponIdParamSchema))
+		couponId: CouponIdParamSchemaInput,
+		@CurrentUser() currentUser: AuthenticatedUser,
+	) {
+		await this.disableCoupon.execute({
+			couponId,
+			adminUserId: currentUser.id,
+		});
+		return { ok: true };
+	}
+
+	@Get(':couponId/report')
+	async report(
+		@Param('couponId', new ZodValidationPipe(couponIdParamSchema))
+		couponId: CouponIdParamSchemaInput,
+		@CurrentUser() _currentUser: AuthenticatedUser,
+	) {
+		return await this.getCouponReport.execute({ couponId });
+	}
+}

--- a/apps/api/src/modules/orders/presentation/coupons-admin.request-schemas.ts
+++ b/apps/api/src/modules/orders/presentation/coupons-admin.request-schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export {
+	type CreateCouponInput as CreateCouponSchemaInput,
+	createCouponSchema,
+} from '@packages/shared/coupons/create-coupon.schema';
+
+export const couponIdParamSchema = z.string().trim().min(1);
+export type CouponIdParamSchemaInput = z.infer<typeof couponIdParamSchema>;

--- a/apps/api/test/orders.e2e-spec.ts
+++ b/apps/api/test/orders.e2e-spec.ts
@@ -2,9 +2,11 @@ import { createHmac } from 'node:crypto';
 import { CHAT_REPOSITORY_KEY } from '@modules/chat/application/ports/chat-repository.port';
 import { CHAT_THREAD_WRITER_KEY } from '@modules/chat/application/ports/chat-thread-writer.port';
 import { CLIENT_ORDER_READER_KEY } from '@modules/orders/application/ports/client-order-reader.port';
+import { COUPON_EVENT_RECORDER_KEY } from '@modules/orders/application/ports/coupon-event-recorder.port';
 import type { StoredCoupon } from '@modules/orders/application/ports/coupon-lookup.port';
 import { COUPON_LOOKUP_PORT_KEY } from '@modules/orders/application/ports/coupon-lookup.port';
 import { ORDER_CHECKOUT_PORT_KEY } from '@modules/orders/application/ports/order-checkout.port';
+import { ORDER_CLIENT_READER_KEY } from '@modules/orders/application/ports/order-client-reader.port';
 import {
 	ORDER_PRICING_VERSION_REPOSITORY_KEY,
 	type OrderPricingVersionRepositoryPort,
@@ -23,6 +25,7 @@ import {
 	getTestJwtSecret,
 	signTestAccessToken as signToken,
 } from './support/auth-token';
+import { makeStoredCoupon } from './support/coupons/make-stored-coupon';
 import { InMemoryChatRepository } from './support/in-memory/chat/in-memory-chat.repository';
 import { InMemoryOrderRepository } from './support/in-memory/orders/in-memory-order.repository';
 import { InMemoryOrderCheckoutRepository } from './support/in-memory/orders/in-memory-order-checkout.repository';
@@ -32,6 +35,7 @@ import { InMemoryOrderQuoteRepository } from './support/in-memory/orders/in-memo
 describe('Orders (e2e)', () => {
 	let app: ApiHttpApp;
 	let couponLookup: CouponLookupStub;
+	let clientReader: ClientReaderStub;
 	let orderRepository: InMemoryOrderRepository;
 	let chatRepository: InMemoryChatRepository;
 	let pricingVersions: OrderPricingVersionRepositoryPort;
@@ -52,6 +56,28 @@ describe('Orders (e2e)', () => {
 
 		async findById(id: string): Promise<StoredCoupon | null> {
 			return this.coupons.get(id) ?? null;
+		}
+
+		async countConfirmedUsage(): Promise<number> {
+			return 0;
+		}
+
+		async countConfirmedUsageForClient(): Promise<number> {
+			return 0;
+		}
+	}
+
+	class ClientReaderStub {
+		public emails = new Map<string, string>();
+
+		constructor(private readonly orders: InMemoryOrderRepository) {}
+
+		async findEmailById(clientId: string): Promise<string | null> {
+			return this.emails.get(clientId) ?? null;
+		}
+
+		async hasPaidOrder(clientId: string): Promise<boolean> {
+			return (await this.orders.existsPaidOrderForClient?.(clientId)) ?? false;
 		}
 	}
 
@@ -153,6 +179,7 @@ describe('Orders (e2e)', () => {
 	beforeEach(async () => {
 		couponLookup = new CouponLookupStub();
 		orderRepository = new InMemoryOrderRepository();
+		clientReader = new ClientReaderStub(orderRepository);
 		chatRepository = new InMemoryChatRepository(orderRepository);
 		const moduleRef = await Test.createTestingModule({
 			imports: [AppModule],
@@ -161,6 +188,10 @@ describe('Orders (e2e)', () => {
 			.useValue(orderRepository)
 			.overrideProvider(CLIENT_ORDER_READER_KEY)
 			.useValue(orderRepository)
+			.overrideProvider(ORDER_CLIENT_READER_KEY)
+			.useValue(clientReader)
+			.overrideProvider(COUPON_EVENT_RECORDER_KEY)
+			.useValue({ record: async (): Promise<void> => undefined })
 			.overrideProvider(ORDER_CHECKOUT_PORT_KEY)
 			.useClass(InMemoryOrderCheckoutRepository)
 			.overrideProvider(ORDER_QUOTE_REPOSITORY_KEY)
@@ -682,14 +713,16 @@ describe('Orders (e2e)', () => {
 
 	it('returns the same invalid coupon response for missing and inactive coupons', async () => {
 		const token = signToken({ sub: 'client-coupon', role: 'CLIENT' });
-		couponLookup.coupons.set('INACTIVE10', {
-			id: 'coupon-inactive',
-			code: 'INACTIVE10',
-			discountType: 'percentage',
-			discount: 10,
-			isActive: false,
-			firstOrderOnly: false,
-		});
+		couponLookup.coupons.set(
+			'INACTIVE10',
+			makeStoredCoupon({
+				id: 'coupon-inactive',
+				code: 'INACTIVE10',
+				discountType: 'percentage',
+				discount: 10,
+				isActive: false,
+			}),
+		);
 
 		await requestHttp(app)
 			.post('/orders/quote')
@@ -716,17 +749,20 @@ describe('Orders (e2e)', () => {
 
 	it('returns the same invalid coupon response when a first-order coupon becomes ineligible', async () => {
 		const token = signToken({ sub: 'client-first-order', role: 'CLIENT' });
-		couponLookup.coupons.set('FIRST10', {
-			id: 'coupon-first',
-			code: 'FIRST10',
-			discountType: 'percentage',
-			discount: 10,
-			isActive: true,
-			firstOrderOnly: true,
-		});
+		couponLookup.coupons.set(
+			'FIRST10',
+			makeStoredCoupon({
+				id: 'coupon-first',
+				code: 'FIRST10',
+				discountType: 'percentage',
+				discount: 10,
+				firstOrderOnly: true,
+			}),
+		);
 
 		const existingOrder = await createQuotedOrder(token);
-		expect(await orderRepository.findById(existingOrder.id)).toBeTruthy();
+		await markOrderAsPaidUseCase.execute({ orderId: existingOrder.id });
+		expect(await clientReader.hasPaidOrder('client-first-order')).toBe(true);
 
 		await requestHttp(app)
 			.post('/orders/quote')
@@ -743,14 +779,16 @@ describe('Orders (e2e)', () => {
 	it('rejects consuming a stale first-order coupon quote after another order is created', async () => {
 		const token = signToken({ sub: 'client-stale-coupon', role: 'CLIENT' });
 		let couponQuoteId = '';
-		couponLookup.coupons.set('coupon-first', {
-			id: 'coupon-first',
-			code: 'FIRST10',
-			discountType: 'percentage',
-			discount: 10,
-			isActive: true,
-			firstOrderOnly: true,
-		});
+		couponLookup.coupons.set(
+			'coupon-first',
+			makeStoredCoupon({
+				id: 'coupon-first',
+				code: 'FIRST10',
+				discountType: 'percentage',
+				discount: 10,
+				firstOrderOnly: true,
+			}),
+		);
 
 		await requestHttp(app)
 			.post('/orders/quote')
@@ -762,7 +800,8 @@ describe('Orders (e2e)', () => {
 			})
 			.execute();
 
-		await createQuotedOrder(token);
+		const otherOrder = await createQuotedOrder(token);
+		await markOrderAsPaidUseCase.execute({ orderId: otherOrder.id });
 
 		await requestHttp(app)
 			.post('/orders')

--- a/apps/api/test/support/coupons/make-stored-coupon.ts
+++ b/apps/api/test/support/coupons/make-stored-coupon.ts
@@ -1,0 +1,26 @@
+import type { StoredCoupon } from '@modules/orders/application/ports/coupon-lookup.port';
+
+export function makeStoredCoupon(
+	overrides: Partial<StoredCoupon> = {},
+): StoredCoupon {
+	return {
+		id: 'coupon-1',
+		code: 'WELCOME10',
+		discountType: 'percentage',
+		discount: 10,
+		isActive: true,
+		firstOrderOnly: false,
+		allowedServiceTypes: [],
+		allowedQueues: [],
+		allowedEmails: [],
+		minSubtotal: null,
+		maxSubtotal: null,
+		minRankIndex: null,
+		maxRankIndex: null,
+		minExtrasCount: null,
+		requiredExtra: null,
+		globalUsageLimit: null,
+		perUserUsageLimit: null,
+		...overrides,
+	};
+}

--- a/apps/api/test/support/in-memory/orders/in-memory-order-checkout.repository.ts
+++ b/apps/api/test/support/in-memory/orders/in-memory-order-checkout.repository.ts
@@ -81,14 +81,8 @@ export class InMemoryOrderCheckoutRepository implements OrderCheckoutPort {
 		if (!input.couponId) return;
 
 		const coupon = await this.couponLookup.findById(input.couponId);
-		if (!coupon) throw new OrderCouponInvalidError();
-		if (!coupon.isActive) throw new OrderCouponInvalidError();
-		if (!Number.isFinite(coupon.discount) || coupon.discount < 0)
-			throw new OrderCouponInvalidError();
-		if (coupon.discountType !== 'percentage' && coupon.discountType !== 'fixed')
-			throw new OrderCouponInvalidError();
-		if (!coupon.firstOrderOnly) return;
-		if (await this.orderRepository.existsForClient?.(input.clientId))
+		if (!coupon || !coupon.firstOrderOnly) return;
+		if (await this.orderRepository.existsPaidOrderForClient?.(input.clientId))
 			throw new OrderCouponInvalidError();
 	}
 }

--- a/apps/api/test/support/in-memory/orders/in-memory-order.repository.ts
+++ b/apps/api/test/support/in-memory/orders/in-memory-order.repository.ts
@@ -56,6 +56,20 @@ export class InMemoryOrderRepository
 		);
 	}
 
+	existsPaidOrderForClient(clientId: string): Promise<boolean> {
+		const paidStatuses = new Set<OrderStatus>([
+			OrderStatus.PENDING_BOOSTER,
+			OrderStatus.IN_PROGRESS,
+			OrderStatus.COMPLETED,
+		]);
+		return Promise.resolve(
+			Array.from(this.orders.values()).some(
+				(order) =>
+					order.clientId === clientId && paidStatuses.has(order.status),
+			),
+		);
+	}
+
 	findRecentForClient(
 		clientId: string,
 		limit: number,

--- a/apps/web/src/app/(dashboard)/admin/coupons/page.tsx
+++ b/apps/web/src/app/(dashboard)/admin/coupons/page.tsx
@@ -1,0 +1,10 @@
+import { getAdminCoupons } from '@/modules/admin-dashboard/actions/coupon-actions';
+import { AdminCouponsPage } from '@/modules/admin-dashboard/presentation/coupons/admin-coupons-page';
+
+const Page = async () => {
+	const coupons = await getAdminCoupons();
+
+	return <AdminCouponsPage coupons={coupons} />;
+};
+
+export default Page;

--- a/apps/web/src/modules/admin-dashboard/actions/coupon-actions.ts
+++ b/apps/web/src/modules/admin-dashboard/actions/coupon-actions.ts
@@ -1,0 +1,150 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { api } from '@/shared/api-client-management/api-client';
+import { getAuthErrorMessage } from '@/shared/api-client-management/user-messages';
+import { redirectOnAuthError } from '@/shared/auth/redirect-on-auth-error';
+import type { AuthSession } from '@/shared/auth/session';
+import { getAuthSession } from '@/shared/auth/session';
+import { assertSameOriginRequest } from '@/shared/security/origin';
+import type {
+	AdminCouponSummaryOutput,
+	CreateCouponPayload,
+} from '../server/coupon-contracts';
+import {
+	createAdminCoupon,
+	disableAdminCoupon,
+	getAdminCoupons as getAdminCouponsFromApi,
+} from '../server/coupon-service';
+
+export type CouponActionState = {
+	error?: string;
+	success?: boolean;
+};
+
+const getAdminSessionOrRedirect = async () => {
+	const session = await getAuthSession();
+	if (!session || session.userRole !== 'ADMIN' || !session.userId)
+		redirect('/login');
+	return session as AuthSession & { userId: string };
+};
+
+const renderReadApiRequest = <T>(
+	path: string,
+	init: RequestInit & { auth: true },
+) => api.request<T>(path, { ...init, allowSessionRefresh: false });
+
+const optionalString = (
+	value: FormDataEntryValue | null,
+): string | undefined => {
+	const text = String(value ?? '').trim();
+	return text.length > 0 ? text : undefined;
+};
+
+const optionalInt = (value: FormDataEntryValue | null): number | undefined => {
+	const text = String(value ?? '').trim();
+	if (text.length === 0) return undefined;
+	const parsed = Number.parseInt(text, 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const optionalReaisToCents = (
+	value: FormDataEntryValue | null,
+): number | undefined => {
+	const text = String(value ?? '')
+		.trim()
+		.replace(',', '.');
+	if (text.length === 0) return undefined;
+	const parsed = Number.parseFloat(text);
+	return Number.isFinite(parsed) ? Math.round(parsed * 100) : undefined;
+};
+
+const splitList = (value: FormDataEntryValue | null): string[] =>
+	String(value ?? '')
+		.split(/[\n,]/)
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+
+const optionalRank = (
+	league: FormDataEntryValue | null,
+	division: FormDataEntryValue | null,
+): { league: string; division: string } | undefined => {
+	const leagueText = optionalString(league);
+	const divisionText = optionalString(division);
+	if (!leagueText || !divisionText) return undefined;
+	return { league: leagueText, division: divisionText };
+};
+
+const parseCreateCouponForm = (formData: FormData): CreateCouponPayload => {
+	const discountType =
+		formData.get('discountType') === 'fixed' ? 'fixed' : 'percentage';
+	return {
+		code: optionalString(formData.get('code')),
+		discountType,
+		discount: Number(formData.get('discount') ?? 0),
+		firstOrderOnly: formData.get('firstOrderOnly') === 'on',
+		allowedServiceTypes: formData
+			.getAll('allowedServiceTypes')
+			.map((entry) => String(entry)),
+		allowedQueues: splitList(formData.get('allowedQueues')),
+		allowedEmails: splitList(formData.get('allowedEmails')),
+		minSubtotal: optionalReaisToCents(formData.get('minSubtotal')),
+		maxSubtotal: optionalReaisToCents(formData.get('maxSubtotal')),
+		minRank: optionalRank(
+			formData.get('minRankLeague'),
+			formData.get('minRankDivision'),
+		),
+		maxRank: optionalRank(
+			formData.get('maxRankLeague'),
+			formData.get('maxRankDivision'),
+		),
+		minExtrasCount: optionalInt(formData.get('minExtrasCount')),
+		requiredExtra: optionalString(formData.get('requiredExtra')),
+		globalUsageLimit: optionalInt(formData.get('globalUsageLimit')),
+		perUserUsageLimit: optionalInt(formData.get('perUserUsageLimit')),
+	};
+};
+
+export const getAdminCoupons = async (): Promise<
+	AdminCouponSummaryOutput[]
+> => {
+	await getAdminSessionOrRedirect();
+	try {
+		return await getAdminCouponsFromApi(renderReadApiRequest);
+	} catch (error) {
+		return redirectOnAuthError(error);
+	}
+};
+
+export const createAdminCouponAction = async (
+	_state: CouponActionState,
+	formData: FormData,
+): Promise<CouponActionState> => {
+	try {
+		await assertSameOriginRequest();
+		await getAdminSessionOrRedirect();
+		await createAdminCoupon(parseCreateCouponForm(formData), api.request);
+		revalidatePath('/admin/coupons');
+		return { success: true };
+	} catch (error) {
+		return { error: getAuthErrorMessage(error) };
+	}
+};
+
+export const disableAdminCouponAction = async (
+	_state: CouponActionState,
+	formData: FormData,
+): Promise<CouponActionState> => {
+	try {
+		await assertSameOriginRequest();
+		await getAdminSessionOrRedirect();
+		const couponId = String(formData.get('couponId') ?? '').trim();
+		if (!couponId) return { error: 'Cupom inválido.' };
+		await disableAdminCoupon(couponId, api.request);
+		revalidatePath('/admin/coupons');
+		return { success: true };
+	} catch (error) {
+		return { error: getAuthErrorMessage(error) };
+	}
+};

--- a/apps/web/src/modules/admin-dashboard/presentation/coupons/admin-coupons-page.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/coupons/admin-coupons-page.tsx
@@ -1,0 +1,90 @@
+import type { AdminCouponSummaryOutput } from '../../server/coupon-contracts';
+import { AdminCreateCouponForm } from './admin-create-coupon-form';
+import { AdminDisableCouponButton } from './admin-disable-coupon-button';
+
+const formatDiscount = (coupon: AdminCouponSummaryOutput): string =>
+	coupon.discountType === 'percentage'
+		? `${coupon.discount}%`
+		: `R$${coupon.discount.toFixed(2)}`;
+
+const formatLimit = (value: number | null): string =>
+	value === null ? '∞' : String(value);
+
+export const AdminCouponsPage = ({
+	coupons,
+}: {
+	coupons: AdminCouponSummaryOutput[];
+}) => {
+	return (
+		<div className="grid gap-6">
+			<header className="grid gap-1">
+				<h1 className="text-sm font-black uppercase tracking-[0.22em] text-white">
+					Cupons
+				</h1>
+				<p className="text-xs text-white/45">
+					Crie, liste e desative cupons de desconto.
+				</p>
+			</header>
+
+			<AdminCreateCouponForm />
+
+			<div className="overflow-x-auto rounded-sm border border-white/10">
+				<table className="w-full min-w-[720px] text-left text-xs">
+					<thead className="bg-white/[0.03] text-[10px] uppercase tracking-widest text-white/35">
+						<tr>
+							<th className="px-3 py-2">Código</th>
+							<th className="px-3 py-2">Desconto</th>
+							<th className="px-3 py-2">Status</th>
+							<th className="px-3 py-2">Uso</th>
+							<th className="px-3 py-2">Limite global</th>
+							<th className="px-3 py-2">Limite/usuário</th>
+							<th className="px-3 py-2">1ª compra</th>
+							<th className="px-3 py-2 text-right">Ações</th>
+						</tr>
+					</thead>
+					<tbody>
+						{coupons.length === 0 ? (
+							<tr>
+								<td className="px-3 py-6 text-white/35" colSpan={8}>
+									Nenhum cupom criado ainda.
+								</td>
+							</tr>
+						) : (
+							coupons.map((coupon) => (
+								<tr
+									key={coupon.id}
+									className="border-t border-white/5 text-white/70"
+								>
+									<td className="px-3 py-2 font-bold text-white">
+										{coupon.code}
+									</td>
+									<td className="px-3 py-2">{formatDiscount(coupon)}</td>
+									<td className="px-3 py-2">
+										{coupon.isActive ? 'Ativo' : 'Desativado'}
+									</td>
+									<td className="px-3 py-2">{coupon.usageCount}</td>
+									<td className="px-3 py-2">
+										{formatLimit(coupon.globalUsageLimit)}
+									</td>
+									<td className="px-3 py-2">
+										{formatLimit(coupon.perUserUsageLimit)}
+									</td>
+									<td className="px-3 py-2">
+										{coupon.firstOrderOnly ? 'Sim' : 'Não'}
+									</td>
+									<td className="px-3 py-2 text-right">
+										{coupon.isActive ? (
+											<AdminDisableCouponButton couponId={coupon.id} />
+										) : (
+											<span className="text-white/25">—</span>
+										)}
+									</td>
+								</tr>
+							))
+						)}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/modules/admin-dashboard/presentation/coupons/admin-create-coupon-form.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/coupons/admin-create-coupon-form.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { orderExtraTypes } from '@packages/shared/orders/order-extra';
+import { orderRankProgression } from '@packages/shared/orders/order-rank-progression';
+import { orderServiceTypes } from '@packages/shared/orders/service-type';
+import { TicketPercent } from 'lucide-react';
+import { useActionState, useEffect, useRef } from 'react';
+import { getButtonClassName } from '@/shared/ui/components/button';
+import { fieldSurface } from '@/shared/ui/styles/classes';
+import { cn } from '@/shared/ui/utils/cn';
+import {
+	type CouponActionState,
+	createAdminCouponAction,
+} from '../../actions/coupon-actions';
+
+const serviceTypeLabels: Record<string, string> = {
+	elo_boost: 'Elojob',
+	duo_boost: 'Duo Boost',
+	md5: 'MD5',
+	coaching: 'Coaching',
+};
+
+const fieldLabel =
+	'text-[10px] font-black uppercase tracking-widest text-white/35';
+
+const rankOptions = orderRankProgression.map((step) => ({
+	value: `${step.league}:${step.division}`,
+	label: `${step.league} ${step.division}`,
+	league: step.league,
+	division: step.division,
+}));
+
+export const AdminCreateCouponForm = () => {
+	const [state, formAction, pending] = useActionState<
+		CouponActionState,
+		FormData
+	>(createAdminCouponAction, {});
+	const formRef = useRef<HTMLFormElement>(null);
+
+	useEffect(() => {
+		if (state.success) formRef.current?.reset();
+	}, [state.success]);
+
+	return (
+		<form
+			ref={formRef}
+			action={formAction}
+			className="grid gap-4 rounded-sm border border-white/10 bg-white/[0.02] p-4"
+		>
+			<div className="grid gap-3 md:grid-cols-[200px_160px_minmax(0,1fr)]">
+				<label className="grid gap-2">
+					<span className={fieldLabel}>Código (opcional)</span>
+					<input
+						name="code"
+						className={cn(fieldSurface, 'bg-black/20')}
+						placeholder="gerado se vazio"
+						maxLength={24}
+					/>
+				</label>
+				<label className="grid gap-2">
+					<span className={fieldLabel}>Tipo</span>
+					<select
+						name="discountType"
+						className={cn(fieldSurface, 'bg-black/20')}
+						defaultValue="percentage"
+					>
+						<option value="percentage">Percentual (%)</option>
+						<option value="fixed">Valor fixo (R$)</option>
+					</select>
+				</label>
+				<label className="grid gap-2">
+					<span className={fieldLabel}>Desconto</span>
+					<input
+						name="discount"
+						type="number"
+						step="0.01"
+						min="0"
+						className={cn(fieldSurface, 'bg-black/20')}
+						required
+					/>
+				</label>
+			</div>
+
+			<fieldset className="grid gap-2">
+				<span className={fieldLabel}>Serviços permitidos (vazio = todos)</span>
+				<div className="flex flex-wrap gap-3">
+					{orderServiceTypes.map((serviceType) => (
+						<label
+							key={serviceType}
+							className="flex items-center gap-2 text-xs text-white/70"
+						>
+							<input
+								type="checkbox"
+								name="allowedServiceTypes"
+								value={serviceType}
+							/>
+							{serviceTypeLabels[serviceType] ?? serviceType}
+						</label>
+					))}
+				</div>
+			</fieldset>
+
+			<div className="grid gap-3 md:grid-cols-2">
+				<label className="grid gap-2">
+					<span className={fieldLabel}>Subtotal mínimo (R$)</span>
+					<input
+						name="minSubtotal"
+						type="number"
+						step="0.01"
+						min="0"
+						className={cn(fieldSurface, 'bg-black/20')}
+					/>
+				</label>
+				<label className="grid gap-2">
+					<span className={fieldLabel}>Subtotal máximo (R$)</span>
+					<input
+						name="maxSubtotal"
+						type="number"
+						step="0.01"
+						min="0"
+						className={cn(fieldSurface, 'bg-black/20')}
+					/>
+				</label>
+			</div>
+
+			<div className="grid gap-3 md:grid-cols-2">
+				<div className="grid gap-2">
+					<span className={fieldLabel}>Rank mínimo</span>
+					<RankSelect prefix="minRank" />
+				</div>
+				<div className="grid gap-2">
+					<span className={fieldLabel}>Rank máximo</span>
+					<RankSelect prefix="maxRank" />
+				</div>
+			</div>
+
+			<div className="grid gap-3 md:grid-cols-2">
+				<label className="grid gap-2">
+					<span className={fieldLabel}>
+						Filas permitidas (separadas por vírgula)
+					</span>
+					<input
+						name="allowedQueues"
+						className={cn(fieldSurface, 'bg-black/20')}
+						placeholder="solo_duo, flex"
+					/>
+				</label>
+				<label className="grid gap-2">
+					<span className={fieldLabel}>E-mails permitidos (vírgula/linha)</span>
+					<textarea
+						name="allowedEmails"
+						className={cn(fieldSurface, 'min-h-11 bg-black/20')}
+						placeholder="cliente@email.com"
+					/>
+				</label>
+			</div>
+
+			<div className="grid gap-3 md:grid-cols-2">
+				<label className="grid gap-2">
+					<span className={fieldLabel}>Extra obrigatório</span>
+					<select
+						name="requiredExtra"
+						className={cn(fieldSurface, 'bg-black/20')}
+						defaultValue=""
+					>
+						<option value="">Nenhum</option>
+						{orderExtraTypes.map((extra) => (
+							<option key={extra} value={extra}>
+								{extra}
+							</option>
+						))}
+					</select>
+				</label>
+				<label className="grid gap-2">
+					<span className={fieldLabel}>Mínimo de extras</span>
+					<input
+						name="minExtrasCount"
+						type="number"
+						min="1"
+						className={cn(fieldSurface, 'bg-black/20')}
+					/>
+				</label>
+			</div>
+
+			<div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+				<label className="grid gap-2">
+					<span className={fieldLabel}>Limite global de uso</span>
+					<input
+						name="globalUsageLimit"
+						type="number"
+						min="1"
+						className={cn(fieldSurface, 'bg-black/20')}
+						placeholder="ilimitado"
+					/>
+				</label>
+				<label className="grid gap-2">
+					<span className={fieldLabel}>Limite por usuário</span>
+					<input
+						name="perUserUsageLimit"
+						type="number"
+						min="1"
+						className={cn(fieldSurface, 'bg-black/20')}
+						placeholder="ilimitado"
+					/>
+				</label>
+				<label className="flex items-end gap-2 text-xs text-white/70">
+					<input type="checkbox" name="firstOrderOnly" />
+					Apenas primeira compra
+				</label>
+			</div>
+
+			<div className="flex items-center justify-between gap-4">
+				<p className="min-h-4 text-[10px] font-medium text-red-300">
+					{state.error ?? (state.success ? 'Cupom criado.' : '')}
+				</p>
+				<button
+					type="submit"
+					disabled={pending}
+					className={getButtonClassName({
+						size: 'md',
+						variant: 'secondary',
+						className: 'min-h-11 gap-2',
+					})}
+				>
+					<TicketPercent className="h-4 w-4" />
+					{pending ? 'Criando' : 'Criar cupom'}
+				</button>
+			</div>
+		</form>
+	);
+};
+
+const RankSelect = ({ prefix }: { prefix: 'minRank' | 'maxRank' }) => (
+	<>
+		<select
+			className={cn(fieldSurface, 'bg-black/20')}
+			defaultValue=""
+			onChange={(event) => {
+				const [league, division] = event.target.value.split(':');
+				const form = event.target.form;
+				if (!form) return;
+				(form.elements.namedItem(`${prefix}League`) as HTMLInputElement).value =
+					league ?? '';
+				(
+					form.elements.namedItem(`${prefix}Division`) as HTMLInputElement
+				).value = division ?? '';
+			}}
+		>
+			<option value="">Sem limite</option>
+			{rankOptions.map((option) => (
+				<option key={option.value} value={option.value}>
+					{option.label}
+				</option>
+			))}
+		</select>
+		<input type="hidden" name={`${prefix}League`} />
+		<input type="hidden" name={`${prefix}Division`} />
+	</>
+);

--- a/apps/web/src/modules/admin-dashboard/presentation/coupons/admin-disable-coupon-button.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/coupons/admin-disable-coupon-button.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useActionState } from 'react';
+import { getButtonClassName } from '@/shared/ui/components/button';
+import {
+	type CouponActionState,
+	disableAdminCouponAction,
+} from '../../actions/coupon-actions';
+
+export const AdminDisableCouponButton = ({
+	couponId,
+}: {
+	couponId: string;
+}) => {
+	const [state, formAction, pending] = useActionState<
+		CouponActionState,
+		FormData
+	>(disableAdminCouponAction, {});
+
+	return (
+		<form action={formAction} className="flex flex-col items-end gap-1">
+			<input type="hidden" name="couponId" value={couponId} />
+			<button
+				type="submit"
+				disabled={pending}
+				className={getButtonClassName({ variant: 'danger', size: 'sm' })}
+			>
+				{pending ? 'Desativando' : 'Desativar'}
+			</button>
+			{state.error ? (
+				<span className="text-[10px] font-medium text-red-300">
+					{state.error}
+				</span>
+			) : null}
+		</form>
+	);
+};

--- a/apps/web/src/modules/admin-dashboard/presentation/dashboard/admin-navigation.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/dashboard/admin-navigation.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { BarChart3, FileText, Ticket, Users } from 'lucide-react';
+import {
+	BarChart3,
+	FileText,
+	Ticket,
+	TicketPercent,
+	Users,
+} from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import type { ElementType } from 'react';
 import { DashboardNavItem } from '@/shared/dashboard/dashboard-nav-item';
@@ -15,6 +21,7 @@ const navigationItems: NavigationItem[] = [
 	{ href: '/admin', label: 'Visão geral', icon: BarChart3 },
 	{ href: '/admin/users', label: 'Usuários', icon: Users },
 	{ href: '/admin/orders', label: 'Pedidos', icon: FileText },
+	{ href: '/admin/coupons', label: 'Cupons', icon: TicketPercent },
 	{ href: '/admin/support', label: 'Suporte', icon: Ticket },
 ];
 

--- a/apps/web/src/modules/admin-dashboard/server/coupon-contracts.ts
+++ b/apps/web/src/modules/admin-dashboard/server/coupon-contracts.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+export const adminCouponSummarySchema = z.object({
+	id: z.string(),
+	code: z.string(),
+	discountType: z.enum(['percentage', 'fixed']),
+	discount: z.number(),
+	isActive: z.boolean(),
+	firstOrderOnly: z.boolean(),
+	allowedServiceTypes: z.array(z.string()),
+	allowedQueues: z.array(z.string()),
+	allowedEmails: z.array(z.string()),
+	minSubtotal: z.number().nullable(),
+	maxSubtotal: z.number().nullable(),
+	minRankIndex: z.number().nullable(),
+	maxRankIndex: z.number().nullable(),
+	minExtrasCount: z.number().nullable(),
+	requiredExtra: z.string().nullable(),
+	globalUsageLimit: z.number().nullable(),
+	perUserUsageLimit: z.number().nullable(),
+	usageCount: z.number().int().nonnegative(),
+	createdAt: z.coerce.string(),
+});
+
+export const adminCouponReportSchema = z.object({
+	couponId: z.string(),
+	code: z.string(),
+	usageCount: z.number().int().nonnegative(),
+	discountTotalCents: z.number().int().nonnegative(),
+	revenueCents: z.number().int().nonnegative(),
+	uniqueClients: z.number().int().nonnegative(),
+	appliedCount: z.number().int().nonnegative(),
+	conversionRate: z.number(),
+	eventCounts: z.record(z.string(), z.number()),
+});
+
+export type AdminCouponSummaryOutput = z.infer<typeof adminCouponSummarySchema>;
+export type AdminCouponReportOutput = z.infer<typeof adminCouponReportSchema>;
+
+export type CreateCouponPayload = {
+	code?: string;
+	discountType: 'percentage' | 'fixed';
+	discount: number;
+	firstOrderOnly: boolean;
+	allowedServiceTypes: string[];
+	allowedQueues: string[];
+	allowedEmails: string[];
+	minSubtotal?: number;
+	maxSubtotal?: number;
+	minRank?: { league: string; division: string };
+	maxRank?: { league: string; division: string };
+	minExtrasCount?: number;
+	requiredExtra?: string;
+	globalUsageLimit?: number;
+	perUserUsageLimit?: number;
+};

--- a/apps/web/src/modules/admin-dashboard/server/coupon-service.ts
+++ b/apps/web/src/modules/admin-dashboard/server/coupon-service.ts
@@ -1,0 +1,52 @@
+import type { AuthenticatedApiRequest } from './admin-service';
+import {
+	type AdminCouponReportOutput,
+	type AdminCouponSummaryOutput,
+	adminCouponReportSchema,
+	adminCouponSummarySchema,
+	type CreateCouponPayload,
+} from './coupon-contracts';
+
+type ApiRequest = <T>(
+	path: string,
+	init: RequestInit & { auth: true },
+) => Promise<T>;
+
+export const getAdminCoupons = async (
+	apiRequest: AuthenticatedApiRequest,
+): Promise<AdminCouponSummaryOutput[]> => {
+	const response = await apiRequest<unknown>('/admin/coupons', { auth: true });
+	return adminCouponSummarySchema.array().parse(response);
+};
+
+export const getAdminCouponReport = async (
+	couponId: string,
+	apiRequest: AuthenticatedApiRequest,
+): Promise<AdminCouponReportOutput> => {
+	const response = await apiRequest<unknown>(
+		`/admin/coupons/${encodeURIComponent(couponId)}/report`,
+		{ auth: true },
+	);
+	return adminCouponReportSchema.parse(response);
+};
+
+export const createAdminCoupon = async (
+	payload: CreateCouponPayload,
+	apiRequest: ApiRequest,
+): Promise<{ id: string; code: string }> => {
+	return await apiRequest<{ id: string; code: string }>('/admin/coupons', {
+		auth: true,
+		method: 'POST',
+		body: JSON.stringify(payload),
+	});
+};
+
+export const disableAdminCoupon = async (
+	couponId: string,
+	apiRequest: ApiRequest,
+): Promise<void> => {
+	await apiRequest(`/admin/coupons/${encodeURIComponent(couponId)}/disable`, {
+		auth: true,
+		method: 'POST',
+	});
+};

--- a/packages/database/prisma/migrations/20260627004323_add_coupon_targeting_and_events/migration.sql
+++ b/packages/database/prisma/migrations/20260627004323_add_coupon_targeting_and_events/migration.sql
@@ -1,0 +1,41 @@
+-- CreateEnum
+CREATE TYPE "CouponEventType" AS ENUM ('created', 'disabled', 'validation_failed', 'eligibility_failed', 'usage_limit_failed', 'applied_at_checkout', 'confirmed_by_payment');
+
+-- AlterTable
+ALTER TABLE "coupons" ADD COLUMN     "allowedEmails" TEXT[],
+ADD COLUMN     "allowedQueues" TEXT[],
+ADD COLUMN     "allowedServiceTypes" "ServiceType"[],
+ADD COLUMN     "globalUsageLimit" INTEGER,
+ADD COLUMN     "maxRankIndex" INTEGER,
+ADD COLUMN     "maxSubtotal" INTEGER,
+ADD COLUMN     "minExtrasCount" INTEGER,
+ADD COLUMN     "minRankIndex" INTEGER,
+ADD COLUMN     "minSubtotal" INTEGER,
+ADD COLUMN     "perUserUsageLimit" INTEGER,
+ADD COLUMN     "requiredExtra" TEXT;
+
+-- CreateTable
+CREATE TABLE "coupon_events" (
+    "id" TEXT NOT NULL,
+    "couponId" TEXT,
+    "code" TEXT NOT NULL,
+    "type" "CouponEventType" NOT NULL,
+    "clientId" TEXT,
+    "orderId" TEXT,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "coupon_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "coupon_events_couponId_type_idx" ON "coupon_events"("couponId", "type");
+
+-- CreateIndex
+CREATE INDEX "coupon_events_type_createdAt_idx" ON "coupon_events"("type", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "coupon_events_code_idx" ON "coupon_events"("code");
+
+-- AddForeignKey
+ALTER TABLE "coupon_events" ADD CONSTRAINT "coupon_events_couponId_fkey" FOREIGN KEY ("couponId") REFERENCES "coupons"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260627010125_coupon_array_defaults_backfill/migration.sql
+++ b/packages/database/prisma/migrations/20260627010125_coupon_array_defaults_backfill/migration.sql
@@ -1,0 +1,9 @@
+-- Backfill rows created before the targeting columns existed (added without a default).
+UPDATE "coupons" SET "allowedServiceTypes" = ARRAY[]::"ServiceType"[] WHERE "allowedServiceTypes" IS NULL;
+UPDATE "coupons" SET "allowedQueues" = ARRAY[]::TEXT[] WHERE "allowedQueues" IS NULL;
+UPDATE "coupons" SET "allowedEmails" = ARRAY[]::TEXT[] WHERE "allowedEmails" IS NULL;
+
+-- AlterTable
+ALTER TABLE "coupons" ALTER COLUMN "allowedEmails" SET DEFAULT ARRAY[]::TEXT[],
+ALTER COLUMN "allowedQueues" SET DEFAULT ARRAY[]::TEXT[],
+ALTER COLUMN "allowedServiceTypes" SET DEFAULT ARRAY[]::"ServiceType"[];

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -51,6 +51,16 @@ enum CouponDiscountType {
   FIXED
 }
 
+enum CouponEventType {
+  created
+  disabled
+  validation_failed
+  eligibility_failed
+  usage_limit_failed
+  applied_at_checkout
+  confirmed_by_payment
+}
+
 enum PricingVersionStatus {
   DRAFT
   ACTIVE
@@ -312,13 +322,47 @@ model Coupon {
   discount       Float
   isActive       Boolean  @default(true)
   firstOrderOnly Boolean  @default(false)
+
+  // Targeting rules. Empty list / null means "no restriction on this dimension".
+  allowedServiceTypes ServiceType[] @default([])
+  allowedQueues       String[]      @default([])
+  allowedEmails       String[]      @default([])
+  minSubtotal         Int?
+  maxSubtotal         Int?
+  minRankIndex        Int?
+  maxRankIndex        Int?
+  minExtrasCount      Int?
+  requiredExtra       String?
+
+  // Usage limits. Null means unlimited.
+  globalUsageLimit  Int?
+  perUserUsageLimit Int?
+
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
   orders Order[]
   orderQuotes OrderQuote[]
+  events CouponEvent[]
 
   @@map("coupons")
+}
+
+model CouponEvent {
+  id        String          @id @default(cuid())
+  couponId  String?
+  coupon    Coupon?         @relation(fields: [couponId], references: [id])
+  code      String
+  type      CouponEventType
+  clientId  String?
+  orderId   String?
+  reason    String?
+  createdAt DateTime        @default(now())
+
+  @@index([couponId, type])
+  @@index([type, createdAt])
+  @@index([code])
+  @@map("coupon_events")
 }
 
 model PricingVersion {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,14 @@
 			"types": "./dist/chat/send-chat-message.schema.d.ts",
 			"default": "./dist/chat/send-chat-message.schema.js"
 		},
+		"./coupons/coupon": {
+			"types": "./dist/coupons/coupon.d.ts",
+			"default": "./dist/coupons/coupon.js"
+		},
+		"./coupons/create-coupon.schema": {
+			"types": "./dist/coupons/create-coupon.schema.d.ts",
+			"default": "./dist/coupons/create-coupon.schema.js"
+		},
 		"./money/money": {
 			"types": "./dist/money/money.d.ts",
 			"default": "./dist/money/money.js"

--- a/packages/shared/src/coupons/coupon.ts
+++ b/packages/shared/src/coupons/coupon.ts
@@ -1,0 +1,47 @@
+export const couponDiscountTypes = ['percentage', 'fixed'] as const;
+export type CouponDiscountType = (typeof couponDiscountTypes)[number];
+
+export const couponEventTypes = [
+	'created',
+	'disabled',
+	'validation_failed',
+	'eligibility_failed',
+	'usage_limit_failed',
+	'applied_at_checkout',
+	'confirmed_by_payment',
+] as const;
+export type CouponEventType = (typeof couponEventTypes)[number];
+
+export const COUPON_CODE_MIN_LENGTH = 4;
+export const COUPON_CODE_MAX_LENGTH = 24;
+const COUPON_CODE_PATTERN = /^[A-Z0-9]+$/;
+
+export const COUPON_MAX_PERCENTAGE_DISCOUNT = 99;
+export const COUPON_MIN_FIXED_DISCOUNT = 0.5;
+export const COUPON_MIN_ORDER_TOTAL_CENTS = 50;
+
+export function normalizeCouponCode(code: string): string {
+	return code.trim().toUpperCase();
+}
+
+export function isValidCouponCode(code: string): boolean {
+	return (
+		code.length >= COUPON_CODE_MIN_LENGTH &&
+		code.length <= COUPON_CODE_MAX_LENGTH &&
+		COUPON_CODE_PATTERN.test(code)
+	);
+}
+
+const GENERATED_CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+const GENERATED_CODE_LENGTH = 10;
+
+export function generateCouponCode(
+	randomInt: (maxExclusive: number) => number = (max) =>
+		Math.floor(Math.random() * max),
+): string {
+	let code = '';
+	for (let i = 0; i < GENERATED_CODE_LENGTH; i += 1) {
+		code += GENERATED_CODE_ALPHABET[randomInt(GENERATED_CODE_ALPHABET.length)];
+	}
+	return code;
+}

--- a/packages/shared/src/coupons/create-coupon.schema.ts
+++ b/packages/shared/src/coupons/create-coupon.schema.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+import { orderExtraTypes } from '../orders/order-extra';
+import { findOrderRankIndex } from '../orders/order-rank-progression';
+import { orderServiceTypes } from '../orders/service-type';
+import {
+	COUPON_CODE_MAX_LENGTH,
+	COUPON_CODE_MIN_LENGTH,
+	COUPON_MAX_PERCENTAGE_DISCOUNT,
+	COUPON_MIN_FIXED_DISCOUNT,
+	isValidCouponCode,
+	normalizeCouponCode,
+} from './coupon';
+
+const rankSchema = z
+	.object({
+		league: z.string().trim().min(1),
+		division: z.string().trim().min(1),
+	})
+	.refine((rank) => findOrderRankIndex(rank.league, rank.division) >= 0, {
+		message: 'Unknown rank.',
+	});
+
+export const createCouponSchema = z
+	.object({
+		code: z
+			.string()
+			.transform(normalizeCouponCode)
+			.refine(isValidCouponCode, {
+				message: `Code must be ${COUPON_CODE_MIN_LENGTH}-${COUPON_CODE_MAX_LENGTH} uppercase letters or numbers.`,
+			})
+			.optional(),
+		discountType: z.enum(['percentage', 'fixed']),
+		discount: z.number().positive(),
+		firstOrderOnly: z.boolean().default(false),
+		allowedServiceTypes: z.array(z.enum(orderServiceTypes)).default([]),
+		allowedQueues: z.array(z.string().trim().min(1)).default([]),
+		allowedEmails: z.array(z.string().trim().email().toLowerCase()).default([]),
+		minSubtotal: z.number().int().positive().optional(),
+		maxSubtotal: z.number().int().positive().optional(),
+		minRank: rankSchema.optional(),
+		maxRank: rankSchema.optional(),
+		minExtrasCount: z.number().int().positive().optional(),
+		requiredExtra: z.enum(orderExtraTypes).optional(),
+		globalUsageLimit: z.number().int().positive().optional(),
+		perUserUsageLimit: z.number().int().positive().optional(),
+	})
+	.superRefine((value, ctx) => {
+		if (value.discountType === 'percentage') {
+			if (
+				!Number.isInteger(value.discount) ||
+				value.discount < 1 ||
+				value.discount > COUPON_MAX_PERCENTAGE_DISCOUNT
+			) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['discount'],
+					message: `Percentage discount must be an integer between 1 and ${COUPON_MAX_PERCENTAGE_DISCOUNT}.`,
+				});
+			}
+		} else if (value.discount < COUPON_MIN_FIXED_DISCOUNT) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['discount'],
+				message: `Fixed discount must be at least R$${COUPON_MIN_FIXED_DISCOUNT.toFixed(2)}.`,
+			});
+		}
+
+		if (
+			value.minSubtotal !== undefined &&
+			value.maxSubtotal !== undefined &&
+			value.minSubtotal > value.maxSubtotal
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['maxSubtotal'],
+				message: 'maxSubtotal must be greater than or equal to minSubtotal.',
+			});
+		}
+
+		if (
+			value.minRank &&
+			value.maxRank &&
+			findOrderRankIndex(value.minRank.league, value.minRank.division) >
+				findOrderRankIndex(value.maxRank.league, value.maxRank.division)
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['maxRank'],
+				message: 'maxRank must be the same as or higher than minRank.',
+			});
+		}
+	});
+
+export type CreateCouponInput = z.infer<typeof createCouponSchema>;

--- a/packages/shared/src/orders/order-rank-progression.ts
+++ b/packages/shared/src/orders/order-rank-progression.ts
@@ -39,3 +39,14 @@ export const orderRankProgression: readonly OrderRankStep[] = [
 	{ league: 'diamond', division: 'I' },
 	{ league: 'master', division: 'MASTER' },
 ] as const;
+
+export function findOrderRankIndex(league: string, division: string): number {
+	const normalizedLeague = league.trim().toLowerCase();
+	const normalizedDivision = division.trim().toUpperCase();
+	if (normalizedLeague === 'master') return orderRankProgression.length - 1;
+	return orderRankProgression.findIndex(
+		(step) =>
+			step.league === normalizedLeague &&
+			step.division.toUpperCase() === normalizedDivision,
+	);
+}


### PR DESCRIPTION
## Summary

Adds end-to-end coupon creation and management for admins.

- **Database:** Coupon targeting columns (service types, queues, emails, subtotal range, rank range, extras rules), global/per-user usage limits, and a `CouponEvent` audit table (+ backfill migration with empty-array defaults).
- **Shared:** coupon code rules (4–24 uppercase alnum + generator), discount limits (max 99%, min R$0.50 fixed, R$0.50 total floor), and the create-coupon zod schema reused by API and web.
- **API (checkout):** full eligibility evaluation, global/per-user usage limits, R$0.50 floor, and audit events. First-order = first **paid** order. Disabling a coupon keeps the already-quoted checkout price (consumption guard no longer re-checks `isActive`).
- **API (admin):** `admin/coupons` create (manual or generated code) / list (with usage) / disable / usage report. `created`/`disabled` events written in the same transaction as the mutation; `confirmed_by_payment` recorded on payment. Structured `coupon.lifecycle` logs via nestjs-pino for create/disable/payment-confirmed.
- **Web:** `/admin/coupons` page with a full create form, list, disable action, and nav entry.

Usage is counted only from payment-confirmed orders (PM decision), so the usage-limit check is non-atomic and brief oversubscription is accepted — documented with a `ponytail:` note at the check site.

Closes: N/A — no tracking issue provided.

## Verification

\`\`\`text
# API
cd apps/api && npx tsc -p tsconfig.json --noEmit
npx jest --silent --testPathPatterns "src/.*\.spec\.ts"        # 328 passed
npx jest --config test/jest-e2e.json orders.e2e                 # 33 passed
# Web
cd apps/web && npx tsc -p tsconfig.json --noEmit && npx jest --silent   # 123 passed
# Lint
npx biome check apps/api/src apps/api/test apps/web/src packages/shared/src   # clean
\`\`\`

Skipped checks and remaining risk: integration-db suite not run here (no scoped coupon integration tests added). Usage-limit oversubscription is an accepted, documented trade-off of count-after-payment.

## Screenshots

UI changes only. Otherwise: None.

_(New admin page at `/admin/coupons` — create form, coupon list with disable.)_

## Breaking Changes

None.