### PR TITLE
feat(web): improve client order details layout

### DIFF
--- a/apps/web/src/app/(dashboard)/client/tickets/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/client/tickets/new/page.tsx
@@ -1,10 +1,21 @@
 import { getClientDashboardOrders } from '@/modules/client-dashboard/actions/order-actions';
 import { NewTicketPage } from '@/modules/client-dashboard/presentation/new-ticket/new-ticket-page';
 
-const ClientNewTicketPage = async () => {
+type ClientNewTicketPageProps = {
+	searchParams?: Promise<{
+		orderId?: string;
+	}>;
+};
+
+const ClientNewTicketPage = async ({
+	searchParams,
+}: ClientNewTicketPageProps) => {
+	const params = await searchParams;
 	const dashboard = await getClientDashboardOrders();
 
-	return <NewTicketPage orders={dashboard.orders} />;
+	return (
+		<NewTicketPage initialOrderId={params?.orderId} orders={dashboard.orders} />
+	);
 };
 
 export default ClientNewTicketPage;

--- a/apps/web/src/modules/client-dashboard/presentation/new-ticket/new-ticket-page.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-ticket/new-ticket-page.tsx
@@ -7,10 +7,14 @@ import type { ClientDashboardOrder } from '../../model/orders';
 import { SupportTicketPanel } from './support-ticket-panel';
 
 type NewTicketPageProps = {
+	initialOrderId?: string;
 	orders: ClientDashboardOrder[];
 };
 
-export const NewTicketPage = ({ orders }: NewTicketPageProps) => (
+export const NewTicketPage = ({
+	initialOrderId,
+	orders,
+}: NewTicketPageProps) => (
 	<DashboardEntrance>
 		<div className="dashboard-animate flex flex-none flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
 			<div className="flex items-start gap-4">
@@ -41,6 +45,10 @@ export const NewTicketPage = ({ orders }: NewTicketPageProps) => (
 			</Link>
 		</div>
 
-		<SupportTicketPanel action={createSupportTicketAction} orders={orders} />
+		<SupportTicketPanel
+			action={createSupportTicketAction}
+			initialOrderId={initialOrderId}
+			orders={orders}
+		/>
 	</DashboardEntrance>
 );

--- a/apps/web/src/modules/client-dashboard/presentation/new-ticket/support-ticket-panel.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-ticket/support-ticket-panel.spec.tsx
@@ -44,6 +44,20 @@ describe('SupportTicketPanel', () => {
 		expect(screen.getByText('01 disponíveis')).toBeInTheDocument();
 	});
 
+	it('preselects the linked order when it is available', () => {
+		render(
+			<SupportTicketPanel
+				action={jest.fn().mockResolvedValue({})}
+				initialOrderId="order-1234abcd"
+				orders={[buildOrder()]}
+			/>,
+		);
+
+		expect(
+			screen.getByRole('combobox', { name: /pedido relacionado/i }),
+		).toHaveValue('order-1234abcd');
+	});
+
 	it('shows the empty-orders helper when there are no orders', () => {
 		render(
 			<SupportTicketPanel

--- a/apps/web/src/modules/client-dashboard/presentation/new-ticket/support-ticket-panel.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-ticket/support-ticket-panel.tsx
@@ -14,14 +14,19 @@ type SupportTicketPanelProps = {
 		state: CreateSupportTicketActionState,
 		formData: FormData,
 	) => Promise<CreateSupportTicketActionState>;
+	initialOrderId?: string;
 	orders: ClientDashboardOrder[];
 };
 
 export const SupportTicketPanel = ({
 	action,
+	initialOrderId,
 	orders,
 }: SupportTicketPanelProps) => {
 	const [state, formAction] = useActionState(action, {});
+	const selectedOrderId = orders.some((order) => order.id === initialOrderId)
+		? initialOrderId
+		: '';
 
 	return (
 		<section className="dashboard-animate grid w-full overflow-hidden rounded-sm border border-white/10 bg-[#0b0b0d] lg:grid-cols-[minmax(0,1fr)_340px]">
@@ -34,7 +39,7 @@ export const SupportTicketPanel = ({
 						<select
 							name="orderId"
 							className={cn(fieldSurface, 'h-12 bg-white/[0.03] text-sm')}
-							defaultValue=""
+							defaultValue={selectedOrderId}
 						>
 							<option value="">Ticket geral</option>
 							{orders.map((order) => (

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-activity-card.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-activity-card.tsx
@@ -5,10 +5,11 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@/shared/ui/components/card';
+import { orderDetailsLayout } from './order-details-layout';
 
 export const OrderActivityCard = () => {
 	return (
-		<Card>
+		<Card className={orderDetailsLayout.railCard}>
 			<CardHeader>
 				<CardTitle className="flex items-center gap-2">
 					<Activity className="w-4 h-4 text-hextech-cyan" />

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-booster-card.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-booster-card.tsx
@@ -5,10 +5,12 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@/shared/ui/components/card';
+import { cn } from '@/shared/ui/utils/cn';
+import { orderDetailsLayout } from './order-details-layout';
 
 export const OrderBoosterCard = () => {
 	return (
-		<Card className="border-hextech-cyan/10">
+		<Card className={cn(orderDetailsLayout.railCard, 'border-hextech-cyan/10')}>
 			<CardHeader>
 				<CardTitle className="flex items-center gap-2">
 					<Shield className="w-4 h-4 text-hextech-cyan" />

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-panel.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-panel.spec.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { OrderChatPanel } from './order-chat-panel';
+
+jest.mock('@/shared/chat/chat-panel', () => ({
+	ChatPanel: ({
+		isDisabled,
+		isReadOnly,
+		statusText,
+	}: {
+		isDisabled?: boolean;
+		isReadOnly?: boolean;
+		statusText?: string;
+	}) => (
+		<div
+			data-disabled={isDisabled ? 'true' : 'false'}
+			data-readonly={isReadOnly ? 'true' : 'false'}
+			data-testid="chat-panel"
+		>
+			{statusText}
+		</div>
+	),
+}));
+
+jest.mock('../../actions/order-actions', () => ({
+	sendOrderChatMessageAction: jest.fn(),
+}));
+
+const renderPanel = (orderStatus: string) =>
+	render(
+		<OrderChatPanel
+			currentUserId="client-1"
+			initialMessages={[]}
+			orderId="order-1"
+			orderStatus={orderStatus}
+		/>,
+	);
+
+describe('OrderChatPanel', () => {
+	it('keeps terminal order chat read-only', () => {
+		renderPanel('completed');
+
+		const panel = screen.getByTestId('chat-panel');
+		expect(panel).toHaveAttribute('data-readonly', 'true');
+		expect(panel).toHaveAttribute('data-disabled', 'true');
+		expect(panel).toHaveTextContent('Somente leitura');
+	});
+
+	it('keeps pending order chat disabled but not read-only', () => {
+		renderPanel('pending_booster');
+
+		const panel = screen.getByTestId('chat-panel');
+		expect(panel).toHaveAttribute('data-readonly', 'false');
+		expect(panel).toHaveAttribute('data-disabled', 'true');
+		expect(panel).toHaveTextContent('Aguardando aceite');
+	});
+});

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-panel.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-panel.tsx
@@ -4,6 +4,8 @@ import { useCallback, useState, useTransition } from 'react';
 import type { ChatMessage } from '@/shared/chat/chat.types';
 import { ChatPanel } from '@/shared/chat/chat-panel';
 import { sendOrderChatMessageAction } from '../../actions/order-actions';
+import { orderDetailsLayout } from './order-details-layout';
+import { getOrderStageCopy, isReadOnlyOrderStatus } from './order-stage-copy';
 
 type OrderChatPanelProps = {
 	orderId: string;
@@ -12,22 +14,12 @@ type OrderChatPanelProps = {
 	initialMessages: ChatMessage[];
 };
 
-const isReadOnlyStatus = (orderStatus: string) =>
-	orderStatus === 'completed' || orderStatus === 'cancelled';
-
-const getStatusText = (orderStatus: string) => {
-	if (orderStatus === 'in_progress') return 'Ativo';
-	if (isReadOnlyStatus(orderStatus)) return 'Somente leitura';
-
-	return 'Aguardando aceite';
-};
-
 const getEmptyDescription = (orderStatus: string) => {
 	if (orderStatus === 'in_progress') {
 		return 'Envie a primeira mensagem para alinhar os detalhes deste pedido.';
 	}
 
-	if (isReadOnlyStatus(orderStatus)) {
+	if (isReadOnlyOrderStatus(orderStatus)) {
 		return 'Nenhuma conversa foi registrada para este pedido.';
 	}
 
@@ -43,7 +35,9 @@ export const OrderChatPanel = ({
 	const [messages, setMessages] = useState(initialMessages);
 	const [error, setError] = useState<string | null>(null);
 	const [isPending, startTransition] = useTransition();
+	const isReadOnly = isReadOnlyOrderStatus(orderStatus);
 	const isDisabled = orderStatus !== 'in_progress' || isPending;
+	const copy = getOrderStageCopy(orderStatus);
 
 	const handleSendMessage = useCallback(
 		(content: string) => {
@@ -71,11 +65,12 @@ export const OrderChatPanel = ({
 				onSendMessage={handleSendMessage}
 				isSending={isPending}
 				isDisabled={isDisabled}
+				isReadOnly={isReadOnly}
 				title="Chat do pedido"
-				statusText={getStatusText(orderStatus)}
+				statusText={copy.chatStatus}
 				emptyTitle="Nenhuma mensagem"
 				emptyDescription={getEmptyDescription(orderStatus)}
-				className="max-w-none"
+				className={orderDetailsLayout.chat}
 			/>
 			{error ? (
 				<p className="text-[10px] font-bold uppercase tracking-wider text-red-400">

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-header.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-header.spec.tsx
@@ -39,6 +39,7 @@ describe('OrderDetailsHeader', () => {
 		expect(
 			screen.getByRole('button', { name: /retomar pagamento/i }),
 		).toBeInTheDocument();
+		expect(screen.getByText(/conclua o pagamento/i)).toBeInTheDocument();
 	});
 
 	it('hides resume payment after checkout is no longer pending', () => {
@@ -47,5 +48,23 @@ describe('OrderDetailsHeader', () => {
 		expect(
 			screen.queryByRole('button', { name: /retomar pagamento/i }),
 		).not.toBeInTheDocument();
+	});
+
+	it('wraps long order ids without forcing one-line header layout', () => {
+		render(
+			<OrderDetailsHeader
+				order={{
+					...makeOrder('completed'),
+					id: 'very-long-order-id-that-needs-to-wrap-on-mobile',
+				}}
+			/>,
+		);
+
+		expect(
+			screen.getByRole('heading', {
+				name: 'very-long-order-id-that-needs-to-wrap-on-mobile',
+			}),
+		).toHaveClass('break-all');
+		expect(screen.getByText(/pedido foi finalizado/i)).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-header.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-header.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { OrderStatusBadge } from '@/shared/ui/components/status-badge';
 import type { ClientOrder } from '../../model/orders';
+import { getOrderStageCopy } from './order-stage-copy';
 import { ResumePaymentButton } from './resume-payment-button';
 
 type OrderDetailsHeaderProps = {
@@ -10,6 +11,7 @@ type OrderDetailsHeaderProps = {
 
 export const OrderDetailsHeader = ({ order }: OrderDetailsHeaderProps) => {
 	const canResumePayment = order.status === 'awaiting_payment';
+	const copy = getOrderStageCopy(order.status);
 
 	return (
 		<>
@@ -21,16 +23,16 @@ export const OrderDetailsHeader = ({ order }: OrderDetailsHeaderProps) => {
 				Voltar ao Painel
 			</Link>
 
-			<header className="flex flex-col md:flex-row md:items-center justify-between gap-6 bg-white/[0.02] border border-white/5 p-8 rounded-sm">
-				<div className="space-y-2">
-					<div className="flex items-center gap-3">
-						<h1 className="text-2xl font-black uppercase tracking-tight">
+			<header className="flex flex-col justify-between gap-6 rounded-sm border border-white/5 bg-white/[0.02] p-6 sm:p-8 md:flex-row md:items-center">
+				<div className="min-w-0 space-y-2">
+					<div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center">
+						<h1 className="break-all text-2xl font-black uppercase tracking-tight">
 							{order.id}
 						</h1>
 						<OrderStatusBadge status={order.status} />
 					</div>
 					<p className="text-xs text-white/40 tracking-wider">
-						Os dados disponíveis deste pedido vieram da sua conta.
+						{copy.headerDescription}
 					</p>
 				</div>
 				{canResumePayment ? <ResumePaymentButton orderId={order.id} /> : null}

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-layout.ts
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-layout.ts
@@ -1,0 +1,6 @@
+export const orderDetailsLayout = {
+	grid: 'grid items-start gap-8 xl:grid-cols-[minmax(0,1fr)_360px]',
+	rail: 'grid content-start gap-6',
+	railCard: 'min-h-36',
+	chat: 'h-[min(560px,calc(100vh-10rem))] max-w-none',
+} as const;

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
@@ -11,6 +11,7 @@ import { OrderActivityCard } from './order-activity-card';
 import { OrderBoosterCard } from './order-booster-card';
 import { OrderChatPanel } from './order-chat-panel';
 import { OrderDetailsHeader } from './order-details-header';
+import { orderDetailsLayout } from './order-details-layout';
 import { OrderServiceCard } from './order-service-card';
 import { OrderSupportCard } from './order-support-card';
 
@@ -45,30 +46,38 @@ export const OrderDetailsPage = async ({ orderId }: OrderDetailsPageProps) => {
 		ratings = await getOrderRatings(order.id);
 	}
 
+	const chatPanel = (
+		<OrderChatPanel
+			orderId={order.id}
+			orderStatus={order.status}
+			currentUserId={session.userId}
+			initialMessages={chatMessages}
+		/>
+	);
+
+	const ratingCard =
+		order.status === 'completed' ? (
+			<RatingCard
+				className={orderDetailsLayout.railCard}
+				orderId={order.id}
+				currentUserId={session.userId}
+				initialRatings={ratings}
+			/>
+		) : null;
+
 	return (
 		<div className="space-y-8">
 			<OrderDetailsHeader order={order} />
 
-			<div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_360px]">
-				<OrderChatPanel
-					orderId={order.id}
-					orderStatus={order.status}
-					currentUserId={session.userId}
-					initialMessages={chatMessages}
-				/>
+			<div className={orderDetailsLayout.grid}>
+				{chatPanel}
 
-				<div className="grid content-start gap-8">
+				<div className={orderDetailsLayout.rail}>
 					<OrderServiceCard order={order} />
 					<OrderBoosterCard />
 					<OrderActivityCard />
-					<OrderSupportCard />
-					{order.status === 'completed' ? (
-						<RatingCard
-							orderId={order.id}
-							currentUserId={session.userId}
-							initialRatings={ratings}
-						/>
-					) : null}
+					<OrderSupportCard orderId={order.id} />
+					{ratingCard}
 				</div>
 			</div>
 		</div>

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-service-card.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-service-card.tsx
@@ -10,6 +10,7 @@ import {
 import { OrderStatusBadge } from '@/shared/ui/components/status-badge';
 import type { ClientOrder } from '../../model/orders';
 import { OrderRankRoute } from '../order-rank-route';
+import { orderDetailsLayout } from './order-details-layout';
 
 type OrderServiceCardProps = {
 	order: ClientOrder;
@@ -17,15 +18,15 @@ type OrderServiceCardProps = {
 
 export const OrderServiceCard = ({ order }: OrderServiceCardProps) => {
 	return (
-		<Card>
+		<Card className={orderDetailsLayout.railCard}>
 			<CardHeader>
 				<CardTitle className="flex items-center gap-2">
 					<FileText className="w-4 h-4 text-hextech-cyan" />
 					Dados do Serviço
 				</CardTitle>
 			</CardHeader>
-			<CardContent className="grid grid-cols-2 md:grid-cols-4 gap-8">
-				<div className="col-span-2 md:col-span-4 space-y-2">
+			<CardContent className="space-y-7">
+				<div className="space-y-2">
 					<p className="text-[10px] text-white/40 uppercase tracking-widest">
 						Rota
 					</p>
@@ -37,26 +38,31 @@ export const OrderServiceCard = ({ order }: OrderServiceCardProps) => {
 						desiredDivision={order.desiredDivision}
 					/>
 				</div>
-				<div className="space-y-1">
+				<div className="space-y-2">
 					<p className="text-[10px] text-white/40 uppercase tracking-widest">
 						Status
 					</p>
-					<OrderStatusBadge status={order.status} />
+					<OrderStatusBadge
+						className="min-w-0 w-fit max-w-full"
+						status={order.status}
+					/>
 				</div>
-				<DefinitionItem
-					label="Subtotal"
-					value={formatCurrency(order.subtotal)}
-					valueClassName="text-hextech-cyan"
-				/>
-				<DefinitionItem
-					label="Desconto"
-					value={formatCurrency(order.discountAmount)}
-				/>
-				<DefinitionItem
-					label="Total"
-					value={formatCurrency(order.totalAmount)}
-					valueClassName="text-hextech-cyan"
-				/>
+				<div className="grid gap-5 sm:grid-cols-3">
+					<DefinitionItem
+						label="Subtotal"
+						value={formatCurrency(order.subtotal)}
+						valueClassName="text-hextech-cyan"
+					/>
+					<DefinitionItem
+						label="Desconto"
+						value={formatCurrency(order.discountAmount)}
+					/>
+					<DefinitionItem
+						label="Total"
+						value={formatCurrency(order.totalAmount)}
+						valueClassName="text-hextech-cyan"
+					/>
+				</div>
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-stage-copy.ts
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-stage-copy.ts
@@ -1,0 +1,42 @@
+const orderStageCopy: Record<
+	string,
+	{
+		chatStatus: string;
+		headerDescription: string;
+	}
+> = {
+	awaiting_payment: {
+		chatStatus: 'Aguardando pagamento',
+		headerDescription:
+			'Conclua o pagamento para liberar a fila e os próximos dados do pedido.',
+	},
+	pending_booster: {
+		chatStatus: 'Aguardando aceite',
+		headerDescription:
+			'Seu pedido está na fila aguardando um booster aceitar o serviço.',
+	},
+	in_progress: {
+		chatStatus: 'Ativo',
+		headerDescription:
+			'O serviço está em andamento. Use o chat para alinhar detalhes com o booster.',
+	},
+	completed: {
+		chatStatus: 'Somente leitura',
+		headerDescription:
+			'O pedido foi finalizado. Você pode consultar o histórico e avaliar o serviço.',
+	},
+	cancelled: {
+		chatStatus: 'Somente leitura',
+		headerDescription:
+			'Este pedido foi cancelado. O suporte segue disponível se precisar de ajuda.',
+	},
+};
+
+export const getOrderStageCopy = (status: string) =>
+	orderStageCopy[status] ?? {
+		chatStatus: 'Em análise',
+		headerDescription: 'Acompanhe as atualizações deste pedido por aqui.',
+	};
+
+export const isReadOnlyOrderStatus = (status: string) =>
+	status === 'completed' || status === 'cancelled';

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-support-card.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-support-card.spec.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import type { AnchorHTMLAttributes, PropsWithChildren } from 'react';
+import { OrderSupportCard } from './order-support-card';
+
+jest.mock('next/link', () => ({
+	__esModule: true,
+	default: ({
+		children,
+		href,
+		...props
+	}: PropsWithChildren<
+		AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }
+	>) => (
+		<a href={href} {...props}>
+			{children}
+		</a>
+	),
+}));
+
+describe('OrderSupportCard', () => {
+	it('links ticket creation to the current order', () => {
+		render(<OrderSupportCard orderId="order 1" />);
+
+		expect(screen.getByRole('link', { name: /abrir ticket/i })).toHaveAttribute(
+			'href',
+			'/client/tickets/new?orderId=order%201',
+		);
+	});
+});

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-support-card.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-support-card.tsx
@@ -1,15 +1,21 @@
 import { Clock } from 'lucide-react';
-import { Button } from '@/shared/ui/components/button';
+import Link from 'next/link';
+import { getButtonClassName } from '@/shared/ui/components/button';
 import {
 	Card,
 	CardContent,
 	CardHeader,
 	CardTitle,
 } from '@/shared/ui/components/card';
+import { orderDetailsLayout } from './order-details-layout';
 
-export const OrderSupportCard = () => {
+type OrderSupportCardProps = {
+	orderId: string;
+};
+
+export const OrderSupportCard = ({ orderId }: OrderSupportCardProps) => {
 	return (
-		<Card>
+		<Card className={orderDetailsLayout.railCard}>
 			<CardHeader>
 				<CardTitle className="flex items-center gap-2">
 					<Clock className="w-4 h-4 text-hextech-cyan" />
@@ -21,9 +27,15 @@ export const OrderSupportCard = () => {
 					Precisa de ajuda com este pedido? Nossa equipe de suporte está
 					disponível a qualquer momento.
 				</p>
-				<Button variant="secondary" className="w-full">
+				<Link
+					href={`/client/tickets/new?orderId=${encodeURIComponent(orderId)}`}
+					className={getButtonClassName({
+						variant: 'secondary',
+						className: 'w-full',
+					})}
+				>
 					Abrir Ticket
-				</Button>
+				</Link>
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-page.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-page.spec.tsx
@@ -197,6 +197,46 @@ describe('ClientDashboardPage', () => {
 		expect(screen.getAllByText('Nenhum pedido encontrado')).toHaveLength(2);
 	});
 
+	it('does not count stale paid status as active', () => {
+		render(
+			<ClientDashboardPage
+				dashboard={{
+					orders: [
+						{
+							id: 'order-paid',
+							status: 'paid',
+							serviceType: 'elo_boost',
+							currentLeague: 'gold',
+							currentDivision: 'II',
+							currentLp: 40,
+							desiredLeague: 'platinum',
+							desiredDivision: 'IV',
+							server: 'br',
+							desiredQueue: 'solo_duo',
+							lpGain: 20,
+							deadline: '2026-05-01T00:00:00.000Z',
+							subtotal: 120,
+							totalAmount: 12000,
+							discountAmount: 0,
+							createdAt: '2026-04-01T00:00:00.000Z',
+						},
+					],
+					summary: {
+						activeOrders: 1,
+						totalOrders: 1,
+						totalInvested: 12000,
+					},
+				}}
+			/>,
+		);
+
+		expect(screen.getByText('Pedidos ativos')).toBeInTheDocument();
+		expect(screen.getByText('00')).toBeInTheDocument();
+		expect(screen.getByTestId('active-orders-progress')).toHaveStyle({
+			width: '0%',
+		});
+	});
+
 	it('renders the development checkout tutorial and copies snippets', async () => {
 		render(
 			<ClientDashboardPage

--- a/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-page.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-page.tsx
@@ -49,7 +49,6 @@ const formatMetricCount = (value: number) => value.toString().padStart(2, '0');
 const paymentRequiredStatuses = new Set(['awaiting_payment']);
 const activeStatuses = new Set([
 	'awaiting_payment',
-	'paid',
 	'pending_booster',
 	'in_progress',
 ]);
@@ -324,7 +323,7 @@ export const ClientDashboardPage = ({
 	const isTicketsTab = tab === 'tickets';
 	const activeProgress =
 		dashboard && dashboard.summary.totalOrders > 0
-			? (dashboard.summary.activeOrders / dashboard.summary.totalOrders) * 100
+			? (activeOrders.length / dashboard.summary.totalOrders) * 100
 			: 0;
 
 	return (
@@ -347,6 +346,7 @@ export const ClientDashboardPage = ({
 							<div className="h-1 w-full bg-white/5 rounded-full overflow-hidden">
 								<div
 									className="h-full bg-hextech-cyan"
+									data-testid="active-orders-progress"
 									style={{ width: `${activeProgress}%` }}
 								/>
 							</div>

--- a/apps/web/src/shared/chat/chat-message-list.tsx
+++ b/apps/web/src/shared/chat/chat-message-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type CSSProperties, type FC, memo, useEffect, useRef } from 'react';
+import { type FC, memo, useEffect, useRef } from 'react';
 import { Badge } from '@/shared/ui/components/badge';
 import { cn } from '@/shared/ui/utils/cn';
 import type { ChatMessage, ChatRoleLabel } from './chat.types';
@@ -57,12 +57,6 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
 	return (
 		<div
 			ref={scrollRef}
-			style={
-				{
-					containIntrinsicSize: '0 420px',
-					contentVisibility: 'auto',
-				} as CSSProperties
-			}
 			className={cn(
 				'flex flex-col gap-4 overflow-y-auto p-4 scrollbar-hide',
 				className,
@@ -107,21 +101,22 @@ const ChatMessageItem = memo(({ message, isMe }: ChatMessageItemProps) => {
 			)}
 		>
 			<div className="flex items-center gap-2 mb-1">
-				{!isMe && (
-					<span className="text-[10px] font-black uppercase tracking-wider text-white/40">
-						{message.sender.username}
-					</span>
-				)}
-				<Badge
-					variant={ROLE_VARIANTS[message.sender.role]}
-					className="h-4 px-1 text-[8px]"
-				>
-					{ROLE_LABELS[message.sender.role]}
-				</Badge>
-				{isMe && (
+				{isMe ? (
 					<span className="text-[10px] font-black uppercase tracking-wider text-white/40">
 						Você
 					</span>
+				) : (
+					<>
+						<span className="text-[10px] font-black uppercase tracking-wider text-white/40">
+							{message.sender.username}
+						</span>
+						<Badge
+							variant={ROLE_VARIANTS[message.sender.role]}
+							className="h-4 px-1 text-[8px]"
+						>
+							{ROLE_LABELS[message.sender.role]}
+						</Badge>
+					</>
 				)}
 			</div>
 			<div

--- a/apps/web/src/shared/chat/chat-panel.tsx
+++ b/apps/web/src/shared/chat/chat-panel.tsx
@@ -57,7 +57,7 @@ export const ChatPanel: FC<ChatPanelProps> = ({
 					<div className="h-3 w-3 animate-spin rounded-full border border-hextech-cyan border-t-transparent" />
 				) : null}
 			</div>
-			<div className="flex-1 overflow-hidden relative">
+			<div className="relative min-h-0 flex-1 overflow-hidden">
 				<ChatMessageList
 					messages={messages}
 					currentUserId={currentUserId}

--- a/apps/web/src/shared/ratings/rating-card.spec.tsx
+++ b/apps/web/src/shared/ratings/rating-card.spec.tsx
@@ -44,6 +44,10 @@ describe('RatingCard', () => {
 		expect(
 			screen.getByRole('button', { name: /enviar avaliação/i }),
 		).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Nota 1' })).toHaveClass(
+			'h-11',
+			'w-11',
+		);
 	});
 
 	it('shows the submitted state when the user already rated', () => {

--- a/apps/web/src/shared/ratings/rating-card.tsx
+++ b/apps/web/src/shared/ratings/rating-card.tsx
@@ -9,6 +9,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@/shared/ui/components/card';
+import { cn } from '@/shared/ui/utils/cn';
 import {
 	type SubmitRatingActionState,
 	submitRatingAction,
@@ -19,10 +20,11 @@ type RatingCardProps = {
 	orderId: string;
 	currentUserId: string;
 	initialRatings: RatingOutput[];
+	className?: string;
 };
 
 const Stars = ({ score }: { score: number }) => (
-	<div className="flex gap-1" role="img" aria-label={`${score} de 5`}>
+	<div className="flex gap-1.5" role="img" aria-label={`${score} de 5`}>
 		{[1, 2, 3, 4, 5].map((value) => (
 			<Star
 				key={value}
@@ -36,6 +38,7 @@ export const RatingCard = ({
 	orderId,
 	currentUserId,
 	initialRatings,
+	className,
 }: RatingCardProps) => {
 	const [state, formAction, isPending] = useActionState<
 		SubmitRatingActionState,
@@ -48,14 +51,14 @@ export const RatingCard = ({
 		initialRatings.find((rating) => rating.fromUserId === currentUserId);
 
 	return (
-		<Card>
+		<Card className={cn('border-hextech-gold/15', className)}>
 			<CardHeader>
 				<CardTitle className="flex items-center gap-2">
 					<Star className="h-4 w-4 text-hextech-gold" />
 					Avaliação
 				</CardTitle>
 			</CardHeader>
-			<CardContent className="space-y-4">
+			<CardContent className="space-y-5">
 				{submitted ? (
 					<div className="space-y-2">
 						<p className="text-[10px] uppercase tracking-widest text-white/40">
@@ -71,27 +74,32 @@ export const RatingCard = ({
 				) : (
 					<form action={formAction} className="space-y-4">
 						<input type="hidden" name="score" value={score} />
-						<div className="flex gap-1">
-							{[1, 2, 3, 4, 5].map((value) => (
-								<button
-									key={value}
-									type="button"
-									onClick={() => setScore(value)}
-									aria-label={`Nota ${value}`}
-									className="p-1"
-								>
-									<Star
-										className={`h-6 w-6 transition-colors ${value <= score ? 'fill-hextech-gold text-hextech-gold' : 'text-white/20 hover:text-white/40'}`}
-									/>
-								</button>
-							))}
+						<div className="space-y-2">
+							<p className="text-xs leading-relaxed text-white/45">
+								Como foi sua experiência com este pedido?
+							</p>
+							<div className="flex gap-1">
+								{[1, 2, 3, 4, 5].map((value) => (
+									<button
+										key={value}
+										type="button"
+										onClick={() => setScore(value)}
+										aria-label={`Nota ${value}`}
+										className="flex h-11 w-11 items-center justify-center rounded-sm border border-white/10 bg-white/[0.02] transition-colors hover:border-hextech-gold/40"
+									>
+										<Star
+											className={`h-5 w-5 transition-colors ${value <= score ? 'fill-hextech-gold text-hextech-gold' : 'text-white/20'}`}
+										/>
+									</button>
+								))}
+							</div>
 						</div>
 						<textarea
 							name="comment"
 							rows={3}
 							maxLength={2000}
-							placeholder="Comentário (opcional)"
-							className="w-full rounded-sm border border-white/10 bg-white/[0.03] p-3 text-sm text-white placeholder:text-white/30 focus:border-hextech-cyan focus:outline-none"
+							placeholder="Comentário opcional"
+							className="min-h-24 w-full resize-none rounded-sm border border-white/10 bg-white/[0.03] p-3 text-sm leading-relaxed text-white placeholder:text-white/30 focus:border-hextech-gold focus:outline-none"
 						/>
 						<button
 							type="submit"

--- a/apps/web/src/shared/ui/components/status-badge.tsx
+++ b/apps/web/src/shared/ui/components/status-badge.tsx
@@ -2,12 +2,19 @@ import {
 	ORDER_STATUS_CONFIG,
 	TICKET_STATUS_CONFIG,
 } from '@/shared/status/status-config';
+import { cn } from '../utils/cn';
 import { Badge } from './badge';
 
 const ORDER_BADGE_WIDTH = 'min-w-50 justify-start';
 const TICKET_BADGE_WIDTH = 'min-w-32 justify-start';
 
-export const OrderStatusBadge = ({ status }: { status: string }) => {
+export const OrderStatusBadge = ({
+	className,
+	status,
+}: {
+	className?: string;
+	status: string;
+}) => {
 	const config = ORDER_STATUS_CONFIG[status];
 	if (!config)
 		throw new Error(
@@ -17,7 +24,7 @@ export const OrderStatusBadge = ({ status }: { status: string }) => {
 		<Badge
 			variant={config.variant}
 			icon={config.icon}
-			className={ORDER_BADGE_WIDTH}
+			className={cn(ORDER_BADGE_WIDTH, className)}
 		>
 			{config.label}
 		</Badge>


### PR DESCRIPTION
## Summary
- Makes client order details chat the primary panel across order states.
- Centralizes order-detail layout classes in one source of truth.
- Improves order status/header copy, service-card price layout, rating UX, and support-ticket linking from an order.
- Fixes active-order dashboard progress to use the same derived active count as the displayed metric.

## Issue
Closes: None

## Verification
- `pnpm biome:fix:all`
- `pnpm web test -- client-dashboard-page rating-card`
- `pnpm web test`
- `pnpm web build`
- `git diff --check`

## Screenshots
Not attached. Local web reached the login page, but the documented dev client credentials were rejected in this database, so dashboard/order-detail screenshots were blocked without mutating local data.

## Skipped Checks / Remaining Risk
- Browser dashboard smoke was not completed because the local dev client login rejected documented seed credentials.
- `docs/tasks/` remains untracked and intentionally excluded from this PR per request.

## Breaking Changes
None