### PR TITLE
feat: client order details UX and order lifecycle emails

### DIFF
--- a/apps/api/src/common/email/build-branded-email.ts
+++ b/apps/api/src/common/email/build-branded-email.ts
@@ -1,0 +1,81 @@
+export const BRAND_NAME = 'EloNew';
+export const ACCENT_COLOR = '#0ea5e9';
+export const BACKGROUND_COLOR = '#09090b';
+export const SURFACE_COLOR = '#0d0d0f';
+export const TEXT_COLOR = '#ffffff';
+export const MUTED_TEXT_COLOR = 'rgba(255,255,255,0.55)';
+
+type BrandedEmailHtmlInput = {
+	title: string;
+	contentHtml: string;
+	ctaLabel: string;
+	ctaUrl: string;
+	showLinkFallback?: boolean;
+	footerText: string;
+};
+
+export const buildBrandedEmailHtml = (input: BrandedEmailHtmlInput) => {
+	const ctaUrl = escapeHtml(input.ctaUrl);
+	const linkFallback = input.showLinkFallback
+		? `
+						<tr>
+							<td style="padding:0 40px 8px;font-family:Arial,Helvetica,sans-serif;">
+								<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:12px;line-height:1.6;">
+									Se o botão não funcionar, copie e cole este link no seu navegador:
+								</p>
+								<p style="margin:8px 0 0;word-break:break-all;">
+									<a href="${ctaUrl}" style="color:${ACCENT_COLOR};font-size:12px;text-decoration:none;">${ctaUrl}</a>
+								</p>
+							</td>
+						</tr>`
+		: '';
+
+	return `
+<!doctype html>
+<html lang="pt-BR">
+	<body style="margin:0;padding:0;background-color:${BACKGROUND_COLOR};">
+		<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${BACKGROUND_COLOR};padding:32px 16px;">
+			<tr>
+				<td align="center">
+					<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background-color:${SURFACE_COLOR};border:1px solid rgba(255,255,255,0.08);border-radius:12px;overflow:hidden;">
+						<tr>
+							<td style="height:4px;background:linear-gradient(90deg,transparent,${ACCENT_COLOR},transparent);"></td>
+						</tr>
+						<tr>
+							<td style="padding:40px 40px 8px;font-family:Arial,Helvetica,sans-serif;">
+								<p style="margin:0;color:${ACCENT_COLOR};font-size:12px;font-weight:bold;letter-spacing:4px;text-transform:uppercase;">${BRAND_NAME}</p>
+								<h1 style="margin:16px 0 0;color:${TEXT_COLOR};font-size:22px;font-weight:bold;letter-spacing:1px;">${escapeHtml(input.title)}</h1>
+							</td>
+						</tr>
+						<tr>
+							<td style="padding:16px 40px 0;font-family:Arial,Helvetica,sans-serif;">
+								${input.contentHtml}
+							</td>
+						</tr>
+						<tr>
+							<td align="center" style="padding:32px 40px;">
+								<a href="${ctaUrl}" style="display:inline-block;background-color:${ACCENT_COLOR};color:${BACKGROUND_COLOR};font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:bold;letter-spacing:2px;text-transform:uppercase;text-decoration:none;padding:14px 32px;border-radius:8px;">${escapeHtml(input.ctaLabel)}</a>
+							</td>
+						</tr>${linkFallback}
+						<tr>
+							<td style="padding:24px 40px 40px;font-family:Arial,Helvetica,sans-serif;border-top:1px solid rgba(255,255,255,0.06);">
+								<p style="margin:0;color:rgba(255,255,255,0.35);font-size:11px;line-height:1.6;">
+									${escapeHtml(input.footerText)}
+								</p>
+							</td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+	</body>
+</html>`;
+};
+
+export const escapeHtml = (value: string) =>
+	value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#039;');

--- a/apps/api/src/modules/orders/application/emails/build-order-lifecycle-emails.ts
+++ b/apps/api/src/modules/orders/application/emails/build-order-lifecycle-emails.ts
@@ -1,0 +1,77 @@
+import {
+	BRAND_NAME,
+	buildBrandedEmailHtml,
+	escapeHtml,
+	MUTED_TEXT_COLOR,
+	TEXT_COLOR,
+} from '@app/common/email/build-branded-email';
+import type { SendEmailInput } from '@app/common/email/ports/email-sender.port';
+
+type OrderLifecycleEmailInput = {
+	orderId: string;
+	orderUrl: string;
+	route: string | null;
+};
+
+type OrderLifecycleEmailContent = Pick<
+	SendEmailInput,
+	'subject' | 'html' | 'text'
+>;
+
+type OrderLifecycleEmailCopy = {
+	subject: string;
+	title: string;
+	message: string;
+	ctaLabel: string;
+};
+
+const buildOrderLifecycleEmail = (
+	input: OrderLifecycleEmailInput,
+	copy: OrderLifecycleEmailCopy,
+): OrderLifecycleEmailContent => {
+	const routeLine = input.route
+		? `<p style="margin:12px 0 0;color:${TEXT_COLOR};font-size:14px;font-weight:bold;">${escapeHtml(input.route)}</p>`
+		: '';
+
+	const html = buildBrandedEmailHtml({
+		title: copy.title,
+		contentHtml: `<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:14px;line-height:1.6;">${escapeHtml(copy.message)}</p>
+								${routeLine}
+								<p style="margin:12px 0 0;color:${MUTED_TEXT_COLOR};font-size:12px;line-height:1.6;">Pedido <span style="color:${TEXT_COLOR};font-family:monospace;">${escapeHtml(input.orderId)}</span></p>`,
+		ctaLabel: copy.ctaLabel,
+		ctaUrl: input.orderUrl,
+		footerText: `Você recebeu este e-mail porque tem um pedido ativo na ${BRAND_NAME}.`,
+	});
+
+	const text = [
+		copy.message,
+		...(input.route ? [input.route] : []),
+		`Pedido ${input.orderId}`,
+		'',
+		`Acompanhe seu pedido: ${input.orderUrl}`,
+	].join('\n');
+
+	return { subject: copy.subject, html, text };
+};
+
+export const buildOrderPaidEmail = (
+	input: OrderLifecycleEmailInput,
+): OrderLifecycleEmailContent =>
+	buildOrderLifecycleEmail(input, {
+		subject: `Pagamento confirmado na ${BRAND_NAME}`,
+		title: 'Pagamento confirmado',
+		message:
+			'Recebemos o pagamento do seu pedido. Agora é só aguardar: um booster vai assumir o serviço em breve.',
+		ctaLabel: 'Acompanhar pedido',
+	});
+
+export const buildOrderBoosterAssignedEmail = (
+	input: OrderLifecycleEmailInput,
+): OrderLifecycleEmailContent =>
+	buildOrderLifecycleEmail(input, {
+		subject: `Um booster assumiu seu pedido na ${BRAND_NAME}`,
+		title: 'Booster a caminho',
+		message:
+			'Um booster acabou de assumir o seu pedido e o chat já está aberto. Fale com ele para alinhar os detalhes.',
+		ctaLabel: 'Abrir chat do pedido',
+	});

