### PR TITLE
feat: payment checkout flow — correct return URLs, new-tab checkout, live order status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           cd /opt/elonew/elonew
           git fetch --force --tags origin
           git checkout --detach "refs/tags/$tag"
-          docker compose --env-file infrastructure/docker/prod/.env \
+          APP_VERSION="$tag" docker compose --env-file infrastructure/docker/prod/.env \
             -f infrastructure/docker/prod/compose.yml up -d --build
           for attempt in {1..30}; do
             curl --fail --silent --show-error https://api.elonew.com.br/health && exit 0

--- a/apps/api/src/common/logging/logging.module.ts
+++ b/apps/api/src/common/logging/logging.module.ts
@@ -11,7 +11,11 @@ import { LoggerModule } from 'nestjs-pino';
 			useFactory: (settings: AppSettingsService) => ({
 				pinoHttp: {
 					level: 'info',
-					base: { service: 'api', env: settings.nodeEnv },
+					base: {
+						service: 'api',
+						env: settings.nodeEnv,
+						version: process.env.APP_VERSION ?? 'unknown',
+					},
 					genReqId: (req: IncomingMessage, res: ServerResponse) => {
 						const header = req.headers['x-request-id'];
 						const requestId =

--- a/apps/api/src/common/settings/app-settings.service.spec.ts
+++ b/apps/api/src/common/settings/app-settings.service.spec.ts
@@ -222,6 +222,7 @@ describe('AppSettingsService', () => {
 		MERCADO_PAGO_WEBHOOK_SECRET: 'webhook-secret',
 		MERCADO_PAGO_WEBHOOK_URL:
 			'https://example.com/payments/webhooks/mercadopago',
+		WEB_APP_URL: 'https://app.example.com',
 	});
 
 	it('rejects production env when the Resend API key is missing', () => {
@@ -247,6 +248,22 @@ describe('AppSettingsService', () => {
 		expect(result.error.issues).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ path: ['RESEND_API_KEY'] }),
+			]),
+		);
+	});
+
+	it('rejects production env when WEB_APP_URL is left at the localhost default', () => {
+		const result = envSchema.safeParse({
+			...buildValidProductionEnv(),
+			RESEND_API_KEY: 're_live_realkey',
+			WEB_APP_URL: 'http://localhost:3001',
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error.issues).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ path: ['WEB_APP_URL'] }),
 			]),
 		);
 	});

