### PR TITLE
fix(api): approval webhooks skipped after a pending notification for the same payment

### DIFF
--- a/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
@@ -586,6 +586,68 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 		expect(savedPayment?.gatewayStatusDetail).toBe('pending_capture');
 		await expect(
 			processedWebhookEventPort.has(processedWebhookKey('notification-8')),
+		).resolves.toBe(false);
+	});
+
+	it('confirms a payment whose approval arrives after a pending notification for the same resource', async () => {
+		const paymentRepository = new InMemoryPaymentRepository();
+		const processedWebhookEventPort = new InMemoryProcessedWebhookEventPort();
+		const orderPaymentConfirmationPort =
+			new InMemoryOrderPaymentConfirmationPort();
+		const paymentGatewayPort = new InMemoryPaymentGatewayPort();
+		paymentRepository.insert(
+			Payment.create({
+				id: 'payment-11',
+				orderId: 'order-11',
+				grossAmount: 100,
+				paymentMethod: 'pix',
+			}),
+		);
+		paymentGatewayPort.notification = {
+			internalPaymentId: 'payment-11',
+			gatewayPaymentId: 'mp-payment-11',
+			gatewayStatus: 'pending',
+			gatewayStatusDetail: 'pending_waiting_transfer',
+		};
+		const useCase = new HandlePaymentConfirmedWebhookUseCase(
+			paymentRepository,
+			processedWebhookEventPort,
+			orderPaymentConfirmationPort,
+			new InMemoryOrderCredentialCleanupPort(),
+			new AcceptAllPaymentWebhookSignatureVerifier(),
+			paymentGatewayPort,
+		);
+
+		await useCase.execute({
+			eventId: 'event-11-pending',
+			topic: 'payment.updated',
+			notificationResourceId: 'notification-11',
+			requestId: 'request-11',
+			signature: 'signature-11',
+		});
+
+		paymentGatewayPort.notification = {
+			internalPaymentId: 'payment-11',
+			gatewayPaymentId: 'mp-payment-11',
+			gatewayStatus: 'approved',
+			gatewayStatusDetail: 'accredited',
+		};
+
+		await expect(
+			useCase.execute({
+				eventId: 'event-11-approved',
+				topic: 'payment.updated',
+				notificationResourceId: 'notification-11',
+				requestId: 'request-11',
+				signature: 'signature-11',
+			}),
+		).resolves.toEqual({ processed: true });
+
+		const savedPayment = await paymentRepository.findById('payment-11');
+		expect(savedPayment?.status).toBe('held');
+		expect(orderPaymentConfirmationPort.orderIds).toEqual(['order-11']);
+		await expect(
+			processedWebhookEventPort.has(processedWebhookKey('notification-11')),
 		).resolves.toBe(true);
 	});
 

--- a/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.ts
+++ b/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.ts
@@ -146,7 +146,8 @@ export class HandlePaymentConfirmedWebhookUseCase {
 				await this.orderCredentialCleanupPort.clearCredentials(payment.orderId);
 				logEvent.side_effects?.push('order_credentials_cleared');
 			}
-			await this.processedWebhookEventPort.markProcessed(processedEventKey);
+			if (resolution === 'confirm' || resolution === 'fail')
+				await this.processedWebhookEventPort.markProcessed(processedEventKey);
 
 			logEvent.outcome = 'success';
 			logEvent.payment_status_after = payment.status;

--- a/apps/api/test/integration/payments/payments.integration.spec.ts
+++ b/apps/api/test/integration/payments/payments.integration.spec.ts
@@ -372,6 +372,22 @@ describe('Payments module integration', () => {
 			id: createdOrder.id,
 			status: 'awaiting_payment',
 		});
+
+		await expect(
+			paymentsController.handleMercadoPagoWebhook(
+				{
+					id: 'event-approved-after-authorized',
+					type: 'payment.updated',
+					action: 'payment.updated',
+					data: { id: payment.id },
+				},
+				'signature-approved',
+				'request-approved',
+			),
+		).resolves.toEqual({ processed: true });
+		await expect(
+			paymentsController.get(payment.id, clientUser),
+		).resolves.toMatchObject({ id: payment.id, status: 'held' });
 	});
 
 	it('fails the payment for rejected webhook statuses', async () => {


### PR DESCRIPTION
## Summary

Pix payments in production never confirm: Mercado Pago first sends a webhook while the payment is `pending_waiting_transfer`, the handler marks the per-resource dedup key `mercadopago:{paymentId}` as processed, and the approval webhook seconds later is skipped as a replay (`webhook_already_processed: true`, observed live on payment `167999254886` / order `ca69829a` under v0.7.0). The fix marks the dedup key only on terminal resolutions (`confirm`/`fail`); pending notifications are idempotent status updates and stay reprocessable. Replay protection for confirmed/failed payments is unchanged.

Closes:

## Verification

```text
cd apps/api && npx jest --runInBand handle-payment-confirmed payments.integration   # 2 suites, 25 tests
```

New regression coverage: unit test delivering pending then approved for the same resource (payment must reach `held`), same flow asserted end-to-end in the payments integration spec, and the authorized-status test now asserts the key is NOT marked.

Skipped checks and remaining risk:

- Full suites left to CI.
- Repeated pending webhooks now hit the MP payment-fetch API each time instead of being deduped; volume is one or two extra calls per payment, negligible.
- Stuck payments confirmed before this fix (e.g. order `ca69829a`) need a manual webhook resend from the MP dashboard after the release deploys.

## Screenshots

None.

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)