--- a/apps/api/src/modules/orders/application/services/order-lifecycle-email.service.spec.ts
+++ b/apps/api/src/modules/orders/application/services/order-lifecycle-email.service.spec.ts
@@ -1,0 +1,107 @@
+import type {
+	EmailSenderPort,
+	SendEmailInput,
+} from '@app/common/email/ports/email-sender.port';
+import type { AppSettingsService } from '@app/common/settings/app-settings.service';
+import type { OrderClientReaderPort } from '@modules/orders/application/ports/order-client-reader.port';
+import { OrderLifecycleEmailService } from '@modules/orders/application/services/order-lifecycle-email.service';
+import { Order } from '@modules/orders/domain/order.entity';
+
+class EmailSenderSpy implements EmailSenderPort {
+	readonly sent: SendEmailInput[] = [];
+
+	async send(input: SendEmailInput): Promise<void> {
+		this.sent.push(input);
+	}
+}
+
+const clientReaderStub = (email: string | null): OrderClientReaderPort => ({
+	findEmailById: async () => email,
+	hasPaidOrder: async () => false,
+});
+
+const appSettingsStub = {
+	webAppUrl: 'https://elonew.test',
+} as AppSettingsService;
+
+const makeOrder = () =>
+	Order.create('order-1', {
+		clientId: 'client-1',
+		requestDetails: {
+			serviceType: 'elo_boost',
+			currentLeague: 'iron',
+			currentDivision: 'IV',
+			currentLp: 0,
+			desiredLeague: 'gold',
+			desiredDivision: 'IV',
+			server: 'br',
+			desiredQueue: 'solo_duo',
+			lpGain: 20,
+			deadline: new Date('2026-08-01T00:00:00Z'),
+		},
+	});
+
+describe('OrderLifecycleEmailService', () => {
+	it('sends the order paid email to the client', async () => {
+		const emailSender = new EmailSenderSpy();
+		const service = new OrderLifecycleEmailService(
+			clientReaderStub('client@elonew.test'),
+			emailSender,
+			appSettingsStub,
+		);
+
+		await service.sendOrderPaidEmail(makeOrder());
+
+		expect(emailSender.sent).toHaveLength(1);
+		expect(emailSender.sent[0].to).toBe('client@elonew.test');
+		expect(emailSender.sent[0].subject).toContain('Pagamento confirmado');
+		expect(emailSender.sent[0].html).toContain('Iron IV → Gold IV');
+		expect(emailSender.sent[0].html).toContain(
+			'https://elonew.test/client/orders/order-1',
+		);
+	});
+
+	it('sends the booster assigned email to the client', async () => {
+		const emailSender = new EmailSenderSpy();
+		const service = new OrderLifecycleEmailService(
+			clientReaderStub('client@elonew.test'),
+			emailSender,
+			appSettingsStub,
+		);
+
+		await service.sendBoosterAssignedEmail(makeOrder());
+
+		expect(emailSender.sent).toHaveLength(1);
+		expect(emailSender.sent[0].subject).toContain('booster assumiu');
+	});
+
+	it('skips sending when the client has no email', async () => {
+		const emailSender = new EmailSenderSpy();
+		const service = new OrderLifecycleEmailService(
+			clientReaderStub(null),
+			emailSender,
+			appSettingsStub,
+		);
+
+		await service.sendOrderPaidEmail(makeOrder());
+
+		expect(emailSender.sent).toHaveLength(0);
+	});
+
+	it('swallows sender failures without throwing', async () => {
+		const failingSender: EmailSenderPort = {
+			send: async () => {
+				throw new Error('provider down');
+			},
+		};
+		const service = new OrderLifecycleEmailService(
+			clientReaderStub('client@elonew.test'),
+			failingSender,
+			appSettingsStub,
+		);
+
+		await expect(
+			service.sendOrderPaidEmail(makeOrder()),
+		).resolves.toBeUndefined();
+	});
+});