--- a/apps/api/src/modules/payments/application/logging/payment-lifecycle.logger.ts
+++ b/apps/api/src/modules/payments/application/logging/payment-lifecycle.logger.ts
@@ -29,6 +29,7 @@ export type PaymentLifecycleLogEvent = {
 	gateway_status?: string;
 	gateway_status_detail?: string;
 	checkout_url_present?: boolean;
+	back_url?: string;
 	webhook_event_id?: string;
 	webhook_topic?: string;
 	webhook_resource_id?: string;

--- a/apps/api/src/modules/payments/application/ports/payment-gateway.port.ts
+++ b/apps/api/src/modules/payments/application/ports/payment-gateway.port.ts
@@ -9,6 +9,7 @@ export type InitiatePaymentInput = {
 
 export type InitiatePaymentOutput = {
 	checkoutUrl: string;
+	backUrl: string | null;
 	gatewayReferenceId: string;
 	gatewayStatus: string | null;
 };

--- a/apps/api/src/modules/payments/application/use-cases/create-payment/create-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/create-payment/create-payment.use-case.spec.ts
@@ -109,6 +109,7 @@ class InMemoryPaymentGatewayPort implements PaymentGatewayPort {
 		paymentMethod: 'pix' | 'credit_card' | 'boleto';
 	}): Promise<{
 		checkoutUrl: string;
+		backUrl: string | null;
 		gatewayReferenceId: string;
 		gatewayStatus: string | null;
 	}> {
@@ -116,6 +117,7 @@ class InMemoryPaymentGatewayPort implements PaymentGatewayPort {
 
 		return {
 			checkoutUrl: `https://mercadopago.test/checkout/${input.paymentId}`,
+			backUrl: null,
 			gatewayReferenceId: `pref-${input.paymentId}`,
 			gatewayStatus: 'pending',
 		};

--- a/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
@@ -111,6 +111,7 @@ class InMemoryPaymentGatewayPort implements PaymentGatewayPort {
 
 	async initiatePayment(): Promise<{
 		checkoutUrl: string;
+		backUrl: string | null;
 		gatewayReferenceId: string;
 		gatewayStatus: string | null;
 	}> {

--- a/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.spec.ts
@@ -1,5 +1,10 @@
 import { OrderStatus } from '@modules/orders/domain/order-status';
 import type { OrderStatusPort } from '@modules/payments/application/ports/order-status.port';
+import type {
+	InitiatePaymentInput,
+	InitiatePaymentOutput,
+	PaymentGatewayPort,
+} from '@modules/payments/application/ports/payment-gateway.port';
 import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import { ResumePaymentCheckoutUseCase } from '@modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case';
 import { Payment } from '@modules/payments/domain/payment.entity';
@@ -86,6 +91,27 @@ class InMemoryOrderStatusPort implements OrderStatusPort {
 	}
 }
 
+class FakePaymentGateway implements PaymentGatewayPort {
+	lastInput: InitiatePaymentInput | undefined;
+
+	async initiatePayment(
+		input: InitiatePaymentInput,
+	): Promise<InitiatePaymentOutput> {
+		this.lastInput = input;
+
+		return {
+			checkoutUrl: `https://checkout.example/fresh/${input.paymentId}`,
+			backUrl: `https://app.example/client/orders/${input.orderId}`,
+			gatewayReferenceId: `pref-fresh-${input.paymentId}`,
+			gatewayStatus: 'pending',
+		};
+	}
+
+	async fetchPaymentNotification(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+}
+
 const makePayment = (input?: { checkoutUrl?: string | null }) => {
 	const payment = Payment.create({
 		id: 'payment-1',
@@ -108,7 +134,7 @@ const makePayment = (input?: { checkoutUrl?: string | null }) => {
 };
 
 describe('ResumePaymentCheckoutUseCase', () => {
-	it('returns the stored checkout URL for an owned awaiting payment', async () => {
+	it('creates a fresh checkout for an owned awaiting payment', async () => {
 		const repository = new InMemoryPaymentRepository();
 		const orderStatusPort = new InMemoryOrderStatusPort();
 		repository.insert(makePayment(), 'client-1');
@@ -116,14 +142,19 @@ describe('ResumePaymentCheckoutUseCase', () => {
 		const useCase = new ResumePaymentCheckoutUseCase(
 			repository,
 			orderStatusPort,
+			new FakePaymentGateway(),
 		);
 
 		await expect(
 			useCase.execute({ orderId: 'order-1', clientId: 'client-1' }),
 		).resolves.toEqual({
 			paymentId: 'payment-1',
-			checkoutUrl: 'https://checkout.example/pay',
+			checkoutUrl: 'https://checkout.example/fresh/payment-1',
 		});
+
+		const saved = await repository.findById('payment-1');
+		expect(saved?.gatewayReferenceId).toBe('pref-fresh-payment-1');
+		expect(saved?.checkoutUrl).toBe('https://checkout.example/fresh/payment-1');
 	});
 
 	it('throws when the payment belongs to another client', async () => {
@@ -134,6 +165,7 @@ describe('ResumePaymentCheckoutUseCase', () => {
 		const useCase = new ResumePaymentCheckoutUseCase(
 			repository,
 			orderStatusPort,
+			new FakePaymentGateway(),
 		);
 
 		await expect(
@@ -151,6 +183,7 @@ describe('ResumePaymentCheckoutUseCase', () => {
 		const useCase = new ResumePaymentCheckoutUseCase(
 			repository,
 			orderStatusPort,
+			new FakePaymentGateway(),
 		);
 
 		await expect(
@@ -158,7 +191,7 @@ describe('ResumePaymentCheckoutUseCase', () => {
 		).rejects.toThrow(PaymentCheckoutResumeNotAllowedError);
 	});
 
-	it('throws when an older payment has no stored checkout URL', async () => {
+	it('recovers an older payment that has no stored checkout URL', async () => {
 		const repository = new InMemoryPaymentRepository();
 		const orderStatusPort = new InMemoryOrderStatusPort();
 		repository.insert(makePayment({ checkoutUrl: null }), 'client-1');
@@ -166,11 +199,15 @@ describe('ResumePaymentCheckoutUseCase', () => {
 		const useCase = new ResumePaymentCheckoutUseCase(
 			repository,
 			orderStatusPort,
+			new FakePaymentGateway(),
 		);
 
 		await expect(
 			useCase.execute({ orderId: 'order-1', clientId: 'client-1' }),
-		).rejects.toThrow(PaymentCheckoutResumeNotAllowedError);
+		).resolves.toEqual({
+			paymentId: 'payment-1',
+			checkoutUrl: 'https://checkout.example/fresh/payment-1',
+		});
 	});
 
 	it.each([
@@ -186,6 +223,7 @@ describe('ResumePaymentCheckoutUseCase', () => {
 		const useCase = new ResumePaymentCheckoutUseCase(
 			repository,
 			orderStatusPort,
+			new FakePaymentGateway(),
 		);
 
 		await expect(

--- a/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.ts
+++ b/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.ts
@@ -9,6 +9,10 @@ import {
 	type OrderStatusPort,
 } from '@modules/payments/application/ports/order-status.port';
 import {
+	PAYMENT_GATEWAY_PORT_KEY,
+	type PaymentGatewayPort,
+} from '@modules/payments/application/ports/payment-gateway.port';
+import {
 	PAYMENT_REPOSITORY_KEY,
 	type PaymentRepositoryPort,
 } from '@modules/payments/application/ports/payment-repository.port';
@@ -18,6 +22,7 @@ import {
 } from '@modules/payments/domain/payment.errors';
 import { PaymentStatus } from '@modules/payments/domain/payment-status';
 import { Inject, Injectable, Optional } from '@nestjs/common';
+import { Money } from '@packages/shared/money/money';
 
 type ResumePaymentCheckoutInput = {
 	orderId: string;
@@ -36,6 +41,8 @@ export class ResumePaymentCheckoutUseCase {
 		private readonly paymentRepository: PaymentRepositoryPort,
 		@Inject(ORDER_STATUS_PORT_KEY)
 		private readonly orderStatusPort: OrderStatusPort,
+		@Inject(PAYMENT_GATEWAY_PORT_KEY)
+		private readonly paymentGatewayPort: PaymentGatewayPort,
 		@Optional()
 		private readonly paymentLifecycleLogger?: PaymentLifecycleLogger,
 	) {}
@@ -80,16 +87,33 @@ export class ResumePaymentCheckoutUseCase {
 
 			if (
 				orderStatus !== OrderStatus.AWAITING_PAYMENT ||
-				payment.status !== PaymentStatus.AWAITING_CONFIRMATION ||
-				!payment.checkoutUrl
+				payment.status !== PaymentStatus.AWAITING_CONFIRMATION
 			)
 				throw new PaymentCheckoutResumeNotAllowedError();
 
+			const gatewayPayment = await this.paymentGatewayPort.initiatePayment({
+				paymentId: payment.id,
+				orderId: payment.orderId,
+				amount: Money.fromCents(payment.grossAmount).toDecimal(),
+				paymentMethod: payment.paymentMethod,
+			});
+			payment.attachGatewayDetails({
+				gatewayReferenceId: gatewayPayment.gatewayReferenceId,
+				gatewayId: payment.gatewayId,
+				gatewayStatus: gatewayPayment.gatewayStatus,
+				checkoutUrl: gatewayPayment.checkoutUrl,
+			});
+			await this.paymentRepository.save(payment);
+
 			logEvent.outcome = 'success';
+			logEvent.gateway_reference_id = payment.gatewayReferenceId ?? undefined;
+			logEvent.gateway_status = payment.gatewayStatus ?? undefined;
+			logEvent.checkout_url_present = true;
+			logEvent.back_url = gatewayPayment.backUrl ?? undefined;
 
 			return {
 				paymentId: payment.id,
-				checkoutUrl: payment.checkoutUrl,
+				checkoutUrl: gatewayPayment.checkoutUrl,
 			};
 		} catch (error) {
 			markPaymentLifecycleLogError(logEvent, error);

--- a/apps/api/src/modules/payments/application/use-cases/start-checkout/start-checkout.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/start-checkout/start-checkout.use-case.spec.ts
@@ -43,6 +43,7 @@ class FakeGateway implements PaymentGatewayPort {
 
 		return {
 			checkoutUrl: 'https://checkout.example/pay',
+			backUrl: 'https://app.example/client/orders/order-1',
 			gatewayReferenceId: 'pref-1',
 			gatewayStatus: 'pending',
 		};

--- a/apps/api/src/modules/payments/application/use-cases/start-checkout/start-checkout.use-case.ts
+++ b/apps/api/src/modules/payments/application/use-cases/start-checkout/start-checkout.use-case.ts
@@ -118,6 +118,7 @@ export class StartCheckoutUseCase {
 			logEvent.gateway_reference_id = payment.gatewayReferenceId ?? undefined;
 			logEvent.gateway_status = payment.gatewayStatus ?? undefined;
 			logEvent.checkout_url_present = Boolean(payment.checkoutUrl);
+			logEvent.back_url = gatewayPayment.backUrl ?? undefined;
 
 			return {
 				orderId: order.id,

--- a/apps/api/src/modules/payments/infrastructure/adapters/dev-payment-gateway.adapter.spec.ts
+++ b/apps/api/src/modules/payments/infrastructure/adapters/dev-payment-gateway.adapter.spec.ts
@@ -16,6 +16,7 @@ describe('DevPaymentGatewayAdapter', () => {
 			}),
 		).resolves.toEqual({
 			checkoutUrl: 'http://localhost:3001/client?devPaymentId=payment-1',
+			backUrl: null,
 			gatewayReferenceId: 'dev-payment-1',
 			gatewayStatus: 'pending',
 		});

--- a/apps/api/src/modules/payments/infrastructure/adapters/dev-payment-gateway.adapter.ts
+++ b/apps/api/src/modules/payments/infrastructure/adapters/dev-payment-gateway.adapter.ts
@@ -18,6 +18,7 @@ export class DevPaymentGatewayAdapter implements PaymentGatewayPort {
 
 		return Promise.resolve({
 			checkoutUrl: checkoutUrl.toString(),
+			backUrl: null,
 			gatewayReferenceId: `dev-${input.paymentId}`,
 			gatewayStatus: 'pending',
 		});

--- a/apps/api/test/integration/payments/mercadopago-sdk.integration.spec.ts
+++ b/apps/api/test/integration/payments/mercadopago-sdk.integration.spec.ts
@@ -28,6 +28,7 @@ describe('MercadoPagoSdkAdapter', () => {
 			}),
 		).resolves.toEqual({
 			checkoutUrl: 'https://mercadopago.test/checkout/pref-1',
+			backUrl: 'https://app.elonew.test/client/orders/order-1',
 			gatewayReferenceId: 'pref-1',
 			gatewayStatus: null,
 		});
@@ -65,7 +66,7 @@ describe('MercadoPagoSdkAdapter', () => {
 		});
 	});
 
-	it('sends back_urls and auto_return so the buyer returns to the orders page', async () => {
+	it('sends back_urls and auto_return so the buyer returns to their order page', async () => {
 		const create = jest.fn().mockResolvedValue({
 			id: 'pref-back',
 			init_point: 'https://mercadopago.test/checkout/pref-back',
@@ -90,7 +91,7 @@ describe('MercadoPagoSdkAdapter', () => {
 			paymentMethod: 'pix',
 		});
 
-		const ordersUrl = 'https://app.elonew.test/client/orders';
+		const ordersUrl = 'https://app.elonew.test/client/orders/order-back';
 		expect(create).toHaveBeenCalledWith({
 			body: expect.objectContaining({
 				back_urls: {

--- a/apps/api/test/integration/payments/payments.integration.spec.ts
+++ b/apps/api/test/integration/payments/payments.integration.spec.ts
@@ -14,7 +14,7 @@ import { PAYMENT_REPOSITORY_KEY } from '@modules/payments/application/ports/paym
 import { PROCESSED_WEBHOOK_EVENT_PORT_KEY } from '@modules/payments/application/ports/processed-webhook-event.port';
 import { PaymentsModule } from '@modules/payments/payments.module';
 import { PaymentsController } from '@modules/payments/presentation/payments.controller';
-import { Test } from '@nestjs/testing';
+import { Test, type TestingModule } from '@nestjs/testing';
 import { Role } from '@packages/auth/roles/role';
 import { MERCADO_PAGO_SDK_PORT_KEY } from '@packages/integrations/mercadopago/mercadopago-sdk.port';
 import type { CreateOrderSchemaInput } from '@packages/shared/orders/create-order.schema';
@@ -33,6 +33,7 @@ describe('Payments module integration', () => {
 	let paymentsController: PaymentsController;
 	let pricingVersions: OrderPricingVersionRepositoryPort;
 	let previousSkipMercadoPagoCheckoutInDevMode: string | undefined;
+	let moduleRef: TestingModule;
 	let mercadoPagoSdkMock: {
 		createPayment: jest.Mock;
 		fetchPaymentNotification: jest.Mock;
@@ -96,7 +97,7 @@ describe('Payments module integration', () => {
 			verifyWebhookSignature: jest.fn().mockResolvedValue(true),
 		};
 
-		const moduleRef = await Test.createTestingModule({
+		moduleRef = await Test.createTestingModule({
 			imports: [PaymentsModule],
 		})
 			.overrideProvider(ORDER_REPOSITORY_KEY)
@@ -140,7 +141,9 @@ describe('Payments module integration', () => {
 		});
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
+		await moduleRef.close();
+
 		if (previousSkipMercadoPagoCheckoutInDevMode === undefined) {
 			delete process.env.SKIP_MERCADO_PAGO_CHECKOUT_IN_DEV_MODE;
 			return;

--- a/apps/api/test/integration/payments/payments.integration.spec.ts
+++ b/apps/api/test/integration/payments/payments.integration.spec.ts
@@ -83,6 +83,7 @@ describe('Payments module integration', () => {
 		mercadoPagoSdkMock = {
 			createPayment: jest.fn(async ({ paymentId }) => ({
 				checkoutUrl: `https://mercadopago.test/checkout/${paymentId}`,
+				backUrl: `https://app.elonew.test/client/orders/${paymentId}`,
 				gatewayReferenceId: `pref-${paymentId}`,
 				gatewayStatus: 'pending',
 			})),

--- a/apps/web/src/app/(dashboard)/client/orders/page.tsx
+++ b/apps/web/src/app/(dashboard)/client/orders/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+const ClientOrdersRoute = () => redirect('/client');
+
+export default ClientOrdersRoute;

--- a/apps/web/src/modules/client-dashboard/actions/order-actions.ts
+++ b/apps/web/src/modules/client-dashboard/actions/order-actions.ts
@@ -45,6 +45,7 @@ export type CheckoutActionState = {
 };
 
 export type ResumePaymentCheckoutActionState = {
+	checkoutUrl?: string;
 	error?: string;
 };
 
@@ -235,18 +236,14 @@ export const sendOrderChatMessageAction = async (
 
 export const resumePaymentCheckoutAction = async (
 	orderId: string,
-	_state: ResumePaymentCheckoutActionState,
-	_formData: FormData,
 ): Promise<ResumePaymentCheckoutActionState> => {
 	const session = await getAuthSession();
 	if (!session) redirect('/login');
 
-	let checkoutUrl: string;
-
 	try {
 		await assertSameOriginRequest();
 		const payment = await resumePaymentCheckout(orderId, api.request);
-		checkoutUrl = payment.checkoutUrl;
+		return { checkoutUrl: payment.checkoutUrl };
 	} catch (error) {
 		if (
 			error instanceof ApiRequestError &&
@@ -258,6 +255,4 @@ export const resumePaymentCheckoutAction = async (
 			error: getCheckoutErrorMessage(error),
 		};
 	}
-
-	redirect(checkoutUrl);
 };

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/new-order-wizard.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/new-order-wizard.spec.tsx
@@ -7,6 +7,10 @@ jest.mock('../../actions/order-actions', () => ({
 	startCheckoutAction: jest.fn(),
 }));
 
+jest.mock('next/navigation', () => ({
+	useRouter: () => ({ push: jest.fn() }),
+}));
+
 jest.mock('@/shared/ui/animation/gsap', () => ({
 	gsap: {
 		to: jest.fn(),

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/use-checkout-submit.spec.ts
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/use-checkout-submit.spec.ts
@@ -7,6 +7,17 @@ jest.mock('../../actions/order-actions', () => ({
 	startCheckoutAction: jest.fn(),
 }));
 
+const routerPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+	useRouter: () => ({ push: routerPush }),
+}));
+
+const makeCheckoutTab = () => ({
+	close: jest.fn(),
+	location: { href: '' } as Location,
+});
+
 describe('useCheckoutSubmit', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -30,10 +41,11 @@ describe('useCheckoutSubmit', () => {
 		expect(startCheckoutAction).not.toHaveBeenCalled();
 	});
 
-	it('redirects to the returned checkout URL after a successful checkout', async () => {
-		const redirectToCheckout = jest.fn();
+	it('opens checkout in a new tab and sends the current tab to the order page', async () => {
+		const checkoutTab = makeCheckoutTab();
 		(startCheckoutAction as jest.Mock).mockResolvedValue({
 			checkoutUrl: 'https://checkout.example.com/pay',
+			orderId: 'order-1',
 		});
 
 		const orderInput = createInitialCheckoutInput();
@@ -41,7 +53,7 @@ describe('useCheckoutSubmit', () => {
 			useCheckoutSubmit({
 				hasAcceptedTerms: true,
 				orderInput,
-				redirectToCheckout,
+				openCheckoutTab: () => checkoutTab,
 			}),
 		);
 
@@ -53,14 +65,44 @@ describe('useCheckoutSubmit', () => {
 			expect(startCheckoutAction).toHaveBeenCalledWith(orderInput);
 		});
 		await waitFor(() => {
+			expect(checkoutTab.location.href).toBe(
+				'https://checkout.example.com/pay',
+			);
+		});
+		expect(routerPush).toHaveBeenCalledWith('/client/orders/order-1');
+		expect(result.current.checkoutError).toBeNull();
+	});
+
+	it('falls back to a same-tab redirect when the popup is blocked', async () => {
+		const redirectToCheckout = jest.fn();
+		(startCheckoutAction as jest.Mock).mockResolvedValue({
+			checkoutUrl: 'https://checkout.example.com/pay',
+			orderId: 'order-1',
+		});
+
+		const { result } = renderHook(() =>
+			useCheckoutSubmit({
+				hasAcceptedTerms: true,
+				orderInput: createInitialCheckoutInput(),
+				redirectToCheckout,
+				openCheckoutTab: () => null,
+			}),
+		);
+
+		act(() => {
+			result.current.handleCheckout();
+		});
+
+		await waitFor(() => {
 			expect(redirectToCheckout).toHaveBeenCalledWith(
 				'https://checkout.example.com/pay',
 			);
 		});
-		expect(result.current.checkoutError).toBeNull();
+		expect(routerPush).not.toHaveBeenCalled();
 	});
 
-	it('keeps the user on the page when checkout returns an error', async () => {
+	it('closes the checkout tab and keeps the user on the page when checkout fails', async () => {
+		const checkoutTab = makeCheckoutTab();
 		const redirectToCheckout = jest.fn();
 		(startCheckoutAction as jest.Mock).mockResolvedValue({
 			error: 'Não foi possível iniciar o checkout.',
@@ -71,6 +113,7 @@ describe('useCheckoutSubmit', () => {
 				hasAcceptedTerms: true,
 				orderInput: createInitialCheckoutInput(),
 				redirectToCheckout,
+				openCheckoutTab: () => checkoutTab,
 			}),
 		);
 
@@ -83,6 +126,7 @@ describe('useCheckoutSubmit', () => {
 				'Não foi possível iniciar o checkout.',
 			);
 		});
+		expect(checkoutTab.close).toHaveBeenCalled();
 		expect(redirectToCheckout).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/use-checkout-submit.ts
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/use-checkout-submit.ts
@@ -1,24 +1,32 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useCallback, useState, useTransition } from 'react';
 import { startCheckoutAction } from '../../actions/order-actions';
 import type { StartCheckoutInput } from '../../server/order-contracts';
+
+type CheckoutTab = Pick<Window, 'close' | 'location'>;
 
 type UseCheckoutSubmitInput = {
 	hasAcceptedTerms: boolean;
 	orderInput: StartCheckoutInput;
 	redirectToCheckout?: (checkoutUrl: string) => void;
+	openCheckoutTab?: () => CheckoutTab | null;
 };
 
 const defaultRedirectToCheckout = (checkoutUrl: string) => {
 	window.location.assign(checkoutUrl);
 };
 
+const defaultOpenCheckoutTab = () => window.open('', '_blank');
+
 export const useCheckoutSubmit = ({
 	hasAcceptedTerms,
 	orderInput,
 	redirectToCheckout = defaultRedirectToCheckout,
+	openCheckoutTab = defaultOpenCheckoutTab,
 }: UseCheckoutSubmitInput) => {
+	const router = useRouter();
 	const [checkoutError, setCheckoutError] = useState<string | null>(null);
 	const [isPending, startTransition] = useTransition();
 
@@ -29,16 +37,32 @@ export const useCheckoutSubmit = ({
 		}
 
 		setCheckoutError(null);
+		const checkoutTab = openCheckoutTab();
 		startTransition(async () => {
 			const result = await startCheckoutAction(orderInput);
-			if (result.error) {
-				setCheckoutError(result.error);
+			if (result.error || !result.checkoutUrl) {
+				checkoutTab?.close();
+				setCheckoutError(
+					result.error ?? 'Não foi possível iniciar o checkout.',
+				);
 				return;
 			}
 
-			if (result.checkoutUrl) redirectToCheckout(result.checkoutUrl);
+			if (checkoutTab) {
+				checkoutTab.location.href = result.checkoutUrl;
+				if (result.orderId) router.push(`/client/orders/${result.orderId}`);
+				return;
+			}
+
+			redirectToCheckout(result.checkoutUrl);
 		});
-	}, [hasAcceptedTerms, orderInput, redirectToCheckout]);
+	}, [
+		hasAcceptedTerms,
+		orderInput,
+		redirectToCheckout,
+		openCheckoutTab,
+		router,
+	]);
 
 	return {
 		checkoutError,

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/awaiting-payment-banner.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/awaiting-payment-banner.tsx
@@ -1,0 +1,12 @@
+export const AwaitingPaymentBanner = () => (
+	<div className="flex items-center gap-3 rounded-sm border border-hextech-gold/20 bg-hextech-gold/5 px-4 py-3">
+		<span className="relative flex h-2 w-2 shrink-0">
+			<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-hextech-gold opacity-75" />
+			<span className="relative inline-flex h-2 w-2 rounded-full bg-hextech-gold" />
+		</span>
+		<p className="text-xs font-bold tracking-wider text-hextech-gold">
+			Aguardando a confirmação do pagamento. Esta página atualiza
+			automaticamente assim que o pagamento for aprovado.
+		</p>
+	</div>
+);

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-live-refresh.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-live-refresh.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useDashboardEvents } from '@/shared/dashboard/use-dashboard-events';
+
+const orderDetailsEvents = [
+	'order.paid',
+	'order.accepted',
+	'order.rejected',
+	'order.completed',
+	'order.cancelled',
+] as const;
+
+export const OrderDetailsLiveRefresh = () => {
+	useDashboardEvents({ events: orderDetailsEvents });
+
+	return null;
+};

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
@@ -7,11 +7,13 @@ import { RatingCard } from '@/shared/ratings/rating-card';
 import type { RatingOutput } from '@/shared/ratings/rating-contracts';
 import { getOrder, getOrderChatMessages } from '../../actions/order-actions';
 import type { ClientOrder } from '../../model/orders';
+import { AwaitingPaymentBanner } from './awaiting-payment-banner';
 import { OrderActivityCard } from './order-activity-card';
 import { OrderBoosterCard } from './order-booster-card';
 import { OrderChatPanel } from './order-chat-panel';
 import { OrderDetailsHeader } from './order-details-header';
 import { orderDetailsLayout } from './order-details-layout';
+import { OrderDetailsLiveRefresh } from './order-details-live-refresh';
 import { OrderServiceCard } from './order-service-card';
 import { OrderSupportCard } from './order-support-card';
 
@@ -67,7 +69,9 @@ export const OrderDetailsPage = async ({ orderId }: OrderDetailsPageProps) => {
 
 	return (
 		<div className="space-y-8">
+			<OrderDetailsLiveRefresh />
 			<OrderDetailsHeader order={order} />
+			{order.status === 'awaiting_payment' ? <AwaitingPaymentBanner /> : null}
 
 			<div className={orderDetailsLayout.grid}>
 				{chatPanel}

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/resume-payment-button.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/resume-payment-button.spec.tsx
@@ -1,17 +1,16 @@
-import { render, screen } from '@testing-library/react';
-import { useActionState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { resumePaymentCheckoutAction } from '../../actions/order-actions';
 import { ResumePaymentButton } from './resume-payment-button';
-
-jest.mock('react', () => ({
-	...jest.requireActual('react'),
-	useActionState: jest.fn(),
-}));
 
 jest.mock('../../actions/order-actions', () => ({
 	resumePaymentCheckoutAction: jest.fn(),
 }));
 
-const useActionStateMock = useActionState as jest.Mock;
+const makeCheckoutTab = () => ({
+	close: jest.fn(),
+	location: { href: '' } as Location,
+});
 
 describe('ResumePaymentButton', () => {
 	afterEach(() => {
@@ -19,8 +18,6 @@ describe('ResumePaymentButton', () => {
 	});
 
 	it('renders the localized resume command', () => {
-		useActionStateMock.mockReturnValue([{}, jest.fn(), false]);
-
 		render(<ResumePaymentButton orderId="order-1" />);
 
 		expect(
@@ -28,22 +25,54 @@ describe('ResumePaymentButton', () => {
 		).toBeInTheDocument();
 	});
 
-	it('shows an inline error when resume fails without auth redirect', () => {
-		useActionStateMock.mockReturnValue([
-			{
-				error:
-					'Não foi possível iniciar o pagamento. Tente novamente em instantes.',
-			},
-			jest.fn(),
-			false,
-		]);
+	it('opens the checkout in a new tab on resume', async () => {
+		const checkoutTab = makeCheckoutTab();
+		(resumePaymentCheckoutAction as jest.Mock).mockResolvedValue({
+			checkoutUrl: 'https://checkout.example.com/pay',
+		});
 
-		render(<ResumePaymentButton orderId="order-1" />);
+		render(
+			<ResumePaymentButton
+				orderId="order-1"
+				openCheckoutTab={() => checkoutTab}
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole('button', { name: /retomar pagamento/i }),
+		);
+
+		await waitFor(() => {
+			expect(checkoutTab.location.href).toBe(
+				'https://checkout.example.com/pay',
+			);
+		});
+		expect(resumePaymentCheckoutAction).toHaveBeenCalledWith('order-1');
+	});
+
+	it('shows an inline error and closes the tab when resume fails', async () => {
+		const checkoutTab = makeCheckoutTab();
+		(resumePaymentCheckoutAction as jest.Mock).mockResolvedValue({
+			error:
+				'Não foi possível iniciar o pagamento. Tente novamente em instantes.',
+		});
+
+		render(
+			<ResumePaymentButton
+				orderId="order-1"
+				openCheckoutTab={() => checkoutTab}
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole('button', { name: /retomar pagamento/i }),
+		);
 
 		expect(
-			screen.getByText(
+			await screen.findByText(
 				'Não foi possível iniciar o pagamento. Tente novamente em instantes.',
 			),
 		).toBeInTheDocument();
+		expect(checkoutTab.close).toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/resume-payment-button.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/resume-payment-button.tsx
@@ -1,24 +1,51 @@
 'use client';
 
 import { CreditCard } from 'lucide-react';
-import { useActionState } from 'react';
+import { useCallback, useState, useTransition } from 'react';
 import { getButtonClassName } from '@/shared/ui/components/button';
 import { resumePaymentCheckoutAction } from '../../actions/order-actions';
 
+type CheckoutTab = Pick<Window, 'close' | 'location'>;
+
 type ResumePaymentButtonProps = {
 	orderId: string;
+	openCheckoutTab?: () => CheckoutTab | null;
 };
 
-export const ResumePaymentButton = ({ orderId }: ResumePaymentButtonProps) => {
-	const [state, formAction, isPending] = useActionState(
-		resumePaymentCheckoutAction.bind(null, orderId),
-		{},
-	);
+const defaultOpenCheckoutTab = () => window.open('', '_blank');
+
+export const ResumePaymentButton = ({
+	orderId,
+	openCheckoutTab = defaultOpenCheckoutTab,
+}: ResumePaymentButtonProps) => {
+	const [error, setError] = useState<string | null>(null);
+	const [isPending, startTransition] = useTransition();
+
+	const handleResume = useCallback(() => {
+		setError(null);
+		const checkoutTab = openCheckoutTab();
+		startTransition(async () => {
+			const result = await resumePaymentCheckoutAction(orderId);
+			if (result.error || !result.checkoutUrl) {
+				checkoutTab?.close();
+				setError(result.error ?? 'Não foi possível iniciar o pagamento.');
+				return;
+			}
+
+			if (checkoutTab) {
+				checkoutTab.location.href = result.checkoutUrl;
+				return;
+			}
+
+			window.location.assign(result.checkoutUrl);
+		});
+	}, [orderId, openCheckoutTab]);
 
 	return (
-		<form action={formAction} className="space-y-2">
+		<div className="space-y-2">
 			<button
-				type="submit"
+				type="button"
+				onClick={handleResume}
 				disabled={isPending}
 				className={getButtonClassName({
 					size: 'sm',
@@ -26,13 +53,13 @@ export const ResumePaymentButton = ({ orderId }: ResumePaymentButtonProps) => {
 				})}
 			>
 				<CreditCard className="h-3.5 w-3.5" />
-				{isPending ? 'Redirecionando' : 'Retomar pagamento'}
+				{isPending ? 'Abrindo pagamento' : 'Retomar pagamento'}
 			</button>
-			{state.error ? (
+			{error ? (
 				<p className="max-w-64 text-[10px] font-bold leading-4 text-danger">
-					{state.error}
+					{error}
 				</p>
 			) : null}
-		</form>
+		</div>
 	);
 };

--- a/infrastructure/docker/prod/Dockerfile
+++ b/infrastructure/docker/prod/Dockerfile
@@ -43,7 +43,9 @@ RUN pnpm build:packages \
 
 FROM base AS runtime
 
+ARG APP_VERSION=unknown
 ENV NODE_ENV=production
+ENV APP_VERSION=$APP_VERSION
 
 COPY --from=build --chown=node:node /workspace /workspace
 

--- a/infrastructure/docker/prod/compose.yml
+++ b/infrastructure/docker/prod/compose.yml
@@ -5,6 +5,8 @@ x-shared-app-image: &shared-app-image ${APP_IMAGE:-elonew-prod:latest}
 x-app-image-build: &app-image-build
   context: ../../..
   dockerfile: infrastructure/docker/prod/Dockerfile
+  args:
+    APP_VERSION: ${APP_VERSION:-unknown}
 
 x-postgres-connection-url: &postgres-connection-url postgresql://postgres:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in infrastructure/docker/prod/.env}@database:5432/elonew
 

--- a/packages/config/src/env/env.schema.ts
+++ b/packages/config/src/env/env.schema.ts
@@ -21,6 +21,8 @@ const DEFAULT_ORDER_CREDENTIALS_ENCRYPTION_KEY =
 
 export const RESEND_API_KEY_PLACEHOLDER = 're_xxxxxxxxx';
 
+const DEFAULT_WEB_APP_URL = 'http://localhost:3001';
+
 const PRODUCTION_ONLY_DEFAULT_SECRETS = {
 	JWT_ACCESS_TOKEN_SECRET: DEFAULT_JWT_ACCESS_TOKEN_SECRET,
 	INTERNAL_API_KEY: DEFAULT_INTERNAL_API_KEY,
@@ -112,7 +114,7 @@ export const envSchema = z
 			.trim()
 			.url()
 			.default('http://localhost:3001'),
-		WEB_APP_URL: z.string().trim().url().default('http://localhost:3001'),
+		WEB_APP_URL: z.string().trim().url().default(DEFAULT_WEB_APP_URL),
 		ORDER_QUOTE_TTL_MINUTES: z.coerce.number().int().positive().default(60),
 		AUTH_LOGIN_THROTTLE_LIMIT: z.coerce.number().int().positive().default(5),
 		AUTH_LOGIN_THROTTLE_TTL_SECONDS: z.coerce
@@ -163,6 +165,15 @@ export const envSchema = z
 						'Production environment must override development placeholder secrets.',
 				});
 			}
+		}
+
+		if (env.WEB_APP_URL === DEFAULT_WEB_APP_URL) {
+			context.addIssue({
+				code: 'custom',
+				path: ['WEB_APP_URL'],
+				message:
+					'Production environment must set WEB_APP_URL to the public web app URL.',
+			});
 		}
 
 		if (

--- a/packages/integrations/src/mercadopago/mercadopago-sdk.adapter.ts
+++ b/packages/integrations/src/mercadopago/mercadopago-sdk.adapter.ts
@@ -73,7 +73,10 @@ export class MercadoPagoSdkAdapter implements MercadoPagoSdkPort {
 	async createPayment(
 		input: MercadoPagoCreatePaymentInput,
 	): Promise<MercadoPagoCreatePaymentOutput> {
-		const ordersUrl = new URL('/client/orders', this.webAppUrl).toString();
+		const ordersUrl = new URL(
+			`/client/orders/${input.orderId}`,
+			this.webAppUrl,
+		).toString();
 		const response = await this.preferenceClient.create({
 			body: {
 				external_reference: input.paymentId,
@@ -99,6 +102,7 @@ export class MercadoPagoSdkAdapter implements MercadoPagoSdkPort {
 
 		return {
 			checkoutUrl: response.init_point,
+			backUrl: ordersUrl,
 			gatewayReferenceId: response.id,
 			gatewayStatus: null,
 		};

--- a/packages/integrations/src/mercadopago/mercadopago-sdk.port.ts
+++ b/packages/integrations/src/mercadopago/mercadopago-sdk.port.ts
@@ -9,6 +9,7 @@ export type MercadoPagoCreatePaymentInput = {
 
 export type MercadoPagoCreatePaymentOutput = {
 	checkoutUrl: string;
+	backUrl: string;
 	gatewayReferenceId: string;
 	gatewayStatus: string | null;
 };


### PR DESCRIPTION
## Summary

Buyers returning from Mercado Pago checkout hit a 404 because `back_urls` pointed at `/client/orders`, which is not a route, and Pix payers had no feedback while waiting for confirmation. This PR fixes the return URL (per-order: `/client/orders/{orderId}`), opens checkout in a new tab while the current tab live-tracks the order (awaiting-payment banner + SSE refresh on `order.paid`), regenerates the gateway preference on resume so stale baked-in URLs stop resurfacing, and adds the observability that was missing while debugging this: `back_url` on `payment.lifecycle` create events, release version (`APP_VERSION` from the deploy tag) on every API log line, and a production boot failure when `WEB_APP_URL` is left at its localhost default. `/client/orders` now redirects to `/client` so preferences created before this change stop 404ing.

Closes:

## Verification

```text
pnpm --filter @packages/integrations build
npx tsc --noEmit            # run in apps/api, apps/web, apps/workers, packages/config
npx biome check apps/api/src/modules/payments apps/web/src/modules/client-dashboard packages/integrations/src packages/config/src/env
cd apps/api && npx jest --runInBand payments        # 19 suites, 97 tests
cd apps/web && npx jest --runInBand new-order order-details   # 11 suites, 25 tests
```

Skipped checks and remaining risk:

- Full api/web jest suites and db-backed integration suites not run locally; CI covers them.
- No end-to-end run against the Mercado Pago sandbox; the per-order `back_urls` value is asserted in `mercadopago-sdk.integration.spec.ts` but the redirect was not exercised against MP itself.
- Popup-blocked browsers fall back to the old same-tab redirect (covered by spec, not manually verified across browsers).
- Each resume click creates a new MP preference; superseded preferences are orphaned on MP's side (harmless, `external_reference` unchanged).

## Screenshots

Awaiting-payment banner and new-tab checkout not screenshotted (no local run in this session); banner is a single gold status strip on the order details page.

## Breaking Changes

None for users. Deploy note: production API now refuses to boot if `WEB_APP_URL` is unset (already set on the VPS, verified). `APP_VERSION` is passed by the release workflow; manual builds without it log `version: "unknown"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)