--- a/apps/api/src/modules/orders/application/services/order-lifecycle-email.service.ts
+++ b/apps/api/src/modules/orders/application/services/order-lifecycle-email.service.ts
@@ -1,0 +1,84 @@
+import {
+	EMAIL_SENDER_KEY,
+	type EmailSenderPort,
+} from '@app/common/email/ports/email-sender.port';
+import { AppSettingsService } from '@app/common/settings/app-settings.service';
+import {
+	buildOrderBoosterAssignedEmail,
+	buildOrderPaidEmail,
+} from '@modules/orders/application/emails/build-order-lifecycle-emails';
+import {
+	ORDER_CLIENT_READER_KEY,
+	type OrderClientReaderPort,
+} from '@modules/orders/application/ports/order-client-reader.port';
+import type { Order } from '@modules/orders/domain/order.entity';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+const emailBuilders = {
+	paid: buildOrderPaidEmail,
+	booster_assigned: buildOrderBoosterAssignedEmail,
+};
+
+type OrderLifecycleEmailKind = keyof typeof emailBuilders;
+
+@Injectable()
+export class OrderLifecycleEmailService {
+	private readonly logger = new Logger(OrderLifecycleEmailService.name);
+
+	constructor(
+		@Inject(ORDER_CLIENT_READER_KEY)
+		private readonly orderClientReader: OrderClientReaderPort,
+		@Inject(EMAIL_SENDER_KEY)
+		private readonly emailSender: EmailSenderPort,
+		private readonly appSettings: AppSettingsService,
+	) {}
+
+	async sendOrderPaidEmail(order: Order): Promise<void> {
+		await this.send('paid', order);
+	}
+
+	async sendBoosterAssignedEmail(order: Order): Promise<void> {
+		await this.send('booster_assigned', order);
+	}
+
+	private async send(
+		kind: OrderLifecycleEmailKind,
+		order: Order,
+	): Promise<void> {
+		try {
+			if (!order.clientId) return;
+			const to = await this.orderClientReader.findEmailById(order.clientId);
+			if (!to) return;
+
+			const email = emailBuilders[kind]({
+				orderId: order.id,
+				orderUrl: this.buildOrderUrl(order.id),
+				route: formatOrderRoute(order),
+			});
+			await this.emailSender.send({ to, ...email });
+		} catch (error) {
+			this.logger.warn(
+				`Failed to send order ${kind} email for order ${order.id}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+
+	private buildOrderUrl(orderId: string) {
+		return new URL(
+			`/client/orders/${orderId}`,
+			this.appSettings.webAppUrl,
+		).toString();
+	}
+}
+
+const formatOrderRoute = (order: Order): string | null => {
+	const details = order.requestDetails;
+	if (!details) return null;
+
+	return `${formatTitleCase(details.currentLeague)} ${details.currentDivision} → ${formatTitleCase(details.desiredLeague)} ${details.desiredDivision}`;
+};
+
+const formatTitleCase = (value: string) =>
+	value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();

--- a/apps/api/src/modules/orders/application/use-cases/accept-order/accept-order.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/accept-order/accept-order.use-case.spec.ts
@@ -4,6 +4,7 @@ import type {
 	OrderEventPublisherPort,
 } from '@modules/orders/application/ports/order-event-publisher.port';
 import type { OrderRepositoryPort } from '@modules/orders/application/ports/order-repository.port';
+import type { OrderLifecycleEmailService } from '@modules/orders/application/services/order-lifecycle-email.service';
 import { AcceptOrderUseCase } from '@modules/orders/application/use-cases/accept-order/accept-order.use-case';
 import { Order } from '@modules/orders/domain/order.entity';
 import {
@@ -83,6 +84,22 @@ describe('AcceptOrderUseCase', () => {
 			},
 		]);
 		expect(chatThreadWriter.orderIds).toEqual(['order-1']);
+	});
+
+	it('sends the booster assigned email to the client', async () => {
+		const repository = new InMemoryOrderRepository();
+		const sendBoosterAssignedEmail = jest.fn();
+		const order = Order.create('order-1');
+		order.confirmPayment();
+		repository.insert(order);
+
+		const useCase = new AcceptOrderUseCase(repository, undefined, undefined, {
+			sendBoosterAssignedEmail,
+		} as unknown as OrderLifecycleEmailService);
+		await useCase.execute({ orderId: 'order-1', boosterId: 'booster-1' });
+
+		expect(sendBoosterAssignedEmail).toHaveBeenCalledTimes(1);
+		expect(sendBoosterAssignedEmail).toHaveBeenCalledWith(order);
 	});
 
 	it('throws when order does not exist', async () => {

--- a/apps/api/src/modules/orders/application/use-cases/accept-order/accept-order.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/accept-order/accept-order.use-case.ts
@@ -11,6 +11,7 @@ import {
 	ORDER_REPOSITORY_KEY,
 	type OrderRepositoryPort,
 } from '@modules/orders/application/ports/order-repository.port';
+import { OrderLifecycleEmailService } from '@modules/orders/application/services/order-lifecycle-email.service';
 import { OrderNotFoundError } from '@modules/orders/domain/order.errors';
 import { Inject, Injectable, Optional } from '@nestjs/common';
 
@@ -30,6 +31,8 @@ export class AcceptOrderUseCase {
 		@Optional()
 		@Inject(CHAT_THREAD_WRITER_KEY)
 		private readonly chatThreadWriter?: ChatThreadWriterPort,
+		@Optional()
+		private readonly orderLifecycleEmails?: OrderLifecycleEmailService,
 	) {}
 
 	async execute(input: AcceptOrderInput): Promise<void> {
@@ -46,5 +49,6 @@ export class AcceptOrderUseCase {
 		await this.orderEventPublisher?.publish(
 			createOrderEvent('order.accepted', order),
 		);
+		await this.orderLifecycleEmails?.sendBoosterAssignedEmail(order);
 	}
 }

--- a/apps/api/src/modules/orders/application/use-cases/get-order/get-order.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/get-order/get-order.use-case.spec.ts
@@ -54,6 +54,11 @@ describe('GetOrderUseCase', () => {
 			subtotal: 25.2,
 			totalAmount: 25.2,
 			discountAmount: 0,
+			serviceType: null,
+			currentLeague: null,
+			currentDivision: null,
+			desiredLeague: null,
+			desiredDivision: null,
 		});
 	});
 

--- a/apps/api/src/modules/orders/application/use-cases/get-order/get-order.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/get-order/get-order.use-case.ts
@@ -17,6 +17,11 @@ type GetOrderOutput = {
 	subtotal: number | null;
 	totalAmount: number | null;
 	discountAmount: number;
+	serviceType: string | null;
+	currentLeague: string | null;
+	currentDivision: string | null;
+	desiredLeague: string | null;
+	desiredDivision: string | null;
 };
 
 @Injectable()
@@ -33,12 +38,19 @@ export class GetOrderUseCase {
 		);
 		if (!order) throw new OrderNotFoundError();
 
+		const details = order.requestDetails;
+
 		return {
 			id: order.id,
 			status: order.status,
 			subtotal: order.subtotal,
 			totalAmount: order.totalAmount,
 			discountAmount: order.discountAmount,
+			serviceType: details?.serviceType ?? null,
+			currentLeague: details?.currentLeague ?? null,
+			currentDivision: details?.currentDivision ?? null,
+			desiredLeague: details?.desiredLeague ?? null,
+			desiredDivision: details?.desiredDivision ?? null,
 		};
 	}
 }

--- a/apps/api/src/modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case.spec.ts
@@ -9,6 +9,7 @@ import type {
 	OrderEventPublisherPort,
 } from '@modules/orders/application/ports/order-event-publisher.port';
 import type { OrderRepositoryPort } from '@modules/orders/application/ports/order-repository.port';
+import type { OrderLifecycleEmailService } from '@modules/orders/application/services/order-lifecycle-email.service';
 import { MarkOrderAsPaidUseCase } from '@modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case';
 import { Order } from '@modules/orders/domain/order.entity';
 import { OrderNotFoundError } from '@modules/orders/domain/order.errors';
@@ -62,6 +63,26 @@ class OrderEventPublisherSpy implements OrderEventPublisherPort {
 }
 
 describe('MarkOrderAsPaidUseCase', () => {
+	it('sends the order paid email to the client', async () => {
+		const repository = new InMemoryOrderRepository();
+		const sendOrderPaidEmail = jest.fn();
+		const order = Order.create('order-1');
+		repository.insert(order);
+
+		const useCase = new MarkOrderAsPaidUseCase(
+			repository,
+			couponLookupStub,
+			couponEventsStub,
+			couponLifecycleLoggerStub,
+			undefined,
+			{ sendOrderPaidEmail } as unknown as OrderLifecycleEmailService,
+		);
+		await useCase.execute({ orderId: 'order-1' });
+
+		expect(sendOrderPaidEmail).toHaveBeenCalledTimes(1);
+		expect(sendOrderPaidEmail).toHaveBeenCalledWith(order);
+	});
+
 	it('moves order to pending booster when payment is confirmed', async () => {
 		const repository = new InMemoryOrderRepository();
 		const eventPublisher = new OrderEventPublisherSpy();

--- a/apps/api/src/modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/mark-order-as-paid/mark-order-as-paid.use-case.ts
@@ -20,6 +20,7 @@ import {
 	ORDER_REPOSITORY_KEY,
 	type OrderRepositoryPort,
 } from '@modules/orders/application/ports/order-repository.port';
+import { OrderLifecycleEmailService } from '@modules/orders/application/services/order-lifecycle-email.service';
 import type { Order } from '@modules/orders/domain/order.entity';
 import { OrderNotFoundError } from '@modules/orders/domain/order.errors';
 import { OrderStatus } from '@modules/orders/domain/order-status';
@@ -42,6 +43,8 @@ export class MarkOrderAsPaidUseCase {
 		@Optional()
 		@Inject(ORDER_EVENT_PUBLISHER_KEY)
 		private readonly orderEventPublisher?: OrderEventPublisherPort,
+		@Optional()
+		private readonly orderLifecycleEmails?: OrderLifecycleEmailService,
 	) {}
 
 	async execute(input: MarkOrderAsPaidInput): Promise<void> {
@@ -55,6 +58,7 @@ export class MarkOrderAsPaidUseCase {
 		await this.orderEventPublisher?.publish(
 			createOrderEvent('order.paid', order),
 		);
+		await this.orderLifecycleEmails?.sendOrderPaidEmail(order);
 	}
 
 	private async recordCouponUsage(order: Order): Promise<void> {

--- a/apps/api/src/modules/orders/orders.module.ts
+++ b/apps/api/src/modules/orders/orders.module.ts
@@ -1,3 +1,4 @@
+import { EmailModule } from '@app/common/email/email.module';
 import { LoggingModule } from '@app/common/logging/logging.module';
 import { PrismaModule } from '@app/common/prisma/prisma.module';
 import { AuthModule } from '@modules/auth/auth.module';
@@ -20,6 +21,7 @@ import {
 	ApplyOrderCouponService,
 	ORDER_COUPON_SERVICE_KEY,
 } from '@modules/orders/application/services/order-coupon.service';
+import { OrderLifecycleEmailService } from '@modules/orders/application/services/order-lifecycle-email.service';
 import { ORDER_PRICING_SERVICE_KEY } from '@modules/orders/application/services/order-pricing.service';
 import { AcceptOrderUseCase } from '@modules/orders/application/use-cases/accept-order/accept-order.use-case';
 import { ActivateOrderPricingVersionUseCase } from '@modules/orders/application/use-cases/activate-order-pricing-version/activate-order-pricing-version.use-case';
@@ -66,7 +68,14 @@ import { WalletModule } from '@modules/wallet/wallet.module';
 import { Module } from '@nestjs/common';
 
 @Module({
-	imports: [PrismaModule, AuthModule, ChatModule, WalletModule, LoggingModule],
+	imports: [
+		PrismaModule,
+		AuthModule,
+		ChatModule,
+		WalletModule,
+		LoggingModule,
+		EmailModule,
+	],
 	controllers: [
 		OrdersEventsController,
 		OrdersController,
@@ -123,6 +132,7 @@ import { Module } from '@nestjs/common';
 			inject: [PrismaOrderClientReader],
 		},
 		ApplyOrderCouponService,
+		OrderLifecycleEmailService,
 		{
 			provide: ORDER_COUPON_SERVICE_KEY,
 			useFactory: (

--- a/apps/api/src/modules/orders/presentation/orders.controller.ts
+++ b/apps/api/src/modules/orders/presentation/orders.controller.ts
@@ -251,6 +251,11 @@ export class OrdersController {
 		subtotal: number | null;
 		totalAmount: number | null;
 		discountAmount: number;
+		serviceType: string | null;
+		currentLeague: string | null;
+		currentDivision: string | null;
+		desiredLeague: string | null;
+		desiredDivision: string | null;
 	}> {
 		return await this.getOrderUseCase.execute({
 			orderId,

--- a/apps/api/src/modules/users/application/emails/build-email-confirmation-email.ts
+++ b/apps/api/src/modules/users/application/emails/build-email-confirmation-email.ts
@@ -1,3 +1,10 @@
+import {
+	BRAND_NAME,
+	buildBrandedEmailHtml,
+	escapeHtml,
+	MUTED_TEXT_COLOR,
+	TEXT_COLOR,
+} from '@app/common/email/build-branded-email';
 import type { SendEmailInput } from '@app/common/email/ports/email-sender.port';
 
 type EmailConfirmationEmailInput = {
@@ -11,71 +18,22 @@ type EmailConfirmationEmailContent = Pick<
 	'subject' | 'html' | 'text'
 >;
 
-const BRAND_NAME = 'EloNew';
-const ACCENT_COLOR = '#0ea5e9';
-const BACKGROUND_COLOR = '#09090b';
-const SURFACE_COLOR = '#0d0d0f';
-const TEXT_COLOR = '#ffffff';
-const MUTED_TEXT_COLOR = 'rgba(255,255,255,0.55)';
-
 export const buildEmailConfirmationEmail = (
 	input: EmailConfirmationEmailInput,
 ): EmailConfirmationEmailContent => {
 	const username = escapeHtml(input.username);
-	const confirmationUrl = escapeHtml(input.confirmationUrl);
+	const footerText = `Este link expira em ${input.expiresInMinutes} minutos. Se você não criou uma conta na ${BRAND_NAME}, ignore este e-mail.`;
 
-	const html = `
-<!doctype html>
-<html lang="pt-BR">
-	<body style="margin:0;padding:0;background-color:${BACKGROUND_COLOR};">
-		<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${BACKGROUND_COLOR};padding:32px 16px;">
-			<tr>
-				<td align="center">
-					<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background-color:${SURFACE_COLOR};border:1px solid rgba(255,255,255,0.08);border-radius:12px;overflow:hidden;">
-						<tr>
-							<td style="height:4px;background:linear-gradient(90deg,transparent,${ACCENT_COLOR},transparent);"></td>
-						</tr>
-						<tr>
-							<td style="padding:40px 40px 8px;font-family:Arial,Helvetica,sans-serif;">
-								<p style="margin:0;color:${ACCENT_COLOR};font-size:12px;font-weight:bold;letter-spacing:4px;text-transform:uppercase;">${BRAND_NAME}</p>
-								<h1 style="margin:16px 0 0;color:${TEXT_COLOR};font-size:22px;font-weight:bold;letter-spacing:1px;">Confirme seu e-mail</h1>
-							</td>
-						</tr>
-						<tr>
-							<td style="padding:16px 40px 0;font-family:Arial,Helvetica,sans-serif;">
-								<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:14px;line-height:1.6;">
+	const html = buildBrandedEmailHtml({
+		title: 'Confirme seu e-mail',
+		contentHtml: `<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:14px;line-height:1.6;">
 									Olá, <strong style="color:${TEXT_COLOR};">${username}</strong>. Falta só um passo para ativar sua conta na ${BRAND_NAME}. Clique no botão abaixo para confirmar seu endereço de e-mail.
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td align="center" style="padding:32px 40px;">
-								<a href="${confirmationUrl}" style="display:inline-block;background-color:${ACCENT_COLOR};color:${BACKGROUND_COLOR};font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:bold;letter-spacing:2px;text-transform:uppercase;text-decoration:none;padding:14px 32px;border-radius:8px;">Confirmar e-mail</a>
-							</td>
-						</tr>
-						<tr>
-							<td style="padding:0 40px 8px;font-family:Arial,Helvetica,sans-serif;">
-								<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:12px;line-height:1.6;">
-									Se o botão não funcionar, copie e cole este link no seu navegador:
-								</p>
-								<p style="margin:8px 0 0;word-break:break-all;">
-									<a href="${confirmationUrl}" style="color:${ACCENT_COLOR};font-size:12px;text-decoration:none;">${confirmationUrl}</a>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td style="padding:24px 40px 40px;font-family:Arial,Helvetica,sans-serif;border-top:1px solid rgba(255,255,255,0.06);">
-								<p style="margin:0;color:rgba(255,255,255,0.35);font-size:11px;line-height:1.6;">
-									Este link expira em ${input.expiresInMinutes} minutos. Se você não criou uma conta na ${BRAND_NAME}, ignore este e-mail.
-								</p>
-							</td>
-						</tr>
-					</table>
-				</td>
-			</tr>
-		</table>
-	</body>
-</html>`;
+								</p>`,
+		ctaLabel: 'Confirmar e-mail',
+		ctaUrl: input.confirmationUrl,
+		showLinkFallback: true,
+		footerText,
+	});
 
 	const text = [
 		`Olá, ${input.username}.`,
@@ -83,7 +41,7 @@ export const buildEmailConfirmationEmail = (
 		`Confirme seu e-mail na ${BRAND_NAME} acessando o link abaixo:`,
 		input.confirmationUrl,
 		'',
-		`Este link expira em ${input.expiresInMinutes} minutos. Se você não criou uma conta na ${BRAND_NAME}, ignore este e-mail.`,
+		footerText,
 	].join('\n');
 
 	return {
@@ -92,11 +50,3 @@ export const buildEmailConfirmationEmail = (
 		text,
 	};
 };
-
-const escapeHtml = (value: string) =>
-	value
-		.replaceAll('&', '&amp;')
-		.replaceAll('<', '&lt;')
-		.replaceAll('>', '&gt;')
-		.replaceAll('"', '&quot;')
-		.replaceAll("'", '&#039;');

--- a/apps/api/src/modules/users/application/emails/build-password-setup-email.ts
+++ b/apps/api/src/modules/users/application/emails/build-password-setup-email.ts
@@ -1,3 +1,10 @@
+import {
+	BRAND_NAME,
+	buildBrandedEmailHtml,
+	escapeHtml,
+	MUTED_TEXT_COLOR,
+	TEXT_COLOR,
+} from '@app/common/email/build-branded-email';
 import type { SendEmailInput } from '@app/common/email/ports/email-sender.port';
 
 type PasswordSetupEmailInput = {
@@ -11,71 +18,22 @@ type PasswordSetupEmailContent = Pick<
 	'subject' | 'html' | 'text'
 >;
 
-const BRAND_NAME = 'EloNew';
-const ACCENT_COLOR = '#0ea5e9';
-const BACKGROUND_COLOR = '#09090b';
-const SURFACE_COLOR = '#0d0d0f';
-const TEXT_COLOR = '#ffffff';
-const MUTED_TEXT_COLOR = 'rgba(255,255,255,0.55)';
-
 export const buildPasswordSetupEmail = (
 	input: PasswordSetupEmailInput,
 ): PasswordSetupEmailContent => {
 	const username = escapeHtml(input.username);
-	const setupUrl = escapeHtml(input.setupUrl);
+	const footerText = `Este link expira em ${input.expiresInMinutes} minutos. Se você não esperava este acesso, ignore este e-mail.`;
 
-	const html = `
-<!doctype html>
-<html lang="pt-BR">
-	<body style="margin:0;padding:0;background-color:${BACKGROUND_COLOR};">
-		<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${BACKGROUND_COLOR};padding:32px 16px;">
-			<tr>
-				<td align="center">
-					<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background-color:${SURFACE_COLOR};border:1px solid rgba(255,255,255,0.08);border-radius:12px;overflow:hidden;">
-						<tr>
-							<td style="height:4px;background:linear-gradient(90deg,transparent,${ACCENT_COLOR},transparent);"></td>
-						</tr>
-						<tr>
-							<td style="padding:40px 40px 8px;font-family:Arial,Helvetica,sans-serif;">
-								<p style="margin:0;color:${ACCENT_COLOR};font-size:12px;font-weight:bold;letter-spacing:4px;text-transform:uppercase;">${BRAND_NAME}</p>
-								<h1 style="margin:16px 0 0;color:${TEXT_COLOR};font-size:22px;font-weight:bold;letter-spacing:1px;">Defina sua senha</h1>
-							</td>
-						</tr>
-						<tr>
-							<td style="padding:16px 40px 0;font-family:Arial,Helvetica,sans-serif;">
-								<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:14px;line-height:1.6;">
+	const html = buildBrandedEmailHtml({
+		title: 'Defina sua senha',
+		contentHtml: `<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:14px;line-height:1.6;">
 									Olá, <strong style="color:${TEXT_COLOR};">${username}</strong>. Sua conta na ${BRAND_NAME} foi criada por um administrador. Clique no botão abaixo para definir sua senha e ativar seu acesso.
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td align="center" style="padding:32px 40px;">
-								<a href="${setupUrl}" style="display:inline-block;background-color:${ACCENT_COLOR};color:${BACKGROUND_COLOR};font-family:Arial,Helvetica,sans-serif;font-size:13px;font-weight:bold;letter-spacing:2px;text-transform:uppercase;text-decoration:none;padding:14px 32px;border-radius:8px;">Definir senha</a>
-							</td>
-						</tr>
-						<tr>
-							<td style="padding:0 40px 8px;font-family:Arial,Helvetica,sans-serif;">
-								<p style="margin:0;color:${MUTED_TEXT_COLOR};font-size:12px;line-height:1.6;">
-									Se o botão não funcionar, copie e cole este link no seu navegador:
-								</p>
-								<p style="margin:8px 0 0;word-break:break-all;">
-									<a href="${setupUrl}" style="color:${ACCENT_COLOR};font-size:12px;text-decoration:none;">${setupUrl}</a>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<td style="padding:24px 40px 40px;font-family:Arial,Helvetica,sans-serif;border-top:1px solid rgba(255,255,255,0.06);">
-								<p style="margin:0;color:rgba(255,255,255,0.35);font-size:11px;line-height:1.6;">
-									Este link expira em ${input.expiresInMinutes} minutos. Se você não esperava este acesso, ignore este e-mail.
-								</p>
-							</td>
-						</tr>
-					</table>
-				</td>
-			</tr>
-		</table>
-	</body>
-</html>`;
+								</p>`,
+		ctaLabel: 'Definir senha',
+		ctaUrl: input.setupUrl,
+		showLinkFallback: true,
+		footerText,
+	});
 
 	const text = [
 		`Olá, ${input.username}.`,
@@ -83,7 +41,7 @@ export const buildPasswordSetupEmail = (
 		`Defina sua senha na ${BRAND_NAME} acessando o link abaixo:`,
 		input.setupUrl,
 		'',
-		`Este link expira em ${input.expiresInMinutes} minutos. Se você não esperava este acesso, ignore este e-mail.`,
+		footerText,
 	].join('\n');
 
 	return {
@@ -92,11 +50,3 @@ export const buildPasswordSetupEmail = (
 		text,
 	};
 };
-
-const escapeHtml = (value: string) =>
-	value
-		.replaceAll('&', '&amp;')
-		.replaceAll('<', '&lt;')
-		.replaceAll('>', '&gt;')
-		.replaceAll('"', '&quot;')
-		.replaceAll("'", '&#039;');

--- a/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
+++ b/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
@@ -193,6 +193,11 @@ describe('Orders module integration (db)', () => {
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,
+			serviceType: 'elo_boost',
+			currentLeague: 'gold',
+			currentDivision: 'II',
+			desiredLeague: 'platinum',
+			desiredDivision: 'IV',
 		});
 	});
 
@@ -750,6 +755,11 @@ describe('Orders module integration (db)', () => {
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,
+			serviceType: 'elo_boost',
+			currentLeague: 'gold',
+			currentDivision: 'II',
+			desiredLeague: 'platinum',
+			desiredDivision: 'IV',
 		});
 	});
 
@@ -872,6 +882,11 @@ describe('Orders module integration (db)', () => {
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,
+			serviceType: 'elo_boost',
+			currentLeague: 'gold',
+			currentDivision: 'II',
+			desiredLeague: 'platinum',
+			desiredDivision: 'IV',
 		});
 	});
 

--- a/apps/api/test/integration/orders/orders.integration.spec.ts
+++ b/apps/api/test/integration/orders/orders.integration.spec.ts
@@ -163,6 +163,11 @@ describe('Orders module integration', () => {
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,
+			serviceType: 'elo_boost',
+			currentLeague: 'gold',
+			currentDivision: 'II',
+			desiredLeague: 'platinum',
+			desiredDivision: 'IV',
 		});
 
 		const persistedOrder = await orderRepository.findById(createdOrder.id);
@@ -364,6 +369,11 @@ describe('Orders module integration', () => {
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,
+			serviceType: 'elo_boost',
+			currentLeague: 'gold',
+			currentDivision: 'II',
+			desiredLeague: 'platinum',
+			desiredDivision: 'IV',
 		});
 	});
 

--- a/apps/api/test/orders.e2e-db.spec.ts
+++ b/apps/api/test/orders.e2e-db.spec.ts
@@ -120,6 +120,11 @@ describe('Orders (e2e db)', () => {
 				subtotal: 2520,
 				totalAmount: 2520,
 				discountAmount: 0,
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
 			})
 			.execute();
 	});

--- a/apps/api/test/orders.e2e-spec.ts
+++ b/apps/api/test/orders.e2e-spec.ts
@@ -235,6 +235,11 @@ describe('Orders (e2e)', () => {
 				subtotal: 2520,
 				totalAmount: 2520,
 				discountAmount: 0,
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
 			})
 			.execute();
 	});
@@ -395,6 +400,11 @@ describe('Orders (e2e)', () => {
 				subtotal: 2520,
 				totalAmount: 2520,
 				discountAmount: 0,
+				serviceType: 'elo_boost',
+				currentLeague: 'gold',
+				currentDivision: 'II',
+				desiredLeague: 'platinum',
+				desiredDivision: 'IV',
 			})
 			.execute();
 	});

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-header.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-header.spec.tsx
@@ -25,6 +25,11 @@ const makeOrder = (status: string) => ({
 	subtotal: 100,
 	totalAmount: 100,
 	discountAmount: 0,
+	serviceType: null,
+	currentLeague: null,
+	currentDivision: null,
+	desiredLeague: null,
+	desiredDivision: null,
 });
 
 describe('OrderDetailsHeader', () => {

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
@@ -49,20 +49,18 @@ export const OrderDetailsPage = async ({ orderId }: OrderDetailsPageProps) => {
 		<div className="space-y-8">
 			<OrderDetailsHeader order={order} />
 
-			<div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-				<div className="lg:col-span-2 space-y-8">
-					<OrderServiceCard order={order} />
-					<OrderActivityCard />
-				</div>
+			<div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_360px]">
+				<OrderChatPanel
+					orderId={order.id}
+					orderStatus={order.status}
+					currentUserId={session.userId}
+					initialMessages={chatMessages}
+				/>
 
-				<div className="space-y-8">
+				<div className="grid content-start gap-8">
+					<OrderServiceCard order={order} />
 					<OrderBoosterCard />
-					<OrderChatPanel
-						orderId={order.id}
-						orderStatus={order.status}
-						currentUserId={session.userId}
-						initialMessages={chatMessages}
-					/>
+					<OrderActivityCard />
 					<OrderSupportCard />
 					{order.status === 'completed' ? (
 						<RatingCard

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-service-card.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-service-card.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/shared/ui/components/card';
 import { OrderStatusBadge } from '@/shared/ui/components/status-badge';
 import type { ClientOrder } from '../../model/orders';
+import { OrderRankRoute } from '../order-rank-route';
 
 type OrderServiceCardProps = {
 	order: ClientOrder;
@@ -24,6 +25,18 @@ export const OrderServiceCard = ({ order }: OrderServiceCardProps) => {
 				</CardTitle>
 			</CardHeader>
 			<CardContent className="grid grid-cols-2 md:grid-cols-4 gap-8">
+				<div className="col-span-2 md:col-span-4 space-y-2">
+					<p className="text-[10px] text-white/40 uppercase tracking-widest">
+						Rota
+					</p>
+					<OrderRankRoute
+						size="md"
+						currentLeague={order.currentLeague}
+						currentDivision={order.currentDivision}
+						desiredLeague={order.desiredLeague}
+						desiredDivision={order.desiredDivision}
+					/>
+				</div>
 				<div className="space-y-1">
 					<p className="text-[10px] text-white/40 uppercase tracking-widest">
 						Status

--- a/apps/web/src/modules/client-dashboard/presentation/order-rank-route.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-rank-route.tsx
@@ -1,0 +1,74 @@
+import { ArrowRight } from 'lucide-react';
+import Image from 'next/image';
+import { cn } from '@/shared/ui/utils/cn';
+import { getRankDivisionLabel, getRankOption } from '../model/rank-options';
+
+type OrderRankRouteProps = {
+	currentLeague: string | null;
+	currentDivision: string | null;
+	desiredLeague: string | null;
+	desiredDivision: string | null;
+	size?: 'sm' | 'md';
+};
+
+const imageSizes = { sm: 20, md: 36 };
+
+const RankStep = ({
+	league,
+	division,
+	size,
+}: {
+	league: string;
+	division: string;
+	size: 'sm' | 'md';
+}) => {
+	const rank = getRankOption(league);
+
+	return (
+		<span className="inline-flex items-center gap-1.5">
+			<Image
+				src={rank.image}
+				alt={rank.label}
+				width={imageSizes[size]}
+				height={imageSizes[size]}
+				className="shrink-0 object-contain"
+			/>
+			<span
+				className={cn(
+					'font-black uppercase tracking-wider',
+					size === 'sm' ? 'text-xs' : 'text-sm',
+				)}
+				style={{ color: rank.accent }}
+			>
+				{rank.label} {getRankDivisionLabel(division)}
+			</span>
+		</span>
+	);
+};
+
+export const OrderRankRoute = ({
+	currentLeague,
+	currentDivision,
+	desiredLeague,
+	desiredDivision,
+	size = 'sm',
+}: OrderRankRouteProps) => {
+	if (
+		!currentLeague ||
+		!currentDivision ||
+		!desiredLeague ||
+		!desiredDivision
+	) {
+		return (
+			<span className="text-xs font-bold text-white/40">Rota indisponível</span>
+		);
+	}
+
+	return (
+		<span className="inline-flex flex-wrap items-center gap-2">
+			<RankStep league={currentLeague} division={currentDivision} size={size} />
+			<ArrowRight className="h-3.5 w-3.5 shrink-0 text-white/25" />
+			<RankStep league={desiredLeague} division={desiredDivision} size={size} />
+		</span>
+	);
+};

--- a/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-page.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-page.spec.tsx
@@ -1,9 +1,17 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { PropsWithChildren } from 'react';
+import type { ImgHTMLAttributes, PropsWithChildren } from 'react';
 import { ClientDashboardPage } from './client-dashboard-page';
 
 jest.mock('../../actions/order-actions', () => ({
 	createSupportTicketAction: jest.fn(),
+}));
+
+jest.mock('next/image', () => ({
+	__esModule: true,
+	default: ({ alt, ...props }: ImgHTMLAttributes<HTMLImageElement>) => (
+		// biome-ignore lint/performance/noImgElement: jest mock for next/image
+		<img alt={alt} {...props} />
+	),
 }));
 
 jest.mock('next/link', () => ({
@@ -94,7 +102,8 @@ describe('ClientDashboardPage', () => {
 		expect(screen.getAllByText(/R\$\s*120,00/).length).toBeGreaterThan(0);
 		expect(screen.getByText(/R\$\s*210,00/)).toBeInTheDocument();
 		expect(screen.getAllByText('Elo Boost')).toHaveLength(2);
-		expect(screen.getAllByText('Gold II → Platinum IV')).toHaveLength(2);
+		expect(screen.getAllByText('Ouro II')).toHaveLength(2);
+		expect(screen.getAllByText('Platina IV')).toHaveLength(2);
 		expect(screen.getAllByText('Duo Boost')).toHaveLength(2);
 		expect(screen.getByRole('link', { name: /^Pagar$/i })).toHaveAttribute(
 			'href',
@@ -161,7 +170,8 @@ describe('ClientDashboardPage', () => {
 			screen.getByText('Todos os pedidos carregados para consulta.'),
 		).toBeInTheDocument();
 		expect(screen.getAllByText('Duo Boost')).toHaveLength(2);
-		expect(screen.getAllByText('Gold II → Platinum IV')).toHaveLength(2);
+		expect(screen.getAllByText('Ouro II')).toHaveLength(2);
+		expect(screen.getAllByText('Platina IV')).toHaveLength(2);
 		expect(screen.getByRole('link', { name: /^Detalhes$/i })).toHaveAttribute(
 			'href',
 			'/client/orders/order-2',

--- a/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-page.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-page.tsx
@@ -14,8 +14,11 @@ import { DashboardMetricCard } from '@/shared/dashboard/dashboard-metric-card';
 import { DashboardTableSection } from '@/shared/dashboard/dashboard-table-section';
 import { formatCurrency } from '@/shared/format/currency';
 import { formatDate, formatDateTime } from '@/shared/format/date';
-import { formatOrderRoute, formatServiceType } from '@/shared/format/orders';
-import { getButtonClassName } from '@/shared/ui/components/button';
+import { formatServiceType } from '@/shared/format/orders';
+import {
+	type ButtonVariant,
+	getButtonClassName,
+} from '@/shared/ui/components/button';
 import {
 	OrderStatusBadge,
 	TicketStatusBadge,
@@ -30,6 +33,7 @@ import {
 import type { ClientDashboardTab } from '../../model/client-tabs';
 import type { ClientDashboard, ClientDashboardOrder } from '../../model/orders';
 import type { SupportTicketOutput } from '../../server/ticket-contracts';
+import { OrderRankRoute } from '../order-rank-route';
 import { ClientDashboardLiveRefresh } from './client-dashboard-live-refresh';
 import { DevelopmentCheckoutModal } from './development-checkout-modal';
 
@@ -56,6 +60,9 @@ const getOrderActionLabel = (status: string) => {
 	return 'Detalhes';
 };
 
+const getOrderActionVariant = (status: string): ButtonVariant =>
+	paymentRequiredStatuses.has(status) ? 'primary' : 'outline';
+
 const ClientOrderCard = ({ order }: { order: ClientDashboardOrder }) => (
 	<Link
 		href={`/client/orders/${order.id}`}
@@ -69,8 +76,13 @@ const ClientOrderCard = ({ order }: { order: ClientDashboardOrder }) => (
 						{formatServiceType(order.serviceType)}
 					</p>
 				</div>
-				<p className="mt-2 font-bold text-white/80">
-					{formatOrderRoute(order)}
+				<p className="mt-2">
+					<OrderRankRoute
+						currentLeague={order.currentLeague}
+						currentDivision={order.currentDivision}
+						desiredLeague={order.desiredLeague}
+						desiredDivision={order.desiredDivision}
+					/>
 				</p>
 			</div>
 			<OrderStatusBadge status={order.status} />
@@ -92,7 +104,13 @@ const ClientOrderCard = ({ order }: { order: ClientDashboardOrder }) => (
 			</div>
 		</div>
 		<div className="mt-4">
-			<span className="inline-flex h-8 items-center justify-center rounded-sm border border-white/10 px-3 text-[10px] font-black uppercase tracking-widest text-white/70">
+			<span
+				className={getButtonClassName({
+					variant: getOrderActionVariant(order.status),
+					size: 'sm',
+					className: 'gap-2 font-black uppercase tracking-widest',
+				})}
+			>
 				{getOrderActionLabel(order.status)}
 			</span>
 		</div>
@@ -114,7 +132,12 @@ const ClientOrderRow = ({ order }: { order: ClientDashboardOrder }) => (
 		</TableCell>
 		<TableCell>
 			<div className="space-y-1">
-				<p className="font-bold text-white/80">{formatOrderRoute(order)}</p>
+				<OrderRankRoute
+					currentLeague={order.currentLeague}
+					currentDivision={order.currentDivision}
+					desiredLeague={order.desiredLeague}
+					desiredDivision={order.desiredDivision}
+				/>
 				<p className="text-[10px] uppercase tracking-widest text-white/35">
 					{formatCurrency(order.totalAmount)}
 				</p>
@@ -130,7 +153,7 @@ const ClientOrderRow = ({ order }: { order: ClientDashboardOrder }) => (
 			<Link
 				href={`/client/orders/${order.id}`}
 				className={getButtonClassName({
-					variant: 'outline',
+					variant: getOrderActionVariant(order.status),
 					size: 'sm',
 					className: 'gap-2 font-black uppercase tracking-widest',
 				})}

--- a/apps/web/src/modules/client-dashboard/server/order-contracts.ts
+++ b/apps/web/src/modules/client-dashboard/server/order-contracts.ts
@@ -82,6 +82,11 @@ export type GetOrderOutput = {
 	subtotal: number | null;
 	totalAmount: number | null;
 	discountAmount: number;
+	serviceType: string | null;
+	currentLeague: string | null;
+	currentDivision: string | null;
+	desiredLeague: string | null;
+	desiredDivision: string | null;
 };
 
 export const clientDashboardOrderSchema = z.object({

--- a/apps/web/src/shared/status/status-config.ts
+++ b/apps/web/src/shared/status/status-config.ts
@@ -26,7 +26,7 @@ export const ORDER_STATUS_CONFIG: Record<string, StatusConfig> = {
 	},
 	pending_booster: {
 		label: 'Aguardando booster',
-		variant: 'warning',
+		variant: 'pending',
 		icon: Hourglass,
 	},
 	in_progress: { label: 'Em execução', variant: 'info', icon: Play },

--- a/apps/web/src/shared/ui/components/badge.tsx
+++ b/apps/web/src/shared/ui/components/badge.tsx
@@ -3,7 +3,14 @@ import { focusRing } from '../styles/classes';
 import { cn } from '../utils/cn';
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
-	variant?: 'default' | 'outline' | 'success' | 'warning' | 'error' | 'info';
+	variant?:
+		| 'default'
+		| 'outline'
+		| 'success'
+		| 'warning'
+		| 'error'
+		| 'info'
+		| 'pending';
 	icon?: React.ComponentType<{ className?: string }>;
 }
 
@@ -21,6 +28,7 @@ const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
 			warning: 'border-transparent bg-hextech-gold/10 text-hextech-gold',
 			error: 'border-transparent bg-red-500/10 text-red-400',
 			info: 'border-transparent bg-hextech-cyan/10 text-hextech-cyan',
+			pending: 'border-transparent bg-violet-500/10 text-violet-400',
 		};
 
 		return (

--- a/packages/integrations/src/mercadopago/mercadopago-sdk.adapter.ts
+++ b/packages/integrations/src/mercadopago/mercadopago-sdk.adapter.ts
@@ -22,6 +22,12 @@ type MercadoPagoPreferenceClient = {
 				unit_price: number;
 			}>;
 			notification_url: string;
+			back_urls: {
+				success: string;
+				pending: string;
+				failure: string;
+			};
+			auto_return: 'approved';
 		};
 	}): Promise<PreferenceResponse>;
 };
@@ -38,11 +44,13 @@ export class MercadoPagoSdkAdapter implements MercadoPagoSdkPort {
 		accessToken: string;
 		webhookSecret: string;
 		webhookUrl: string;
+		webAppUrl: string;
 		preferenceClient?: MercadoPagoPreferenceClient;
 		paymentClient?: MercadoPagoPaymentClient;
 	}) {
 		this.webhookSecret = input.webhookSecret;
 		this.webhookUrl = input.webhookUrl;
+		this.webAppUrl = input.webAppUrl;
 
 		if (input.preferenceClient && input.paymentClient) {
 			this.preferenceClient = input.preferenceClient;
@@ -60,10 +68,12 @@ export class MercadoPagoSdkAdapter implements MercadoPagoSdkPort {
 
 	private readonly webhookSecret: string;
 	private readonly webhookUrl: string;
+	private readonly webAppUrl: string;
 
 	async createPayment(
 		input: MercadoPagoCreatePaymentInput,
 	): Promise<MercadoPagoCreatePaymentOutput> {
+		const ordersUrl = new URL('/client/orders', this.webAppUrl).toString();
 		const response = await this.preferenceClient.create({
 			body: {
 				external_reference: input.paymentId,
@@ -76,6 +86,12 @@ export class MercadoPagoSdkAdapter implements MercadoPagoSdkPort {
 					},
 				],
 				notification_url: this.webhookUrl,
+				back_urls: {
+					success: ordersUrl,
+					pending: ordersUrl,
+					failure: ordersUrl,
+				},
+				auto_return: 'approved',
 			},
 		});
 		if (!response.id || !response.init_point)


### PR DESCRIPTION
## Summary

Implements the client order details improvements task:

- **Color-coded statuses and actions**: each order status now has a distinct badge color (new `pending` violet variant for `pending_booster`); order list action buttons are color-differentiated (`Pagar` renders as primary, others as outline).
- **Elo as rank image**: new `OrderRankRoute` component renders the rank icon + Portuguese label (e.g. Ferro IV) for current → desired elo, used in the order details service card and the client dashboard order cards/rows. `GET /orders/:id` now returns the order route details to support it.
- **Email notifications**: clients receive an email when their order is paid and when a booster takes the order, via a new `OrderLifecycleEmailService` hooked into `MarkOrderAsPaidUseCase` and `AcceptOrderUseCase` (optional dependency; failures are logged and never break the payment webhook). Shared branded email layout extracted to `common/email/build-branded-email.ts` and reused by the existing users emails.
- **Chat as centerpiece**: client order details now uses the booster layout pattern (chat in the main column, info cards in a side column).

Note: this branch was cut from local `main` and carries the previously unpushed `fix(orders): successful payments should return the user` commit.

## Issue

None (task doc: `docs/tasks/client-order-details-improvements.md`, kept untracked).

## Verification

- `pnpm biome:check:all`
- `apps/api`: `pnpm exec tsc --noEmit`, `pnpm exec jest "src/.*\.spec\.ts$" --runInBand` (338 passed), `pnpm exec jest "test/integration/.*\.integration\.spec\.ts$" --runInBand` (34 passed)
- `apps/web`: `pnpm exec tsc --noEmit`, `pnpm exec jest --runInBand` (123 passed)
- `apps/workers`: `pnpm test:ci` (11 passed)

## Skipped checks and remaining risk

- `apps/api` `pnpm test:e2e` and the DB-backed suites (`test:e2e:db`, `test:integration:db`) were not run locally — relying on CI. `orders.e2e-spec.ts` assertions were updated for the new `GET /orders/:id` fields.
- No screenshots: UI verified through component tests only.
- Email delivery relies on the existing Resend sender (no-op without a real API key).

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XeBSYaMwnh3k1D3ALd9AB