### PR TITLE
feat(api): reconcile stale awaiting-confirmation checkouts

### DIFF
--- a/apps/api/src/modules/payments/application/logging/payment-lifecycle.logger.ts
+++ b/apps/api/src/modules/payments/application/logging/payment-lifecycle.logger.ts
@@ -11,7 +11,8 @@ export type PaymentLifecycleLogEvent = {
 		| 'fail'
 		| 'release_hold'
 		| 'simulate_dev_outcome'
-		| 'mercadopago_webhook';
+		| 'mercadopago_webhook'
+		| 'reconcile_stale_checkout';
 	outcome?: 'success' | 'error' | 'skipped';
 	duration_ms?: number;
 	client_id?: string;
@@ -40,6 +41,12 @@ export type PaymentLifecycleLogEvent = {
 	webhook_resolution?: string;
 	webhook_ignored_reason?: string;
 	side_effects?: string[];
+	scanned_count?: number;
+	confirmed_count?: number;
+	failed_count?: number;
+	pending_updated_count?: number;
+	skipped_count?: number;
+	gateway_error_count?: number;
 	error_type?: string;
 	error_message?: string;
 	gateway_error_operation?: string;

--- a/apps/api/src/modules/payments/application/ports/payment-gateway.port.ts
+++ b/apps/api/src/modules/payments/application/ports/payment-gateway.port.ts
@@ -23,6 +23,8 @@ export type FetchPaymentNotificationOutput = {
 	gatewayPaymentId: string;
 	gatewayStatus: string;
 	gatewayStatusDetail: string | null;
+	gatewayPaymentMethodId: string | null;
+	gatewayPaymentTypeId: string | null;
 };
 
 export const PAYMENT_GATEWAY_PORT_KEY = Symbol('PAYMENT_GATEWAY_PORT_KEY');
@@ -32,4 +34,7 @@ export interface PaymentGatewayPort {
 	fetchPaymentNotification(
 		input: FetchPaymentNotificationInput,
 	): Promise<FetchPaymentNotificationOutput>;
+	fetchPaymentByExternalReference(
+		externalReference: string,
+	): Promise<FetchPaymentNotificationOutput | null>;
 }

--- a/apps/api/src/modules/payments/application/ports/payment-repository.port.ts
+++ b/apps/api/src/modules/payments/application/ports/payment-repository.port.ts
@@ -2,6 +2,10 @@ import type { Payment } from '@modules/payments/domain/payment.entity';
 
 export const PAYMENT_REPOSITORY_KEY = Symbol('PAYMENT_REPOSITORY_KEY');
 
+export type StalePaymentReconciliationCandidate = {
+	payment: Payment;
+};
+
 export interface PaymentRepositoryPort {
 	findById(id: string): Promise<Payment | null>;
 	findByIdForClient(id: string, clientId: string): Promise<Payment | null>;
@@ -11,5 +15,12 @@ export interface PaymentRepositoryPort {
 		clientId: string,
 	): Promise<Payment | null>;
 	findByGatewayId(gatewayId: string): Promise<Payment | null>;
+	findStaleAwaitingCheckoutCandidates(input: {
+		createdBefore: Date;
+		limit: number;
+	}): Promise<StalePaymentReconciliationCandidate[]>;
+	withStaleCheckoutReconciliationLock<T>(
+		callback: () => Promise<T>,
+	): Promise<T | null>;
 	save(payment: Payment): Promise<void>;
 }

--- a/apps/api/src/modules/payments/application/use-cases/confirm-payment/confirm-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/confirm-payment/confirm-payment.use-case.spec.ts
@@ -32,6 +32,14 @@ class InMemoryPaymentRepository implements PaymentRepositoryPort {
 		throw new Error('not needed in this test');
 	}
 
+	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
+	async withStaleCheckoutReconciliationLock(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
 	async save(payment: Payment): Promise<void> {
 		if (this.failOnSavePaymentIds.has(payment.id))
 			throw new Error('Payment save failed.');

--- a/apps/api/src/modules/payments/application/use-cases/confirm-payment/confirm-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/confirm-payment/confirm-payment.use-case.spec.ts
@@ -1,60 +1,8 @@
 import type { OrderPaymentConfirmationPort } from '@modules/payments/application/ports/order-payment-confirmation.port';
-import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import { ConfirmPaymentUseCase } from '@modules/payments/application/use-cases/confirm-payment/confirm-payment.use-case';
 import { Payment } from '@modules/payments/domain/payment.entity';
 import { PaymentNotFoundError } from '@modules/payments/domain/payment.errors';
-
-class InMemoryPaymentRepository implements PaymentRepositoryPort {
-	private readonly payments = new Map<string, Payment>();
-	private readonly failOnSavePaymentIds = new Set<string>();
-
-	async findById(id: string): Promise<Payment | null> {
-		return this.payments.get(id) ?? null;
-	}
-
-	async findByIdForClient(id: string): Promise<Payment | null> {
-		return this.findById(id);
-	}
-
-	async findByOrderId(orderId: string): Promise<Payment | null> {
-		for (const payment of this.payments.values()) {
-			if (payment.orderId === orderId) return payment;
-		}
-
-		return null;
-	}
-
-	async findByOrderIdForClient(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findByGatewayId(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async withStaleCheckoutReconciliationLock(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async save(payment: Payment): Promise<void> {
-		if (this.failOnSavePaymentIds.has(payment.id))
-			throw new Error('Payment save failed.');
-
-		this.payments.set(payment.id, payment);
-	}
-
-	insert(payment: Payment): void {
-		this.payments.set(payment.id, payment);
-	}
-
-	setFailOnSave(paymentId: string): void {
-		this.failOnSavePaymentIds.add(paymentId);
-	}
-}
+import { InMemoryPaymentRepository } from '../../../../../../test/support/in-memory/payments/in-memory-payment.repository';
 
 class InMemoryOrderPaymentConfirmationPort
 	implements OrderPaymentConfirmationPort

--- a/apps/api/src/modules/payments/application/use-cases/create-payment/create-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/create-payment/create-payment.use-case.spec.ts
@@ -2,57 +2,13 @@ import { OrderStatus } from '@modules/orders/domain/order-status';
 import type { OrderPaymentAmountPort } from '@modules/payments/application/ports/order-payment-amount.port';
 import type { OrderStatusPort } from '@modules/payments/application/ports/order-status.port';
 import type { PaymentGatewayPort } from '@modules/payments/application/ports/payment-gateway.port';
-import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import { CreatePaymentUseCase } from '@modules/payments/application/use-cases/create-payment/create-payment.use-case';
 import { Payment } from '@modules/payments/domain/payment.entity';
 import {
 	PaymentAlreadyExistsError,
 	PaymentOrderNotFoundError,
 } from '@modules/payments/domain/payment.errors';
-
-class InMemoryPaymentRepository implements PaymentRepositoryPort {
-	private readonly payments = new Map<string, Payment>();
-
-	async findById(id: string): Promise<Payment | null> {
-		return this.payments.get(id) ?? null;
-	}
-
-	async findByIdForClient(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findByOrderId(orderId: string): Promise<Payment | null> {
-		for (const payment of this.payments.values()) {
-			if (payment.orderId === orderId) return payment;
-		}
-
-		return null;
-	}
-
-	async findByOrderIdForClient(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findByGatewayId(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async withStaleCheckoutReconciliationLock(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async save(payment: Payment): Promise<void> {
-		this.payments.set(payment.id, payment);
-	}
-
-	insert(payment: Payment): void {
-		this.payments.set(payment.id, payment);
-	}
-}
+import { InMemoryPaymentRepository } from '../../../../../../test/support/in-memory/payments/in-memory-payment.repository';
 
 class InMemoryOrderStatusPort implements OrderStatusPort {
 	private readonly orderStatuses = new Map<

--- a/apps/api/src/modules/payments/application/use-cases/create-payment/create-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/create-payment/create-payment.use-case.spec.ts
@@ -128,8 +128,13 @@ class InMemoryPaymentGatewayPort implements PaymentGatewayPort {
 		gatewayPaymentId: string;
 		gatewayStatus: string;
 		gatewayStatusDetail: string | null;
-		isApproved: boolean;
+		gatewayPaymentMethodId: string | null;
+		gatewayPaymentTypeId: string | null;
 	}> {
+		throw new Error('not needed in this test');
+	}
+
+	async fetchPaymentByExternalReference(): Promise<never> {
 		throw new Error('not needed in this test');
 	}
 }

--- a/apps/api/src/modules/payments/application/use-cases/create-payment/create-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/create-payment/create-payment.use-case.spec.ts
@@ -37,6 +37,14 @@ class InMemoryPaymentRepository implements PaymentRepositoryPort {
 		throw new Error('not needed in this test');
 	}
 
+	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
+	async withStaleCheckoutReconciliationLock(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
 	async save(payment: Payment): Promise<void> {
 		this.payments.set(payment.id, payment);
 	}

--- a/apps/api/src/modules/payments/application/use-cases/fail-payment/fail-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/fail-payment/fail-payment.use-case.spec.ts
@@ -1,52 +1,8 @@
 import type { OrderCredentialCleanupPort } from '@modules/payments/application/ports/order-credential-cleanup.port';
-import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import { FailPaymentUseCase } from '@modules/payments/application/use-cases/fail-payment/fail-payment.use-case';
 import { Payment } from '@modules/payments/domain/payment.entity';
 import { PaymentNotFoundError } from '@modules/payments/domain/payment.errors';
-
-class InMemoryPaymentRepository implements PaymentRepositoryPort {
-	private readonly payments = new Map<string, Payment>();
-
-	async findById(id: string): Promise<Payment | null> {
-		return this.payments.get(id) ?? null;
-	}
-
-	async findByIdForClient(id: string): Promise<Payment | null> {
-		return this.findById(id);
-	}
-
-	async findByOrderId(orderId: string): Promise<Payment | null> {
-		for (const payment of this.payments.values()) {
-			if (payment.orderId === orderId) return payment;
-		}
-
-		return null;
-	}
-
-	async findByOrderIdForClient(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findByGatewayId(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async withStaleCheckoutReconciliationLock(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async save(payment: Payment): Promise<void> {
-		this.payments.set(payment.id, payment);
-	}
-
-	insert(payment: Payment): void {
-		this.payments.set(payment.id, payment);
-	}
-}
+import { InMemoryPaymentRepository } from '../../../../../../test/support/in-memory/payments/in-memory-payment.repository';
 
 class InMemoryOrderCredentialCleanupPort implements OrderCredentialCleanupPort {
 	readonly orderIds: string[] = [];

--- a/apps/api/src/modules/payments/application/use-cases/fail-payment/fail-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/fail-payment/fail-payment.use-case.spec.ts
@@ -31,6 +31,14 @@ class InMemoryPaymentRepository implements PaymentRepositoryPort {
 		throw new Error('not needed in this test');
 	}
 
+	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
+	async withStaleCheckoutReconciliationLock(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
 	async save(payment: Payment): Promise<void> {
 		this.payments.set(payment.id, payment);
 	}

--- a/apps/api/src/modules/payments/application/use-cases/get-payment/get-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/get-payment/get-payment.use-case.spec.ts
@@ -47,6 +47,14 @@ class InMemoryPaymentRepository implements PaymentRepositoryPort {
 		throw new Error('not needed in this test');
 	}
 
+	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
+	async withStaleCheckoutReconciliationLock(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
 	async save(payment: Payment): Promise<void> {
 		this.payments.set(payment.id, { payment, clientId: 'client-1' });
 	}

--- a/apps/api/src/modules/payments/application/use-cases/get-payment/get-payment.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/get-payment/get-payment.use-case.spec.ts
@@ -1,68 +1,7 @@
-import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import { GetPaymentUseCase } from '@modules/payments/application/use-cases/get-payment/get-payment.use-case';
 import { Payment } from '@modules/payments/domain/payment.entity';
 import { PaymentNotFoundError } from '@modules/payments/domain/payment.errors';
-
-class InMemoryPaymentRepository implements PaymentRepositoryPort {
-	private readonly payments = new Map<
-		string,
-		{ payment: Payment; clientId: string }
-	>();
-
-	async findById(id: string): Promise<Payment | null> {
-		return this.payments.get(id)?.payment ?? null;
-	}
-
-	async findByIdForClient(
-		id: string,
-		clientId: string,
-	): Promise<Payment | null> {
-		const record = this.payments.get(id);
-		if (!record || record.clientId !== clientId) return null;
-
-		return record.payment;
-	}
-
-	async findByOrderId(orderId: string): Promise<Payment | null> {
-		for (const record of this.payments.values()) {
-			if (record.payment.orderId === orderId) return record.payment;
-		}
-
-		return null;
-	}
-
-	async findByOrderIdForClient(
-		orderId: string,
-		clientId: string,
-	): Promise<Payment | null> {
-		for (const record of this.payments.values()) {
-			if (record.payment.orderId === orderId && record.clientId === clientId)
-				return record.payment;
-		}
-
-		return null;
-	}
-
-	async findByGatewayId(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async withStaleCheckoutReconciliationLock(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async save(payment: Payment): Promise<void> {
-		this.payments.set(payment.id, { payment, clientId: 'client-1' });
-	}
-
-	insert(payment: Payment, clientId: string): void {
-		this.payments.set(payment.id, { payment, clientId });
-	}
-}
+import { InMemoryPaymentRepository } from '../../../../../../test/support/in-memory/payments/in-memory-payment.repository';
 
 describe('GetPaymentUseCase', () => {
 	it('returns the owned payment summary when the payment exists', async () => {

--- a/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
@@ -4,7 +4,6 @@ import type {
 	FetchPaymentNotificationOutput,
 	PaymentGatewayPort,
 } from '@modules/payments/application/ports/payment-gateway.port';
-import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import type { PaymentWebhookSignatureVerifierPort } from '@modules/payments/application/ports/payment-webhook-signature-verifier.port';
 import type { ProcessedWebhookEventPort } from '@modules/payments/application/ports/processed-webhook-event.port';
 import { HandlePaymentConfirmedWebhookUseCase } from '@modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case';
@@ -15,62 +14,7 @@ import {
 	PaymentWebhookSignatureInvalidError,
 	PaymentWebhookTopicNotSupportedError,
 } from '@modules/payments/domain/payment.errors';
-
-class InMemoryPaymentRepository implements PaymentRepositoryPort {
-	private readonly payments = new Map<string, Payment>();
-	private readonly failOnSavePaymentIds = new Set<string>();
-
-	async findById(id: string): Promise<Payment | null> {
-		return this.payments.get(id) ?? null;
-	}
-
-	async findByIdForClient(id: string): Promise<Payment | null> {
-		return this.findById(id);
-	}
-
-	async findByOrderId(orderId: string): Promise<Payment | null> {
-		for (const payment of this.payments.values()) {
-			if (payment.orderId === orderId) return payment;
-		}
-
-		return null;
-	}
-
-	async findByOrderIdForClient(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findByGatewayId(gatewayId: string): Promise<Payment | null> {
-		for (const payment of this.payments.values()) {
-			if (payment.gatewayId === gatewayId) return payment;
-		}
-
-		return null;
-	}
-
-	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async withStaleCheckoutReconciliationLock(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async save(payment: Payment): Promise<void> {
-		if (this.failOnSavePaymentIds.has(payment.id))
-			throw new Error('Payment save failed.');
-
-		this.payments.set(payment.id, payment);
-	}
-
-	insert(payment: Payment): void {
-		this.payments.set(payment.id, payment);
-	}
-
-	setFailOnSave(paymentId: string): void {
-		this.failOnSavePaymentIds.add(paymentId);
-	}
-}
+import { InMemoryPaymentRepository } from '../../../../../../test/support/in-memory/payments/in-memory-payment.repository';
 
 class InMemoryProcessedWebhookEventPort implements ProcessedWebhookEventPort {
 	private readonly processedEventIds = new Set<string>();

--- a/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
@@ -1,6 +1,9 @@
 import type { OrderCredentialCleanupPort } from '@modules/payments/application/ports/order-credential-cleanup.port';
 import type { OrderPaymentConfirmationPort } from '@modules/payments/application/ports/order-payment-confirmation.port';
-import type { PaymentGatewayPort } from '@modules/payments/application/ports/payment-gateway.port';
+import type {
+	FetchPaymentNotificationOutput,
+	PaymentGatewayPort,
+} from '@modules/payments/application/ports/payment-gateway.port';
 import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import type { PaymentWebhookSignatureVerifierPort } from '@modules/payments/application/ports/payment-webhook-signature-verifier.port';
 import type { ProcessedWebhookEventPort } from '@modules/payments/application/ports/processed-webhook-event.port';
@@ -102,7 +105,16 @@ class InMemoryOrderCredentialCleanupPort implements OrderCredentialCleanupPort {
 class InMemoryPaymentGatewayPort implements PaymentGatewayPort {
 	fetchCalls = 0;
 
-	notification = {
+	notification: Omit<
+		FetchPaymentNotificationOutput,
+		'gatewayPaymentMethodId' | 'gatewayPaymentTypeId'
+	> &
+		Partial<
+			Pick<
+				FetchPaymentNotificationOutput,
+				'gatewayPaymentMethodId' | 'gatewayPaymentTypeId'
+			>
+		> = {
 		internalPaymentId: 'payment-1',
 		gatewayPaymentId: 'mp-payment-1',
 		gatewayStatus: 'approved',
@@ -118,14 +130,21 @@ class InMemoryPaymentGatewayPort implements PaymentGatewayPort {
 		throw new Error('not needed in this test');
 	}
 
-	async fetchPaymentNotification(): Promise<{
-		internalPaymentId: string;
-		gatewayPaymentId: string;
-		gatewayStatus: string;
-		gatewayStatusDetail: string | null;
-	}> {
+	async fetchPaymentNotification(): Promise<FetchPaymentNotificationOutput> {
 		this.fetchCalls++;
-		return this.notification;
+		return {
+			gatewayPaymentMethodId: null,
+			gatewayPaymentTypeId: null,
+			...this.notification,
+		};
+	}
+
+	async fetchPaymentByExternalReference(): Promise<FetchPaymentNotificationOutput | null> {
+		return {
+			gatewayPaymentMethodId: null,
+			gatewayPaymentTypeId: null,
+			...this.notification,
+		};
 	}
 }
 

--- a/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
@@ -48,6 +48,14 @@ class InMemoryPaymentRepository implements PaymentRepositoryPort {
 		return null;
 	}
 
+	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
+	async withStaleCheckoutReconciliationLock(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
 	async save(payment: Payment): Promise<void> {
 		if (this.failOnSavePaymentIds.has(payment.id))
 			throw new Error('Payment save failed.');

--- a/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.ts
+++ b/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.ts
@@ -131,6 +131,8 @@ export class HandlePaymentConfirmedWebhookUseCase {
 				gatewayId: notification.gatewayPaymentId,
 				gatewayStatus: notification.gatewayStatus,
 				gatewayStatusDetail: notification.gatewayStatusDetail,
+				gatewayPaymentMethodId: notification.gatewayPaymentMethodId,
+				gatewayPaymentTypeId: notification.gatewayPaymentTypeId,
 			});
 
 			const resolution = this.resolveNotification(notification.gatewayStatus);

--- a/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.spec.ts
@@ -4,65 +4,30 @@ import type {
 	FetchPaymentNotificationOutput,
 	PaymentGatewayPort,
 } from '@modules/payments/application/ports/payment-gateway.port';
-import type {
-	PaymentRepositoryPort,
-	StalePaymentReconciliationCandidate,
-} from '@modules/payments/application/ports/payment-repository.port';
+import type { StalePaymentReconciliationCandidate } from '@modules/payments/application/ports/payment-repository.port';
 import { Payment } from '@modules/payments/domain/payment.entity';
+import { InMemoryPaymentRepository } from '../../../../../../test/support/in-memory/payments/in-memory-payment.repository';
 import { ReconcileStaleCheckoutsUseCase } from './reconcile-stale-checkouts.use-case';
 
-class PaymentRepositoryStub implements PaymentRepositoryPort {
-	readonly payments = new Map<string, Payment>();
+class PaymentRepositoryStub extends InMemoryPaymentRepository {
 	lockAvailable = true;
 	candidates: StalePaymentReconciliationCandidate[] = [];
 
-	async findById(id: string): Promise<Payment | null> {
-		return this.payments.get(id) ?? null;
-	}
-
-	async findByIdForClient(id: string): Promise<Payment | null> {
-		return this.findById(id);
-	}
-
-	async findByOrderId(orderId: string): Promise<Payment | null> {
-		return (
-			[...this.payments.values()].find(
-				(payment) => payment.orderId === orderId,
-			) ?? null
-		);
-	}
-
-	async findByOrderIdForClient(orderId: string): Promise<Payment | null> {
-		return this.findByOrderId(orderId);
-	}
-
-	async findByGatewayId(gatewayId: string): Promise<Payment | null> {
-		return (
-			[...this.payments.values()].find(
-				(payment) => payment.gatewayId === gatewayId,
-			) ?? null
-		);
-	}
-
-	async findStaleAwaitingCheckoutCandidates(): Promise<
+	override async findStaleAwaitingCheckoutCandidates(): Promise<
 		StalePaymentReconciliationCandidate[]
 	> {
 		return this.candidates;
 	}
 
-	async withStaleCheckoutReconciliationLock<T>(
+	override async withStaleCheckoutReconciliationLock<T>(
 		callback: () => Promise<T>,
 	): Promise<T | null> {
 		if (!this.lockAvailable) return null;
 		return await callback();
 	}
 
-	async save(payment: Payment): Promise<void> {
-		this.payments.set(payment.id, payment);
-	}
-
-	insert(payment: Payment): void {
-		this.payments.set(payment.id, payment);
+	override insert(payment: Payment): void {
+		super.insert(payment);
 		this.candidates.push({ payment });
 	}
 }
@@ -250,7 +215,7 @@ describe('ReconcileStaleCheckoutsUseCase', () => {
 		const currentPayment = makePayment('payment-concurrent');
 		currentPayment.confirm();
 		repository.candidates.push({ payment: staleCandidate });
-		repository.payments.set(currentPayment.id, currentPayment);
+		await repository.save(currentPayment);
 		gateway.notifications.set(
 			'mp-payment-concurrent',
 			makeProviderPayment(

--- a/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.spec.ts
@@ -1,0 +1,319 @@
+import type { OrderCredentialCleanupPort } from '@modules/payments/application/ports/order-credential-cleanup.port';
+import type { OrderPaymentConfirmationPort } from '@modules/payments/application/ports/order-payment-confirmation.port';
+import type {
+	FetchPaymentNotificationOutput,
+	PaymentGatewayPort,
+} from '@modules/payments/application/ports/payment-gateway.port';
+import type {
+	PaymentRepositoryPort,
+	StalePaymentReconciliationCandidate,
+} from '@modules/payments/application/ports/payment-repository.port';
+import { Payment } from '@modules/payments/domain/payment.entity';
+import { ReconcileStaleCheckoutsUseCase } from './reconcile-stale-checkouts.use-case';
+
+class PaymentRepositoryStub implements PaymentRepositoryPort {
+	readonly payments = new Map<string, Payment>();
+	lockAvailable = true;
+	candidates: StalePaymentReconciliationCandidate[] = [];
+
+	async findById(id: string): Promise<Payment | null> {
+		return this.payments.get(id) ?? null;
+	}
+
+	async findByIdForClient(id: string): Promise<Payment | null> {
+		return this.findById(id);
+	}
+
+	async findByOrderId(orderId: string): Promise<Payment | null> {
+		return (
+			[...this.payments.values()].find(
+				(payment) => payment.orderId === orderId,
+			) ?? null
+		);
+	}
+
+	async findByOrderIdForClient(orderId: string): Promise<Payment | null> {
+		return this.findByOrderId(orderId);
+	}
+
+	async findByGatewayId(gatewayId: string): Promise<Payment | null> {
+		return (
+			[...this.payments.values()].find(
+				(payment) => payment.gatewayId === gatewayId,
+			) ?? null
+		);
+	}
+
+	async findStaleAwaitingCheckoutCandidates(): Promise<
+		StalePaymentReconciliationCandidate[]
+	> {
+		return this.candidates;
+	}
+
+	async withStaleCheckoutReconciliationLock<T>(
+		callback: () => Promise<T>,
+	): Promise<T | null> {
+		if (!this.lockAvailable) return null;
+		return await callback();
+	}
+
+	async save(payment: Payment): Promise<void> {
+		this.payments.set(payment.id, payment);
+	}
+
+	insert(payment: Payment): void {
+		this.payments.set(payment.id, payment);
+		this.candidates.push({ payment });
+	}
+}
+
+class PaymentGatewayStub implements PaymentGatewayPort {
+	readonly fetchIds: string[] = [];
+	readonly externalReferences: string[] = [];
+	notifications = new Map<string, FetchPaymentNotificationOutput | null>();
+	shouldFail = false;
+
+	async initiatePayment(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
+	async fetchPaymentNotification(input: {
+		notificationId: string;
+	}): Promise<FetchPaymentNotificationOutput> {
+		this.fetchIds.push(input.notificationId);
+		if (this.shouldFail) throw new Error('gateway down');
+		const notification = this.notifications.get(input.notificationId);
+		if (!notification) throw new Error('payment not found');
+		return notification;
+	}
+
+	async fetchPaymentByExternalReference(
+		externalReference: string,
+	): Promise<FetchPaymentNotificationOutput | null> {
+		this.externalReferences.push(externalReference);
+		if (this.shouldFail) throw new Error('gateway down');
+		return this.notifications.get(externalReference) ?? null;
+	}
+}
+
+class OrderPaymentConfirmationSpy implements OrderPaymentConfirmationPort {
+	readonly orderIds: string[] = [];
+	shouldFail = false;
+
+	async markAsPaid(orderId: string): Promise<void> {
+		if (this.shouldFail) throw new Error('order update failed');
+		this.orderIds.push(orderId);
+	}
+}
+
+class OrderCredentialCleanupSpy implements OrderCredentialCleanupPort {
+	readonly orderIds: string[] = [];
+	shouldFail = false;
+
+	async clearCredentials(orderId: string): Promise<void> {
+		if (this.shouldFail) throw new Error('credential cleanup failed');
+		this.orderIds.push(orderId);
+	}
+}
+
+const makePayment = (id: string, gatewayId: string | null = `mp-${id}`) => {
+	const payment = Payment.create({
+		id,
+		orderId: `order-${id}`,
+		grossAmount: 100,
+		paymentMethod: 'pix',
+	});
+	payment.attachGatewayDetails({
+		gatewayId,
+		gatewayStatus: 'pending',
+	});
+	return payment;
+};
+
+const makeProviderPayment = (
+	paymentId: string,
+	status: string,
+	statusDetail: string | null,
+): FetchPaymentNotificationOutput => ({
+	internalPaymentId: paymentId,
+	gatewayPaymentId: `mp-${paymentId}`,
+	gatewayStatus: status,
+	gatewayStatusDetail: statusDetail,
+	gatewayPaymentMethodId: 'pix',
+	gatewayPaymentTypeId: 'bank_transfer',
+});
+
+const makeUseCase = () => {
+	const repository = new PaymentRepositoryStub();
+	const gateway = new PaymentGatewayStub();
+	const confirmation = new OrderPaymentConfirmationSpy();
+	const cleanup = new OrderCredentialCleanupSpy();
+	const useCase = new ReconcileStaleCheckoutsUseCase(
+		repository,
+		gateway,
+		confirmation,
+		cleanup,
+	);
+
+	return { repository, gateway, confirmation, cleanup, useCase };
+};
+
+const runAt = new Date('2026-07-09T18:00:00.000Z');
+
+describe('ReconcileStaleCheckoutsUseCase', () => {
+	it('confirms approved provider payments', async () => {
+		const { repository, gateway, confirmation, useCase } = makeUseCase();
+		const payment = makePayment('payment-1');
+		repository.insert(payment);
+		gateway.notifications.set(
+			'mp-payment-1',
+			makeProviderPayment('payment-1', 'approved', 'accredited'),
+		);
+
+		const result = await useCase.execute({ now: runAt, limit: 50 });
+
+		expect(result).toMatchObject({
+			skipped: false,
+			scannedCount: 1,
+			confirmedCount: 1,
+		});
+		expect(payment.status).toBe('held');
+		expect(payment.gatewayPaymentMethodId).toBe('pix');
+		expect(payment.gatewayPaymentTypeId).toBe('bank_transfer');
+		expect(confirmation.orderIds).toEqual(['order-payment-1']);
+	});
+
+	it('fails rejected provider payments and clears credentials', async () => {
+		const { repository, gateway, cleanup, useCase } = makeUseCase();
+		const payment = makePayment('payment-2');
+		repository.insert(payment);
+		gateway.notifications.set(
+			'mp-payment-2',
+			makeProviderPayment('payment-2', 'rejected', 'cc_rejected_high_risk'),
+		);
+
+		const result = await useCase.execute({ now: runAt, limit: 50 });
+
+		expect(result.failedCount).toBe(1);
+		expect(payment.status).toBe('failed');
+		expect(cleanup.orderIds).toEqual(['order-payment-2']);
+	});
+
+	it('updates pending provider metadata without changing payment status', async () => {
+		const { repository, gateway, useCase } = makeUseCase();
+		const payment = makePayment('payment-3');
+		repository.insert(payment);
+		gateway.notifications.set(
+			'mp-payment-3',
+			makeProviderPayment('payment-3', 'pending', 'pending_waiting_transfer'),
+		);
+
+		const result = await useCase.execute({ now: runAt, limit: 50 });
+
+		expect(result.pendingUpdatedCount).toBe(1);
+		expect(payment.status).toBe('awaiting_confirmation');
+		expect(payment.gatewayStatus).toBe('pending');
+		expect(payment.gatewayStatusDetail).toBe('pending_waiting_transfer');
+	});
+
+	it('uses external reference search when the gateway payment id is missing', async () => {
+		const { repository, gateway, useCase } = makeUseCase();
+		const payment = makePayment('payment-4', null);
+		repository.insert(payment);
+		gateway.notifications.set(
+			'payment-4',
+			makeProviderPayment('payment-4', 'pending', 'pending_waiting_transfer'),
+		);
+
+		await useCase.execute({ now: runAt, limit: 50 });
+
+		expect(gateway.externalReferences).toEqual(['payment-4']);
+		expect(gateway.fetchIds).toEqual([]);
+		expect(payment.gatewayId).toBe('mp-payment-4');
+	});
+
+	it('counts gateway failures and leaves payment state unchanged', async () => {
+		const { repository, gateway, useCase } = makeUseCase();
+		const payment = makePayment('payment-5');
+		repository.insert(payment);
+		gateway.shouldFail = true;
+
+		const result = await useCase.execute({ now: runAt, limit: 50 });
+
+		expect(result.gatewayErrorCount).toBe(1);
+		expect(payment.status).toBe('awaiting_confirmation');
+	});
+
+	it('does not overwrite payments that changed after candidate selection', async () => {
+		const { repository, gateway, confirmation, useCase } = makeUseCase();
+		const staleCandidate = makePayment('payment-concurrent');
+		const currentPayment = makePayment('payment-concurrent');
+		currentPayment.confirm();
+		repository.candidates.push({ payment: staleCandidate });
+		repository.payments.set(currentPayment.id, currentPayment);
+		gateway.notifications.set(
+			'mp-payment-concurrent',
+			makeProviderPayment(
+				'payment-concurrent',
+				'pending',
+				'pending_waiting_transfer',
+			),
+		);
+
+		const result = await useCase.execute({ now: runAt, limit: 50 });
+
+		expect(result.skippedCount).toBe(1);
+		expect(currentPayment.status).toBe('held');
+		expect(confirmation.orderIds).toEqual([]);
+	});
+
+	it('keeps approved payments retryable when marking the order as paid fails', async () => {
+		const { repository, gateway, confirmation, useCase } = makeUseCase();
+		const payment = makePayment('payment-6');
+		repository.insert(payment);
+		confirmation.shouldFail = true;
+		gateway.notifications.set(
+			'mp-payment-6',
+			makeProviderPayment('payment-6', 'approved', 'accredited'),
+		);
+
+		await expect(useCase.execute({ now: runAt, limit: 50 })).rejects.toThrow(
+			'order update failed',
+		);
+
+		expect(payment.status).toBe('awaiting_confirmation');
+	});
+
+	it('keeps rejected payments retryable when credential cleanup fails', async () => {
+		const { repository, gateway, cleanup, useCase } = makeUseCase();
+		const payment = makePayment('payment-7');
+		repository.insert(payment);
+		cleanup.shouldFail = true;
+		gateway.notifications.set(
+			'mp-payment-7',
+			makeProviderPayment('payment-7', 'rejected', 'cc_rejected_high_risk'),
+		);
+
+		await expect(useCase.execute({ now: runAt, limit: 50 })).rejects.toThrow(
+			'credential cleanup failed',
+		);
+
+		expect(payment.status).toBe('awaiting_confirmation');
+	});
+
+	it('skips the run when another reconciliation holds the advisory lock', async () => {
+		const { repository, useCase } = makeUseCase();
+		repository.lockAvailable = false;
+
+		await expect(useCase.execute({ now: runAt, limit: 50 })).resolves.toEqual({
+			skipped: true,
+			reason: 'lock_unavailable',
+			scannedCount: 0,
+			confirmedCount: 0,
+			failedCount: 0,
+			pendingUpdatedCount: 0,
+			skippedCount: 0,
+			gatewayErrorCount: 0,
+		});
+	});
+});

--- a/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.ts
+++ b/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.ts
@@ -1,0 +1,237 @@
+import {
+	markPaymentLifecycleLogError,
+	type PaymentLifecycleLogEvent,
+	PaymentLifecycleLogger,
+} from '@modules/payments/application/logging/payment-lifecycle.logger';
+import {
+	ORDER_CREDENTIAL_CLEANUP_PORT_KEY,
+	type OrderCredentialCleanupPort,
+} from '@modules/payments/application/ports/order-credential-cleanup.port';
+import {
+	ORDER_PAYMENT_CONFIRMATION_PORT_KEY,
+	type OrderPaymentConfirmationPort,
+} from '@modules/payments/application/ports/order-payment-confirmation.port';
+import {
+	type FetchPaymentNotificationOutput,
+	PAYMENT_GATEWAY_PORT_KEY,
+	type PaymentGatewayPort,
+} from '@modules/payments/application/ports/payment-gateway.port';
+import {
+	PAYMENT_REPOSITORY_KEY,
+	type PaymentRepositoryPort,
+} from '@modules/payments/application/ports/payment-repository.port';
+import type { Payment } from '@modules/payments/domain/payment.entity';
+import { PaymentStatus } from '@modules/payments/domain/payment-status';
+import { Inject, Injectable, Optional } from '@nestjs/common';
+
+const DEFAULT_STALE_AFTER_MINUTES = 15;
+const RECONCILIATION_CONCURRENCY = 3;
+
+type ReconcileStaleCheckoutsInput = {
+	now: Date;
+	limit: number;
+};
+
+type ReconcileStaleCheckoutsOutput = {
+	skipped: boolean;
+	reason?: 'lock_unavailable';
+	scannedCount: number;
+	confirmedCount: number;
+	failedCount: number;
+	pendingUpdatedCount: number;
+	skippedCount: number;
+	gatewayErrorCount: number;
+};
+
+type ReconciliationCounts = Omit<ReconcileStaleCheckoutsOutput, 'skipped'>;
+
+type GatewayResolution = 'confirm' | 'fail' | 'pending' | 'defer';
+
+@Injectable()
+export class ReconcileStaleCheckoutsUseCase {
+	constructor(
+		@Inject(PAYMENT_REPOSITORY_KEY)
+		private readonly paymentRepository: PaymentRepositoryPort,
+		@Inject(PAYMENT_GATEWAY_PORT_KEY)
+		private readonly paymentGatewayPort: PaymentGatewayPort,
+		@Inject(ORDER_PAYMENT_CONFIRMATION_PORT_KEY)
+		private readonly orderPaymentConfirmationPort: OrderPaymentConfirmationPort,
+		@Inject(ORDER_CREDENTIAL_CLEANUP_PORT_KEY)
+		private readonly orderCredentialCleanupPort: OrderCredentialCleanupPort,
+		@Optional()
+		private readonly paymentLifecycleLogger?: PaymentLifecycleLogger,
+	) {}
+
+	async execute(
+		input: ReconcileStaleCheckoutsInput,
+	): Promise<ReconcileStaleCheckoutsOutput> {
+		const startedAt = Date.now();
+		const counts = this.emptyCounts();
+		const logEvent: PaymentLifecycleLogEvent = {
+			event: 'payment.lifecycle',
+			operation: 'reconcile_stale_checkout',
+			gateway: 'MERCADO_PAGO',
+		};
+
+		try {
+			const result =
+				await this.paymentRepository.withStaleCheckoutReconciliationLock(
+					async () => {
+						const createdBefore = new Date(
+							input.now.getTime() - DEFAULT_STALE_AFTER_MINUTES * 60_000,
+						);
+						const candidates =
+							await this.paymentRepository.findStaleAwaitingCheckoutCandidates({
+								createdBefore,
+								limit: input.limit,
+							});
+						counts.scannedCount = candidates.length;
+
+						for (
+							let index = 0;
+							index < candidates.length;
+							index += RECONCILIATION_CONCURRENCY
+						) {
+							await Promise.all(
+								candidates
+									.slice(index, index + RECONCILIATION_CONCURRENCY)
+									.map(({ payment }) => this.reconcilePayment(payment, counts)),
+							);
+						}
+
+						return { skipped: false, ...counts };
+					},
+				);
+
+			if (!result) {
+				const skipped = {
+					skipped: true,
+					reason: 'lock_unavailable' as const,
+					...counts,
+				};
+				this.attachCounts(logEvent, skipped);
+				logEvent.outcome = 'skipped';
+				return skipped;
+			}
+
+			this.attachCounts(logEvent, result);
+			logEvent.outcome = 'success';
+			return result;
+		} catch (error) {
+			this.attachCounts(logEvent, counts);
+			markPaymentLifecycleLogError(logEvent, error);
+			throw error;
+		} finally {
+			this.paymentLifecycleLogger?.emit(logEvent, startedAt);
+		}
+	}
+
+	private async reconcilePayment(
+		payment: Payment,
+		counts: ReconciliationCounts,
+	): Promise<void> {
+		let providerPayment: FetchPaymentNotificationOutput | null;
+		try {
+			providerPayment = payment.gatewayId
+				? await this.paymentGatewayPort.fetchPaymentNotification({
+						notificationId: payment.gatewayId,
+					})
+				: await this.paymentGatewayPort.fetchPaymentByExternalReference(
+						payment.id,
+					);
+		} catch {
+			counts.gatewayErrorCount++;
+			return;
+		}
+
+		if (!providerPayment || providerPayment.internalPaymentId !== payment.id) {
+			counts.skippedCount++;
+			return;
+		}
+
+		const currentPayment = await this.paymentRepository.findById(payment.id);
+		if (
+			!currentPayment ||
+			currentPayment.status !== PaymentStatus.AWAITING_CONFIRMATION
+		) {
+			counts.skippedCount++;
+			return;
+		}
+
+		currentPayment.attachGatewayDetails({
+			gatewayId: providerPayment.gatewayPaymentId,
+			gatewayStatus: providerPayment.gatewayStatus,
+			gatewayStatusDetail: providerPayment.gatewayStatusDetail,
+			gatewayPaymentMethodId: providerPayment.gatewayPaymentMethodId,
+			gatewayPaymentTypeId: providerPayment.gatewayPaymentTypeId,
+		});
+
+		const resolution = this.resolveGatewayStatus(providerPayment.gatewayStatus);
+		if (resolution === 'confirm') {
+			await this.orderPaymentConfirmationPort.markAsPaid(
+				currentPayment.orderId,
+			);
+			currentPayment.confirm();
+			await this.paymentRepository.save(currentPayment);
+			counts.confirmedCount++;
+			return;
+		}
+
+		if (resolution === 'fail') {
+			await this.orderCredentialCleanupPort.clearCredentials(
+				currentPayment.orderId,
+			);
+			currentPayment.fail();
+			await this.paymentRepository.save(currentPayment);
+			counts.failedCount++;
+			return;
+		}
+
+		if (resolution === 'pending') {
+			await this.paymentRepository.save(currentPayment);
+			counts.pendingUpdatedCount++;
+			return;
+		}
+
+		counts.skippedCount++;
+	}
+
+	private resolveGatewayStatus(gatewayStatus: string): GatewayResolution {
+		switch (gatewayStatus) {
+			case 'approved':
+				return 'confirm';
+			case 'rejected':
+			case 'cancelled':
+				return 'fail';
+			case 'authorized':
+			case 'pending':
+			case 'in_process':
+				return 'pending';
+			default:
+				return 'defer';
+		}
+	}
+
+	private emptyCounts(): ReconciliationCounts {
+		return {
+			scannedCount: 0,
+			confirmedCount: 0,
+			failedCount: 0,
+			pendingUpdatedCount: 0,
+			skippedCount: 0,
+			gatewayErrorCount: 0,
+		};
+	}
+
+	private attachCounts(
+		logEvent: PaymentLifecycleLogEvent,
+		counts: ReconciliationCounts,
+	): void {
+		logEvent.scanned_count = counts.scannedCount;
+		logEvent.confirmed_count = counts.confirmedCount;
+		logEvent.failed_count = counts.failedCount;
+		logEvent.pending_updated_count = counts.pendingUpdatedCount;
+		logEvent.skipped_count = counts.skippedCount;
+		logEvent.gateway_error_count = counts.gatewayErrorCount;
+	}
+}

--- a/apps/api/src/modules/payments/application/use-cases/release-payment-hold/release-payment-hold.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/release-payment-hold/release-payment-hold.use-case.spec.ts
@@ -1,6 +1,5 @@
 import { OrderStatus } from '@modules/orders/domain/order-status';
 import type { OrderStatusPort } from '@modules/payments/application/ports/order-status.port';
-import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import { ReleasePaymentHoldUseCase } from '@modules/payments/application/use-cases/release-payment-hold/release-payment-hold.use-case';
 import { Payment } from '@modules/payments/domain/payment.entity';
 import {
@@ -8,50 +7,7 @@ import {
 	PaymentNotFoundError,
 	PaymentOrderNotFoundError,
 } from '@modules/payments/domain/payment.errors';
-
-class InMemoryPaymentRepository implements PaymentRepositoryPort {
-	private readonly payments = new Map<string, Payment>();
-
-	async findById(id: string): Promise<Payment | null> {
-		return this.payments.get(id) ?? null;
-	}
-
-	async findByIdForClient(id: string): Promise<Payment | null> {
-		return this.findById(id);
-	}
-
-	async findByOrderId(orderId: string): Promise<Payment | null> {
-		for (const payment of this.payments.values()) {
-			if (payment.orderId === orderId) return payment;
-		}
-
-		return null;
-	}
-
-	async findByOrderIdForClient(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findByGatewayId(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async withStaleCheckoutReconciliationLock(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async save(payment: Payment): Promise<void> {
-		this.payments.set(payment.id, payment);
-	}
-
-	insert(payment: Payment): void {
-		this.payments.set(payment.id, payment);
-	}
-}
+import { InMemoryPaymentRepository } from '../../../../../../test/support/in-memory/payments/in-memory-payment.repository';
 
 class InMemoryOrderStatusPort implements OrderStatusPort {
 	private readonly orderStatuses = new Map<string, OrderStatus>();

--- a/apps/api/src/modules/payments/application/use-cases/release-payment-hold/release-payment-hold.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/release-payment-hold/release-payment-hold.use-case.spec.ts
@@ -36,6 +36,14 @@ class InMemoryPaymentRepository implements PaymentRepositoryPort {
 		throw new Error('not needed in this test');
 	}
 
+	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
+	async withStaleCheckoutReconciliationLock(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
 	async save(payment: Payment): Promise<void> {
 		this.payments.set(payment.id, payment);
 	}

--- a/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.spec.ts
@@ -57,6 +57,14 @@ class InMemoryPaymentRepository implements PaymentRepositoryPort {
 		throw new Error('not needed in this test');
 	}
 
+	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
+	async withStaleCheckoutReconciliationLock(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
 	async save(payment: Payment): Promise<void> {
 		this.payments.set(payment.id, { payment, clientId: 'client-1' });
 	}

--- a/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.spec.ts
@@ -110,6 +110,10 @@ class FakePaymentGateway implements PaymentGatewayPort {
 	async fetchPaymentNotification(): Promise<never> {
 		throw new Error('not needed in this test');
 	}
+
+	async fetchPaymentByExternalReference(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
 }
 
 const makePayment = (input?: { checkoutUrl?: string | null }) => {

--- a/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case.spec.ts
@@ -5,74 +5,13 @@ import type {
 	InitiatePaymentOutput,
 	PaymentGatewayPort,
 } from '@modules/payments/application/ports/payment-gateway.port';
-import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import { ResumePaymentCheckoutUseCase } from '@modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case';
 import { Payment } from '@modules/payments/domain/payment.entity';
 import {
 	PaymentCheckoutResumeNotAllowedError,
 	PaymentNotFoundError,
 } from '@modules/payments/domain/payment.errors';
-
-class InMemoryPaymentRepository implements PaymentRepositoryPort {
-	private readonly payments = new Map<
-		string,
-		{ payment: Payment; clientId: string }
-	>();
-
-	async findById(id: string): Promise<Payment | null> {
-		return this.payments.get(id)?.payment ?? null;
-	}
-
-	async findByIdForClient(
-		id: string,
-		clientId: string,
-	): Promise<Payment | null> {
-		const record = this.payments.get(id);
-		if (!record || record.clientId !== clientId) return null;
-
-		return record.payment;
-	}
-
-	async findByOrderId(orderId: string): Promise<Payment | null> {
-		for (const record of this.payments.values()) {
-			if (record.payment.orderId === orderId) return record.payment;
-		}
-
-		return null;
-	}
-
-	async findByOrderIdForClient(
-		orderId: string,
-		clientId: string,
-	): Promise<Payment | null> {
-		for (const record of this.payments.values()) {
-			if (record.payment.orderId === orderId && record.clientId === clientId)
-				return record.payment;
-		}
-
-		return null;
-	}
-
-	async findByGatewayId(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async withStaleCheckoutReconciliationLock(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async save(payment: Payment): Promise<void> {
-		this.payments.set(payment.id, { payment, clientId: 'client-1' });
-	}
-
-	insert(payment: Payment, clientId: string): void {
-		this.payments.set(payment.id, { payment, clientId });
-	}
-}
+import { InMemoryPaymentRepository } from '../../../../../../test/support/in-memory/payments/in-memory-payment.repository';
 
 class InMemoryOrderStatusPort implements OrderStatusPort {
 	private readonly statuses = new Map<

--- a/apps/api/src/modules/payments/application/use-cases/simulate-dev-payment-outcome/simulate-dev-payment-outcome.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/simulate-dev-payment-outcome/simulate-dev-payment-outcome.use-case.spec.ts
@@ -47,6 +47,14 @@ class PaymentRepositoryStub implements PaymentRepositoryPort {
 		throw new Error('not needed in this test');
 	}
 
+	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
+	async withStaleCheckoutReconciliationLock(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
+
 	async save(payment: Payment): Promise<void> {
 		const record = this.payments.get(payment.id);
 		this.payments.set(payment.id, {

--- a/apps/api/src/modules/payments/application/use-cases/simulate-dev-payment-outcome/simulate-dev-payment-outcome.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/simulate-dev-payment-outcome/simulate-dev-payment-outcome.use-case.spec.ts
@@ -1,72 +1,8 @@
 import type { OrderCredentialCleanupPort } from '@modules/payments/application/ports/order-credential-cleanup.port';
 import type { OrderPaymentConfirmationPort } from '@modules/payments/application/ports/order-payment-confirmation.port';
-import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import { SimulateDevPaymentOutcomeUseCase } from '@modules/payments/application/use-cases/simulate-dev-payment-outcome/simulate-dev-payment-outcome.use-case';
 import { Payment } from '@modules/payments/domain/payment.entity';
-
-class PaymentRepositoryStub implements PaymentRepositoryPort {
-	private readonly payments = new Map<
-		string,
-		{ clientId: string; payment: Payment }
-	>();
-
-	async findById(id: string): Promise<Payment | null> {
-		return this.payments.get(id)?.payment ?? null;
-	}
-
-	async findByIdForClient(
-		id: string,
-		clientId: string,
-	): Promise<Payment | null> {
-		const record = this.payments.get(id);
-		if (!record || record.clientId !== clientId) return null;
-
-		return record.payment;
-	}
-
-	async findByOrderId(orderId: string): Promise<Payment | null> {
-		for (const { payment } of this.payments.values()) {
-			if (payment.orderId === orderId) return payment;
-		}
-
-		return null;
-	}
-
-	async findByOrderIdForClient(
-		orderId: string,
-		clientId: string,
-	): Promise<Payment | null> {
-		for (const { payment, clientId: ownerId } of this.payments.values()) {
-			if (payment.orderId === orderId && ownerId === clientId) return payment;
-		}
-
-		return null;
-	}
-
-	async findByGatewayId(): Promise<Payment | null> {
-		throw new Error('not needed in this test');
-	}
-
-	async findStaleAwaitingCheckoutCandidates(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async withStaleCheckoutReconciliationLock(): Promise<never> {
-		throw new Error('not needed in this test');
-	}
-
-	async save(payment: Payment): Promise<void> {
-		const record = this.payments.get(payment.id);
-		this.payments.set(payment.id, {
-			clientId: record?.clientId ?? 'client-1',
-			payment,
-		});
-	}
-
-	insert(clientId: string, payment: Payment): void {
-		this.payments.set(payment.id, { clientId, payment });
-	}
-}
+import { InMemoryPaymentRepository } from '../../../../../../test/support/in-memory/payments/in-memory-payment.repository';
 
 const makePayment = () =>
 	Payment.create({
@@ -78,14 +14,14 @@ const makePayment = () =>
 
 describe('SimulateDevPaymentOutcomeUseCase', () => {
 	it('confirms the owned payment when simulating approval', async () => {
-		const payments = new PaymentRepositoryStub();
+		const payments = new InMemoryPaymentRepository();
 		const confirmation: OrderPaymentConfirmationPort = {
 			markAsPaid: jest.fn(),
 		};
 		const cleanup: OrderCredentialCleanupPort = {
 			clearCredentials: jest.fn(),
 		};
-		payments.insert('client-1', makePayment());
+		payments.insert(makePayment(), 'client-1');
 		const useCase = new SimulateDevPaymentOutcomeUseCase(
 			payments,
 			confirmation,
@@ -109,14 +45,14 @@ describe('SimulateDevPaymentOutcomeUseCase', () => {
 	});
 
 	it('fails the owned payment when simulating rejection', async () => {
-		const payments = new PaymentRepositoryStub();
+		const payments = new InMemoryPaymentRepository();
 		const confirmation: OrderPaymentConfirmationPort = {
 			markAsPaid: jest.fn(),
 		};
 		const cleanup: OrderCredentialCleanupPort = {
 			clearCredentials: jest.fn(),
 		};
-		payments.insert('client-1', makePayment());
+		payments.insert(makePayment(), 'client-1');
 		const useCase = new SimulateDevPaymentOutcomeUseCase(
 			payments,
 			confirmation,
@@ -140,14 +76,14 @@ describe('SimulateDevPaymentOutcomeUseCase', () => {
 	});
 
 	it('keeps pending outcomes awaiting confirmation', async () => {
-		const payments = new PaymentRepositoryStub();
+		const payments = new InMemoryPaymentRepository();
 		const confirmation: OrderPaymentConfirmationPort = {
 			markAsPaid: jest.fn(),
 		};
 		const cleanup: OrderCredentialCleanupPort = {
 			clearCredentials: jest.fn(),
 		};
-		payments.insert('client-1', makePayment());
+		payments.insert(makePayment(), 'client-1');
 		const useCase = new SimulateDevPaymentOutcomeUseCase(
 			payments,
 			confirmation,
@@ -171,8 +107,8 @@ describe('SimulateDevPaymentOutcomeUseCase', () => {
 	});
 
 	it('does not allow another client to simulate a payment', async () => {
-		const payments = new PaymentRepositoryStub();
-		payments.insert('client-1', makePayment());
+		const payments = new InMemoryPaymentRepository();
+		payments.insert(makePayment(), 'client-1');
 		const useCase = new SimulateDevPaymentOutcomeUseCase(
 			payments,
 			{ markAsPaid: jest.fn() },

--- a/apps/api/src/modules/payments/application/use-cases/simulate-dev-payment-outcome/simulate-dev-payment-outcome.use-case.ts
+++ b/apps/api/src/modules/payments/application/use-cases/simulate-dev-payment-outcome/simulate-dev-payment-outcome.use-case.ts
@@ -88,6 +88,8 @@ export class SimulateDevPaymentOutcomeUseCase {
 				gatewayId: `dev-${payment.id}`,
 				gatewayStatus: input.outcome,
 				gatewayStatusDetail: this.resolveGatewayStatusDetail(input.outcome),
+				gatewayPaymentMethodId: payment.paymentMethod,
+				gatewayPaymentTypeId: payment.paymentMethod,
 			});
 
 			if (input.outcome === 'approved') payment.confirm();

--- a/apps/api/src/modules/payments/application/use-cases/start-checkout/start-checkout.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/start-checkout/start-checkout.use-case.spec.ts
@@ -52,6 +52,10 @@ class FakeGateway implements PaymentGatewayPort {
 	async fetchPaymentNotification(): Promise<never> {
 		throw new Error('not needed in this test');
 	}
+
+	async fetchPaymentByExternalReference(): Promise<never> {
+		throw new Error('not needed in this test');
+	}
 }
 
 const run = (orderCheckout: FakeOrderCheckout, gateway: FakeGateway) =>

--- a/apps/api/src/modules/payments/domain/payment.entity.ts
+++ b/apps/api/src/modules/payments/domain/payment.entity.ts
@@ -34,6 +34,8 @@ export class Payment {
 		private attachedGatewayId: string | null,
 		private attachedGatewayStatus: string | null,
 		private attachedGatewayStatusDetail: string | null,
+		private attachedGatewayPaymentMethodId: string | null,
+		private attachedGatewayPaymentTypeId: string | null,
 		private attachedCheckoutUrl: string | null,
 		private currentStatus: PaymentStatus,
 	) {}
@@ -62,6 +64,8 @@ export class Payment {
 			null,
 			null,
 			null,
+			null,
+			null,
 			PaymentStatus.AWAITING_CONFIRMATION,
 		);
 	}
@@ -77,6 +81,8 @@ export class Payment {
 		gatewayId: string | null;
 		gatewayStatus: string | null;
 		gatewayStatusDetail: string | null;
+		gatewayPaymentMethodId?: string | null;
+		gatewayPaymentTypeId?: string | null;
 		checkoutUrl?: string | null;
 		status: PaymentStatus;
 	}): Payment {
@@ -91,6 +97,8 @@ export class Payment {
 			input.gatewayId,
 			input.gatewayStatus,
 			input.gatewayStatusDetail,
+			input.gatewayPaymentMethodId ?? null,
+			input.gatewayPaymentTypeId ?? null,
 			input.checkoutUrl ?? null,
 			input.status,
 		);
@@ -116,6 +124,14 @@ export class Payment {
 		return this.attachedGatewayStatusDetail;
 	}
 
+	get gatewayPaymentMethodId(): string | null {
+		return this.attachedGatewayPaymentMethodId;
+	}
+
+	get gatewayPaymentTypeId(): string | null {
+		return this.attachedGatewayPaymentTypeId;
+	}
+
 	get checkoutUrl(): string | null {
 		return this.attachedCheckoutUrl;
 	}
@@ -125,6 +141,8 @@ export class Payment {
 		gatewayId: string | null;
 		gatewayStatus: string | null;
 		gatewayStatusDetail?: string | null;
+		gatewayPaymentMethodId?: string | null;
+		gatewayPaymentTypeId?: string | null;
 		checkoutUrl?: string | null;
 	}): void {
 		if (input.gatewayReferenceId !== undefined)
@@ -134,6 +152,10 @@ export class Payment {
 		this.attachedGatewayStatus = input.gatewayStatus;
 		if (input.gatewayStatusDetail !== undefined)
 			this.attachedGatewayStatusDetail = input.gatewayStatusDetail;
+		if (input.gatewayPaymentMethodId !== undefined)
+			this.attachedGatewayPaymentMethodId = input.gatewayPaymentMethodId;
+		if (input.gatewayPaymentTypeId !== undefined)
+			this.attachedGatewayPaymentTypeId = input.gatewayPaymentTypeId;
 		if (input.checkoutUrl !== undefined)
 			this.attachedCheckoutUrl = input.checkoutUrl;
 	}

--- a/apps/api/src/modules/payments/infrastructure/adapters/dev-payment-gateway.adapter.ts
+++ b/apps/api/src/modules/payments/infrastructure/adapters/dev-payment-gateway.adapter.ts
@@ -31,4 +31,12 @@ export class DevPaymentGatewayAdapter implements PaymentGatewayPort {
 			new Error('Dev payment gateway does not fetch provider notifications.'),
 		);
 	}
+
+	fetchPaymentByExternalReference(
+		_externalReference: string,
+	): Promise<FetchPaymentNotificationOutput | null> {
+		return Promise.reject(
+			new Error('Dev payment gateway does not fetch provider notifications.'),
+		);
+	}
 }

--- a/apps/api/src/modules/payments/infrastructure/adapters/mercadopago-payment-gateway.adapter.spec.ts
+++ b/apps/api/src/modules/payments/infrastructure/adapters/mercadopago-payment-gateway.adapter.spec.ts
@@ -11,6 +11,9 @@ const buildSdk = (
 	fetchPaymentNotification: async () => {
 		throw new Error('not configured');
 	},
+	fetchPaymentByExternalReference: async () => {
+		throw new Error('not configured');
+	},
 	verifyWebhookSignature: async () => false,
 	...overrides,
 });

--- a/apps/api/src/modules/payments/infrastructure/adapters/mercadopago-payment-gateway.adapter.ts
+++ b/apps/api/src/modules/payments/infrastructure/adapters/mercadopago-payment-gateway.adapter.ts
@@ -40,6 +40,18 @@ export class MercadoPagoPaymentGatewayAdapter implements PaymentGatewayPort {
 			throw toGatewayError('fetch_notification', error);
 		}
 	}
+
+	async fetchPaymentByExternalReference(
+		externalReference: string,
+	): Promise<FetchPaymentNotificationOutput | null> {
+		try {
+			return await this.mercadoPagoSdk.fetchPaymentByExternalReference(
+				externalReference,
+			);
+		} catch (error) {
+			throw toGatewayError('fetch_notification', error);
+		}
+	}
 }
 
 function toGatewayError(

--- a/apps/api/src/modules/payments/infrastructure/repositories/prisma-payment.repository.spec.ts
+++ b/apps/api/src/modules/payments/infrastructure/repositories/prisma-payment.repository.spec.ts
@@ -16,6 +16,8 @@ describe('PrismaPaymentRepository', () => {
 			gatewayId: 'mp-payment-1',
 			gatewayStatus: 'approved',
 			gatewayStatusDetail: null,
+			gatewayPaymentMethodId: null,
+			gatewayPaymentTypeId: null,
 			checkoutUrl: null,
 		});
 		const upsert = jest.fn().mockResolvedValue(undefined);
@@ -53,6 +55,8 @@ describe('PrismaPaymentRepository', () => {
 			gatewayId: 'mp-payment-1',
 			gatewayStatus: 'approved',
 			gatewayStatusDetail: null,
+			gatewayPaymentMethodId: null,
+			gatewayPaymentTypeId: null,
 			checkoutUrl: null,
 		});
 		expect(upsert).toHaveBeenCalledWith({
@@ -69,6 +73,8 @@ describe('PrismaPaymentRepository', () => {
 				gatewayId: 'mp-payment-1',
 				gatewayStatus: 'approved',
 				gatewayStatusDetail: null,
+				gatewayPaymentMethodId: null,
+				gatewayPaymentTypeId: null,
 				checkoutUrl: null,
 			},
 			update: {
@@ -81,6 +87,8 @@ describe('PrismaPaymentRepository', () => {
 				gatewayId: 'mp-payment-1',
 				gatewayStatus: 'approved',
 				gatewayStatusDetail: null,
+				gatewayPaymentMethodId: null,
+				gatewayPaymentTypeId: null,
 				checkoutUrl: null,
 			},
 		});
@@ -124,6 +132,8 @@ describe('PrismaPaymentRepository', () => {
 				gatewayId: null,
 				gatewayStatus: null,
 				gatewayStatusDetail: null,
+				gatewayPaymentMethodId: null,
+				gatewayPaymentTypeId: null,
 				checkoutUrl: null,
 			},
 			update: {
@@ -136,6 +146,8 @@ describe('PrismaPaymentRepository', () => {
 				gatewayId: null,
 				gatewayStatus: null,
 				gatewayStatusDetail: null,
+				gatewayPaymentMethodId: null,
+				gatewayPaymentTypeId: null,
 				checkoutUrl: null,
 			},
 		});
@@ -154,6 +166,8 @@ describe('PrismaPaymentRepository', () => {
 			gatewayId: 'mp-gateway-lookup',
 			gatewayStatus: 'pending',
 			gatewayStatusDetail: null,
+			gatewayPaymentMethodId: null,
+			gatewayPaymentTypeId: null,
 			checkoutUrl: null,
 		});
 		const prisma = {
@@ -205,6 +219,8 @@ describe('PrismaPaymentRepository', () => {
 					gatewayId: null,
 					gatewayStatus: null,
 					gatewayStatusDetail: null,
+					gatewayPaymentMethodId: null,
+					gatewayPaymentTypeId: null,
 					checkoutUrl: null,
 				}),
 				findFirst: jest.fn(),
@@ -233,6 +249,8 @@ describe('PrismaPaymentRepository', () => {
 					gatewayId: null,
 					gatewayStatus: null,
 					gatewayStatusDetail: null,
+					gatewayPaymentMethodId: null,
+					gatewayPaymentTypeId: null,
 					checkoutUrl: null,
 				}),
 				findFirst: jest.fn(),
@@ -265,6 +283,8 @@ describe('PrismaPaymentRepository', () => {
 					gatewayId: null,
 					gatewayStatus: null,
 					gatewayStatusDetail: null,
+					gatewayPaymentMethodId: null,
+					gatewayPaymentTypeId: null,
 					checkoutUrl: null,
 				}),
 				findFirst: jest.fn(),
@@ -276,5 +296,53 @@ describe('PrismaPaymentRepository', () => {
 		await expect(
 			repository.findById('payment-invalid-method-1'),
 		).rejects.toThrow('Invalid payment method persisted: pix');
+	});
+
+	it('uses a transaction-scoped advisory lock for stale checkout reconciliation', async () => {
+		const queryRaw = jest.fn().mockResolvedValue([{ locked: true }]);
+		const transaction = jest.fn(async (callback) =>
+			callback({ $queryRaw: queryRaw }),
+		);
+		const prisma = {
+			payment: {
+				findUnique: jest.fn(),
+				findFirst: jest.fn(),
+				upsert: jest.fn(),
+			},
+			$transaction: transaction,
+		};
+		const repository = new PrismaPaymentRepository(prisma as never);
+
+		await expect(
+			repository.withStaleCheckoutReconciliationLock(async () => 'ran'),
+		).resolves.toBe('ran');
+
+		expect(queryRaw).toHaveBeenCalled();
+		expect(transaction).toHaveBeenCalledWith(expect.any(Function), {
+			timeout: 120_000,
+		});
+	});
+
+	it('skips stale checkout reconciliation when the transaction lock is unavailable', async () => {
+		const queryRaw = jest.fn().mockResolvedValue([{ locked: false }]);
+		const transaction = jest.fn(async (callback) =>
+			callback({ $queryRaw: queryRaw }),
+		);
+		const prisma = {
+			payment: {
+				findUnique: jest.fn(),
+				findFirst: jest.fn(),
+				upsert: jest.fn(),
+			},
+			$transaction: transaction,
+		};
+		const repository = new PrismaPaymentRepository(prisma as never);
+		const callback = jest.fn();
+
+		await expect(
+			repository.withStaleCheckoutReconciliationLock(callback),
+		).resolves.toBeNull();
+
+		expect(callback).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/modules/payments/infrastructure/repositories/prisma-payment.repository.ts
+++ b/apps/api/src/modules/payments/infrastructure/repositories/prisma-payment.repository.ts
@@ -1,11 +1,14 @@
 import { PrismaService } from '@app/common/prisma/prisma.service';
-import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
+import type {
+	PaymentRepositoryPort,
+	StalePaymentReconciliationCandidate,
+} from '@modules/payments/application/ports/payment-repository.port';
 import { Payment } from '@modules/payments/domain/payment.entity';
 import { PaymentStatus } from '@modules/payments/domain/payment-status';
 import { Injectable } from '@nestjs/common';
 import { PaymentMethod } from '@packages/shared/payments/payment-method';
 import { ensurePersistedEnum } from '@packages/shared/utils/enum.utils';
-import { PaymentMethod as PrismaPaymentMethod } from '@prisma/client';
+import { Prisma, PaymentMethod as PrismaPaymentMethod } from '@prisma/client';
 
 type PaymentRecord = {
 	id: string;
@@ -19,6 +22,8 @@ type PaymentRecord = {
 	gatewayId: string | null;
 	gatewayStatus: string | null;
 	gatewayStatusDetail: string | null;
+	gatewayPaymentMethodId: string | null;
+	gatewayPaymentTypeId: string | null;
 	checkoutUrl: string | null;
 };
 
@@ -65,6 +70,15 @@ type PaymentDelegate = {
 					order: { clientId: string };
 			  };
 	}): Promise<PaymentRecord | null>;
+	findMany(args: {
+		where: {
+			status: string;
+			createdAt: { lt: Date };
+			order: { status: string };
+		};
+		orderBy: { createdAt: 'asc' };
+		take: number;
+	}): Promise<PaymentRecord[]>;
 	upsert(args: {
 		where: { id: string };
 		create: PaymentRecord;
@@ -74,7 +88,15 @@ type PaymentDelegate = {
 
 type PaymentPrismaClient = {
 	payment: PaymentDelegate;
+	$transaction<T>(
+		callback: (transaction: {
+			$queryRaw<TQuery = unknown>(query: Prisma.Sql): Promise<TQuery>;
+		}) => Promise<T>,
+		options?: { timeout?: number },
+	): Promise<T>;
 };
+
+const STALE_CHECKOUT_RECONCILIATION_LOCK_ID = 911_984_301;
 
 @Injectable()
 export class PrismaPaymentRepository implements PaymentRepositoryPort {
@@ -133,6 +155,43 @@ export class PrismaPaymentRepository implements PaymentRepositoryPort {
 		return this.mapRecordToDomain(record);
 	}
 
+	async findStaleAwaitingCheckoutCandidates(input: {
+		createdBefore: Date;
+		limit: number;
+	}): Promise<StalePaymentReconciliationCandidate[]> {
+		const records = await this.getDelegate().findMany({
+			where: {
+				status: PaymentStatus.AWAITING_CONFIRMATION,
+				createdAt: { lt: input.createdBefore },
+				order: { status: 'awaiting_payment' },
+			},
+			orderBy: { createdAt: 'asc' },
+			take: input.limit,
+		});
+
+		return records.map((record) => ({
+			payment: this.mapRecordToDomain(record),
+		}));
+	}
+
+	async withStaleCheckoutReconciliationLock<T>(
+		callback: () => Promise<T>,
+	): Promise<T | null> {
+		return await this.getClient().$transaction(
+			async (transaction) => {
+				const [{ locked }] = await transaction.$queryRaw<
+					Array<{ locked: boolean }>
+				>(
+					Prisma.sql`SELECT pg_try_advisory_xact_lock(${STALE_CHECKOUT_RECONCILIATION_LOCK_ID}) AS locked`,
+				);
+				if (!locked) return null;
+
+				return await callback();
+			},
+			{ timeout: 120_000 },
+		);
+	}
+
 	async save(payment: Payment): Promise<void> {
 		await this.getDelegate().upsert({
 			where: { id: payment.id },
@@ -148,6 +207,8 @@ export class PrismaPaymentRepository implements PaymentRepositoryPort {
 				gatewayId: payment.gatewayId,
 				gatewayStatus: payment.gatewayStatus,
 				gatewayStatusDetail: payment.gatewayStatusDetail,
+				gatewayPaymentMethodId: payment.gatewayPaymentMethodId,
+				gatewayPaymentTypeId: payment.gatewayPaymentTypeId,
 				checkoutUrl: payment.checkoutUrl,
 			},
 			update: {
@@ -160,6 +221,8 @@ export class PrismaPaymentRepository implements PaymentRepositoryPort {
 				gatewayId: payment.gatewayId,
 				gatewayStatus: payment.gatewayStatus,
 				gatewayStatusDetail: payment.gatewayStatusDetail,
+				gatewayPaymentMethodId: payment.gatewayPaymentMethodId,
+				gatewayPaymentTypeId: payment.gatewayPaymentTypeId,
 				checkoutUrl: payment.checkoutUrl,
 			},
 		});
@@ -180,6 +243,8 @@ export class PrismaPaymentRepository implements PaymentRepositoryPort {
 			gatewayId: record.gatewayId,
 			gatewayStatus: record.gatewayStatus,
 			gatewayStatusDetail: record.gatewayStatusDetail,
+			gatewayPaymentMethodId: record.gatewayPaymentMethodId,
+			gatewayPaymentTypeId: record.gatewayPaymentTypeId,
 			checkoutUrl: record.checkoutUrl,
 			grossAmount: record.grossAmount,
 			boosterAmount: record.boosterAmount,
@@ -193,6 +258,10 @@ export class PrismaPaymentRepository implements PaymentRepositoryPort {
 	}
 
 	private getDelegate(): PaymentDelegate {
-		return (this.prisma as unknown as PaymentPrismaClient).payment;
+		return this.getClient().payment;
+	}
+
+	private getClient(): PaymentPrismaClient {
+		return this.prisma as unknown as PaymentPrismaClient;
 	}
 }

--- a/apps/api/src/modules/payments/payments.module.ts
+++ b/apps/api/src/modules/payments/payments.module.ts
@@ -17,6 +17,7 @@ import { CreatePaymentUseCase } from '@modules/payments/application/use-cases/cr
 import { FailPaymentUseCase } from '@modules/payments/application/use-cases/fail-payment/fail-payment.use-case';
 import { GetPaymentUseCase } from '@modules/payments/application/use-cases/get-payment/get-payment.use-case';
 import { HandlePaymentConfirmedWebhookUseCase } from '@modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case';
+import { ReconcileStaleCheckoutsUseCase } from '@modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case';
 import { ReleasePaymentHoldUseCase } from '@modules/payments/application/use-cases/release-payment-hold/release-payment-hold.use-case';
 import { ResumePaymentCheckoutUseCase } from '@modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case';
 import { SimulateDevPaymentOutcomeUseCase } from '@modules/payments/application/use-cases/simulate-dev-payment-outcome/simulate-dev-payment-outcome.use-case';
@@ -139,6 +140,7 @@ import { MERCADO_PAGO_SDK_PORT_KEY } from '@packages/integrations/mercadopago/me
 		HandlePaymentConfirmedWebhookUseCase,
 		PaymentLifecycleLogger,
 		ReleasePaymentHoldUseCase,
+		ReconcileStaleCheckoutsUseCase,
 		ResumePaymentCheckoutUseCase,
 		SimulateDevPaymentOutcomeUseCase,
 		StartCheckoutUseCase,

--- a/apps/api/src/modules/payments/presentation/payments.controller.ts
+++ b/apps/api/src/modules/payments/presentation/payments.controller.ts
@@ -13,6 +13,7 @@ import { CreatePaymentUseCase } from '@modules/payments/application/use-cases/cr
 import { FailPaymentUseCase } from '@modules/payments/application/use-cases/fail-payment/fail-payment.use-case';
 import { GetPaymentUseCase } from '@modules/payments/application/use-cases/get-payment/get-payment.use-case';
 import { HandlePaymentConfirmedWebhookUseCase } from '@modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case';
+import { ReconcileStaleCheckoutsUseCase } from '@modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case';
 import { ReleasePaymentHoldUseCase } from '@modules/payments/application/use-cases/release-payment-hold/release-payment-hold.use-case';
 import { ResumePaymentCheckoutUseCase } from '@modules/payments/application/use-cases/resume-payment-checkout/resume-payment-checkout.use-case';
 import { SimulateDevPaymentOutcomeUseCase } from '@modules/payments/application/use-cases/simulate-dev-payment-outcome/simulate-dev-payment-outcome.use-case';
@@ -39,6 +40,8 @@ import {
 	orderIdParamSchema,
 	type PaymentIdParamSchemaInput,
 	paymentIdParamSchema,
+	type ReconcileStaleCheckoutsSchemaInput,
+	reconcileStaleCheckoutsSchema,
 	type SimulateDevPaymentOutcomeSchemaInput,
 	type StartCheckoutSchemaInput,
 	simulateDevPaymentOutcomeSchema,
@@ -54,6 +57,7 @@ export class PaymentsController {
 		private readonly failPaymentUseCase: FailPaymentUseCase,
 		private readonly handlePaymentConfirmedWebhookUseCase: HandlePaymentConfirmedWebhookUseCase,
 		private readonly releasePaymentHoldUseCase: ReleasePaymentHoldUseCase,
+		private readonly reconcileStaleCheckoutsUseCase: ReconcileStaleCheckoutsUseCase,
 		private readonly resumePaymentCheckoutUseCase: ResumePaymentCheckoutUseCase,
 		private readonly simulateDevPaymentOutcomeUseCase: SimulateDevPaymentOutcomeUseCase,
 		private readonly startCheckoutUseCase: StartCheckoutUseCase,
@@ -210,6 +214,28 @@ export class PaymentsController {
 	): Promise<{ success: true }> {
 		await this.releasePaymentHoldUseCase.execute({ paymentId });
 		return { success: true };
+	}
+
+	@Post('internal/reconcile-stale-checkouts')
+	@UseGuards(InternalApiKeyGuard)
+	@HttpCode(200)
+	async reconcileStaleCheckouts(
+		@Body(new ZodValidationPipe(reconcileStaleCheckoutsSchema))
+		body: ReconcileStaleCheckoutsSchemaInput,
+	): Promise<{
+		skipped: boolean;
+		reason?: 'lock_unavailable';
+		scannedCount: number;
+		confirmedCount: number;
+		failedCount: number;
+		pendingUpdatedCount: number;
+		skippedCount: number;
+		gatewayErrorCount: number;
+	}> {
+		return await this.reconcileStaleCheckoutsUseCase.execute({
+			now: body.now ? new Date(body.now) : new Date(),
+			limit: body.limit,
+		});
 	}
 
 	@Post('dev/:paymentId/simulate')

--- a/apps/api/src/modules/payments/presentation/payments.request-schemas.ts
+++ b/apps/api/src/modules/payments/presentation/payments.request-schemas.ts
@@ -19,6 +19,18 @@ export const startCheckoutSchema = z.object({
 
 export type StartCheckoutSchemaInput = z.infer<typeof startCheckoutSchema>;
 
+export const reconcileStaleCheckoutsSchema = z.preprocess(
+	(value) => value ?? {},
+	z.object({
+		now: z.string().datetime({ offset: true }).optional(),
+		limit: z.number().int().min(1).max(500).default(50),
+	}),
+);
+
+export type ReconcileStaleCheckoutsSchemaInput = z.infer<
+	typeof reconcileStaleCheckoutsSchema
+>;
+
 export const mercadoPagoWebhookSchema = z.object({
 	action: z.string().trim().min(1),
 	data: z.object({

--- a/apps/api/test/integration-db/payments/payments.db.integration.spec.ts
+++ b/apps/api/test/integration-db/payments/payments.db.integration.spec.ts
@@ -21,6 +21,7 @@ describe('Payments module integration (db)', () => {
 	let mercadoPagoSdkMock: {
 		createPayment: jest.Mock;
 		fetchPaymentNotification: jest.Mock;
+		fetchPaymentByExternalReference: jest.Mock;
 		verifyWebhookSignature: jest.Mock;
 	};
 
@@ -95,6 +96,16 @@ describe('Payments module integration (db)', () => {
 				gatewayPaymentId: `mp-${notificationId}`,
 				gatewayStatus: 'approved',
 				gatewayStatusDetail: 'accredited',
+				gatewayPaymentMethodId: 'pix',
+				gatewayPaymentTypeId: 'bank_transfer',
+			})),
+			fetchPaymentByExternalReference: jest.fn(async (externalReference) => ({
+				internalPaymentId: externalReference,
+				gatewayPaymentId: `mp-${externalReference}`,
+				gatewayStatus: 'approved',
+				gatewayStatusDetail: 'accredited',
+				gatewayPaymentMethodId: 'pix',
+				gatewayPaymentTypeId: 'bank_transfer',
 			})),
 			verifyWebhookSignature: jest.fn().mockResolvedValue(true),
 		};

--- a/apps/api/test/integration/payments/mercadopago-sdk.integration.spec.ts
+++ b/apps/api/test/integration/payments/mercadopago-sdk.integration.spec.ts
@@ -119,6 +119,8 @@ describe('MercadoPagoSdkAdapter', () => {
 					status: 'approved',
 					status_detail: 'accredited',
 					external_reference: 'payment-1',
+					payment_method_id: 'pix',
+					payment_type_id: 'bank_transfer',
 				}),
 			},
 		});
@@ -132,6 +134,96 @@ describe('MercadoPagoSdkAdapter', () => {
 			gatewayPaymentId: '123',
 			gatewayStatus: 'approved',
 			gatewayStatusDetail: 'accredited',
+			gatewayPaymentMethodId: 'pix',
+			gatewayPaymentTypeId: 'bank_transfer',
+		});
+	});
+
+	it('searches a payment by external reference for stale reconciliation', async () => {
+		const search = jest.fn().mockResolvedValue({
+			results: [
+				{
+					id: 456,
+					status: 'pending',
+					status_detail: 'pending_waiting_transfer',
+					external_reference: 'payment-search',
+					payment_method_id: 'pix',
+					payment_type_id: 'bank_transfer',
+				},
+			],
+		});
+		const adapter = new MercadoPagoSdkAdapter({
+			accessToken: 'mp-access-token',
+			webhookSecret: 'webhook-secret',
+			webhookUrl: 'https://example.com/payments/webhooks/mercadopago',
+			webAppUrl: 'https://app.elonew.test',
+			preferenceClient: {
+				create: jest.fn(),
+			},
+			paymentClient: {
+				get: jest.fn(),
+				search,
+			},
+		});
+
+		await expect(
+			adapter.fetchPaymentByExternalReference('payment-search'),
+		).resolves.toEqual({
+			internalPaymentId: 'payment-search',
+			gatewayPaymentId: '456',
+			gatewayStatus: 'pending',
+			gatewayStatusDetail: 'pending_waiting_transfer',
+			gatewayPaymentMethodId: 'pix',
+			gatewayPaymentTypeId: 'bank_transfer',
+		});
+		expect(search).toHaveBeenCalledWith({
+			options: {
+				external_reference: 'payment-search',
+				limit: 10,
+			},
+		});
+	});
+
+	it('prefers an approved searched payment over older pending attempts', async () => {
+		const search = jest.fn().mockResolvedValue({
+			results: [
+				{
+					id: 456,
+					status: 'pending',
+					status_detail: 'pending_waiting_transfer',
+					external_reference: 'payment-search',
+					date_last_updated: '2026-07-09T17:10:00.000Z',
+				},
+				{
+					id: 789,
+					status: 'approved',
+					status_detail: 'accredited',
+					external_reference: 'payment-search',
+					payment_method_id: 'pix',
+					payment_type_id: 'bank_transfer',
+					date_approved: '2026-07-09T17:00:00.000Z',
+				},
+			],
+		});
+		const adapter = new MercadoPagoSdkAdapter({
+			accessToken: 'mp-access-token',
+			webhookSecret: 'webhook-secret',
+			webhookUrl: 'https://example.com/payments/webhooks/mercadopago',
+			webAppUrl: 'https://app.elonew.test',
+			preferenceClient: {
+				create: jest.fn(),
+			},
+			paymentClient: {
+				get: jest.fn(),
+				search,
+			},
+		});
+
+		await expect(
+			adapter.fetchPaymentByExternalReference('payment-search'),
+		).resolves.toMatchObject({
+			gatewayPaymentId: '789',
+			gatewayStatus: 'approved',
 		});
 	});
 

--- a/apps/api/test/integration/payments/payments.integration.spec.ts
+++ b/apps/api/test/integration/payments/payments.integration.spec.ts
@@ -37,6 +37,7 @@ describe('Payments module integration', () => {
 	let mercadoPagoSdkMock: {
 		createPayment: jest.Mock;
 		fetchPaymentNotification: jest.Mock;
+		fetchPaymentByExternalReference: jest.Mock;
 		verifyWebhookSignature: jest.Mock;
 	};
 	const clientUser: AuthenticatedUser = {
@@ -93,6 +94,16 @@ describe('Payments module integration', () => {
 				gatewayPaymentId: `mp-${notificationId}`,
 				gatewayStatus: 'approved',
 				gatewayStatusDetail: 'accredited',
+				gatewayPaymentMethodId: 'pix',
+				gatewayPaymentTypeId: 'bank_transfer',
+			})),
+			fetchPaymentByExternalReference: jest.fn(async (externalReference) => ({
+				internalPaymentId: externalReference,
+				gatewayPaymentId: `mp-${externalReference}`,
+				gatewayStatus: 'approved',
+				gatewayStatusDetail: 'accredited',
+				gatewayPaymentMethodId: 'pix',
+				gatewayPaymentTypeId: 'bank_transfer',
 			})),
 			verifyWebhookSignature: jest.fn().mockResolvedValue(true),
 		};
@@ -121,6 +132,9 @@ describe('Payments module integration', () => {
 				),
 				fetchPaymentNotification: jest.fn((input) =>
 					mercadoPagoSdkMock.fetchPaymentNotification(input),
+				),
+				fetchPaymentByExternalReference: jest.fn((externalReference) =>
+					mercadoPagoSdkMock.fetchPaymentByExternalReference(externalReference),
 				),
 			})
 			.overrideProvider(ORDER_STATUS_PORT_KEY)

--- a/apps/api/test/payments.e2e-spec.ts
+++ b/apps/api/test/payments.e2e-spec.ts
@@ -37,6 +37,7 @@ describe('Payments (e2e)', () => {
 	let mercadoPagoSdkMock: {
 		createPayment: jest.Mock;
 		fetchPaymentNotification: jest.Mock;
+		fetchPaymentByExternalReference: jest.Mock;
 		verifyWebhookSignature: jest.Mock;
 	};
 	const testInternalApiKey =
@@ -101,6 +102,16 @@ describe('Payments (e2e)', () => {
 				gatewayPaymentId: `mp-${notificationId}`,
 				gatewayStatus: 'approved',
 				gatewayStatusDetail: 'accredited',
+				gatewayPaymentMethodId: 'pix',
+				gatewayPaymentTypeId: 'bank_transfer',
+			})),
+			fetchPaymentByExternalReference: jest.fn(async (externalReference) => ({
+				internalPaymentId: externalReference,
+				gatewayPaymentId: `mp-${externalReference}`,
+				gatewayStatus: 'approved',
+				gatewayStatusDetail: 'accredited',
+				gatewayPaymentMethodId: 'pix',
+				gatewayPaymentTypeId: 'bank_transfer',
 			})),
 			verifyWebhookSignature: jest.fn(async ({ signature }) => {
 				return signature === validWebhookSignature;
@@ -488,6 +499,8 @@ describe('Payments (e2e)', () => {
 			gatewayPaymentId: `mp-${paymentId}`,
 			gatewayStatus: 'authorized',
 			gatewayStatusDetail: 'pending_capture',
+			gatewayPaymentMethodId: 'credit_card',
+			gatewayPaymentTypeId: 'credit_card',
 		});
 
 		await requestHttp(app)
@@ -516,6 +529,81 @@ describe('Payments (e2e)', () => {
 			.execute();
 	});
 
+	it('reconciles stale checkouts through the internal endpoint', async () => {
+		const token = signToken({ sub: 'client-reconcile', role: 'CLIENT' });
+		const createdOrder = await createQuotedOrder(token);
+		let paymentId = '';
+
+		await requestHttp(app)
+			.post('/payments')
+			.set('Authorization', `Bearer ${token}`)
+			.send({
+				orderId: createdOrder.id,
+				paymentMethod: 'pix',
+			})
+			.expect(201)
+			.expect<{ id: string }>(({ body }) => {
+				paymentId = body.id;
+			})
+			.execute();
+
+		mercadoPagoSdkMock.fetchPaymentByExternalReference.mockResolvedValueOnce({
+			internalPaymentId: paymentId,
+			gatewayPaymentId: `mp-${paymentId}`,
+			gatewayStatus: 'approved',
+			gatewayStatusDetail: 'accredited',
+			gatewayPaymentMethodId: 'pix',
+			gatewayPaymentTypeId: 'bank_transfer',
+		});
+
+		await requestHttp(app)
+			.post('/payments/internal/reconcile-stale-checkouts')
+			.set('x-internal-api-key', testInternalApiKey)
+			.send({
+				now: '2026-07-09T18:00:00.000Z',
+				limit: 50,
+			})
+			.expect(200)
+			.expect(({ body }) => {
+				expect(body).toMatchObject({
+					skipped: false,
+					scannedCount: 1,
+					confirmedCount: 1,
+					failedCount: 0,
+					pendingUpdatedCount: 0,
+					skippedCount: 0,
+					gatewayErrorCount: 0,
+				});
+			})
+			.execute();
+
+		await requestHttp(app)
+			.get(`/payments/${paymentId}`)
+			.set('Authorization', `Bearer ${token}`)
+			.expect(200)
+			.expect(({ body }) => {
+				expect(body).toMatchObject({
+					id: paymentId,
+					status: 'held',
+				});
+			})
+			.execute();
+	});
+
+	it('rejects stale checkout reconciliation without the internal API key', async () => {
+		await requestHttp(app)
+			.post('/payments/internal/reconcile-stale-checkouts')
+			.send({
+				now: '2026-07-09T18:00:00.000Z',
+			})
+			.expect(401, {
+				message: 'Internal API key required.',
+				error: 'Unauthorized',
+				statusCode: 401,
+			})
+			.execute();
+	});
+
 	it('fails payments for rejected webhook statuses', async () => {
 		const token = signToken({ sub: 'client-webhook-rejected', role: 'CLIENT' });
 		const createdOrder = await createQuotedOrder(token);
@@ -539,6 +627,8 @@ describe('Payments (e2e)', () => {
 			gatewayPaymentId: `mp-${paymentId}`,
 			gatewayStatus: 'rejected',
 			gatewayStatusDetail: 'cc_rejected_bad_filled_security_code',
+			gatewayPaymentMethodId: 'credit_card',
+			gatewayPaymentTypeId: 'credit_card',
 		});
 
 		await requestHttp(app)

--- a/apps/api/test/support/in-memory/payments/in-memory-payment.repository.ts
+++ b/apps/api/test/support/in-memory/payments/in-memory-payment.repository.ts
@@ -10,6 +10,8 @@ import { Inject, Injectable, Optional } from '@nestjs/common';
 @Injectable()
 export class InMemoryPaymentRepository implements PaymentRepositoryPort {
 	private readonly payments = new Map<string, Payment>();
+	private readonly clientIds = new Map<string, string>();
+	private readonly failOnSavePaymentIds = new Set<string>();
 
 	constructor(
 		@Optional()
@@ -27,6 +29,8 @@ export class InMemoryPaymentRepository implements PaymentRepositoryPort {
 	): Promise<Payment | null> {
 		const payment = await this.findById(id);
 		if (!payment) return null;
+		const ownerId = this.clientIds.get(payment.id);
+		if (ownerId !== undefined) return ownerId === clientId ? payment : null;
 		if (!this.orderRepository) return payment;
 
 		const order = await this.orderRepository.findByIdForClient(
@@ -52,6 +56,8 @@ export class InMemoryPaymentRepository implements PaymentRepositoryPort {
 	): Promise<Payment | null> {
 		const payment = await this.findByOrderId(orderId);
 		if (!payment) return null;
+		const ownerId = this.clientIds.get(payment.id);
+		if (ownerId !== undefined) return ownerId === clientId ? payment : null;
 		if (!this.orderRepository) return payment;
 
 		const order = await this.orderRepository.findByIdForClient(
@@ -94,7 +100,19 @@ export class InMemoryPaymentRepository implements PaymentRepositoryPort {
 	}
 
 	save(payment: Payment): Promise<void> {
+		if (this.failOnSavePaymentIds.has(payment.id))
+			return Promise.reject(new Error('Payment save failed.'));
+
 		this.payments.set(payment.id, payment);
 		return Promise.resolve();
+	}
+
+	insert(payment: Payment, clientId?: string): void {
+		this.payments.set(payment.id, payment);
+		if (clientId !== undefined) this.clientIds.set(payment.id, clientId);
+	}
+
+	setFailOnSave(paymentId: string): void {
+		this.failOnSavePaymentIds.add(paymentId);
 	}
 }

--- a/apps/api/test/support/in-memory/payments/in-memory-payment.repository.ts
+++ b/apps/api/test/support/in-memory/payments/in-memory-payment.repository.ts
@@ -4,6 +4,7 @@ import {
 } from '@modules/orders/application/ports/order-repository.port';
 import type { PaymentRepositoryPort } from '@modules/payments/application/ports/payment-repository.port';
 import type { Payment } from '@modules/payments/domain/payment.entity';
+import { PaymentStatus } from '@modules/payments/domain/payment-status';
 import { Inject, Injectable, Optional } from '@nestjs/common';
 
 @Injectable()
@@ -68,6 +69,28 @@ export class InMemoryPaymentRepository implements PaymentRepositoryPort {
 		}
 
 		return Promise.resolve(null);
+	}
+
+	async findStaleAwaitingCheckoutCandidates(): Promise<
+		Array<{ payment: Payment }>
+	> {
+		const candidates: Array<{ payment: Payment }> = [];
+		for (const payment of this.payments.values()) {
+			if (payment.status !== PaymentStatus.AWAITING_CONFIRMATION) continue;
+			if (this.orderRepository) {
+				const order = await this.orderRepository.findById(payment.orderId);
+				if (!order || order.status !== 'awaiting_payment') continue;
+			}
+			candidates.push({ payment });
+		}
+
+		return candidates;
+	}
+
+	async withStaleCheckoutReconciliationLock<T>(
+		callback: () => Promise<T>,
+	): Promise<T | null> {
+		return await callback();
 	}
 
 	save(payment: Payment): Promise<void> {

--- a/packages/database/prisma/migrations/20260709193000_add_payment_provider_metadata/migration.sql
+++ b/packages/database/prisma/migrations/20260709193000_add_payment_provider_metadata/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "payments"
+ADD COLUMN "gatewayPaymentMethodId" TEXT,
+ADD COLUMN "gatewayPaymentTypeId" TEXT;
+
+CREATE INDEX "payments_status_createdAt_idx" ON "payments"("status", "createdAt");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -277,11 +277,14 @@ model Payment {
   gatewayId     String?       @unique
   gatewayStatus String?
   gatewayStatusDetail String?
+  gatewayPaymentMethodId String?
+  gatewayPaymentTypeId String?
   checkoutUrl   String?
   createdAt     DateTime      @default(now())
   updatedAt     DateTime      @updatedAt
 
   @@index([orderId])
+  @@index([status, createdAt])
   @@map("payments")
 }
 

--- a/packages/integrations/src/mercadopago/mercadopago-sdk.adapter.ts
+++ b/packages/integrations/src/mercadopago/mercadopago-sdk.adapter.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { MercadoPagoConfig, Payment, Preference } from 'mercadopago';
 import type { PaymentResponse } from 'mercadopago/dist/clients/payment/commonTypes';
+import type { PaymentSearchResult } from 'mercadopago/dist/clients/payment/search/types';
 import type { PreferenceResponse } from 'mercadopago/dist/clients/preference/commonTypes';
 import type {
 	MercadoPagoCreatePaymentInput,
@@ -34,6 +35,12 @@ type MercadoPagoPreferenceClient = {
 
 type MercadoPagoPaymentClient = {
 	get(input: { id: string }): Promise<PaymentResponse>;
+	search?(input: {
+		options: {
+			external_reference: string;
+			limit: number;
+		};
+	}): Promise<{ results?: PaymentSearchResult[] }>;
 };
 
 export class MercadoPagoSdkAdapter implements MercadoPagoSdkPort {
@@ -114,15 +121,26 @@ export class MercadoPagoSdkAdapter implements MercadoPagoSdkPort {
 		const response = await this.paymentClient.get({
 			id: input.notificationId,
 		});
-		if (!response.id || !response.status)
-			throw new Error('Mercado Pago payment response is invalid.');
 
-		return {
-			internalPaymentId: response.external_reference?.trim() ?? '',
-			gatewayPaymentId: String(response.id),
-			gatewayStatus: response.status,
-			gatewayStatusDetail: response.status_detail ?? null,
-		};
+		return this.mapPaymentResponse(response);
+	}
+
+	async fetchPaymentByExternalReference(
+		externalReference: string,
+	): Promise<MercadoPagoFetchPaymentNotificationOutput | null> {
+		if (!this.paymentClient.search)
+			throw new Error('Mercado Pago payment search is unavailable.');
+
+		const response = await this.paymentClient.search({
+			options: {
+				external_reference: externalReference,
+				limit: 10,
+			},
+		});
+		const payment = this.selectPaymentSearchResult(response.results ?? []);
+		if (!payment) return null;
+
+		return this.mapPaymentResponse(payment);
 	}
 
 	async verifyWebhookSignature(input: {
@@ -162,5 +180,77 @@ export class MercadoPagoSdkAdapter implements MercadoPagoSdkPort {
 		}
 
 		return null;
+	}
+
+	private mapPaymentResponse(
+		response: PaymentResponse | PaymentSearchResult,
+	): MercadoPagoFetchPaymentNotificationOutput {
+		if (!response.id || !response.status)
+			throw new Error('Mercado Pago payment response is invalid.');
+
+		return {
+			internalPaymentId: response.external_reference?.trim() ?? '',
+			gatewayPaymentId: String(response.id),
+			gatewayStatus: response.status,
+			gatewayStatusDetail: response.status_detail ?? null,
+			gatewayPaymentMethodId: this.nullableString(
+				(response as { payment_method_id?: unknown }).payment_method_id,
+			),
+			gatewayPaymentTypeId: this.nullableString(
+				(response as { payment_type_id?: unknown }).payment_type_id,
+			),
+		};
+	}
+
+	private nullableString(value: unknown): string | null {
+		return typeof value === 'string' && value.trim() ? value.trim() : null;
+	}
+
+	private selectPaymentSearchResult(
+		results: PaymentSearchResult[],
+	): PaymentSearchResult | null {
+		return (
+			[...results].sort(
+				(left, right) =>
+					this.paymentSearchRank(right) - this.paymentSearchRank(left) ||
+					this.paymentSearchTimestamp(right) -
+						this.paymentSearchTimestamp(left) ||
+					String(right.id ?? '').localeCompare(String(left.id ?? '')),
+			)[0] ?? null
+		);
+	}
+
+	private paymentSearchRank(payment: PaymentSearchResult): number {
+		switch (payment.status) {
+			case 'approved':
+				return 3;
+			case 'authorized':
+			case 'pending':
+			case 'in_process':
+				return 2;
+			case 'rejected':
+			case 'cancelled':
+				return 1;
+			default:
+				return 0;
+		}
+	}
+
+	private paymentSearchTimestamp(payment: PaymentSearchResult): number {
+		const record = payment as {
+			date_approved?: unknown;
+			date_last_updated?: unknown;
+			date_created?: unknown;
+		};
+		for (const value of [
+			record.date_approved,
+			record.date_last_updated,
+			record.date_created,
+		]) {
+			if (typeof value !== 'string') continue;
+			const timestamp = Date.parse(value);
+			if (!Number.isNaN(timestamp)) return timestamp;
+		}
+		return 0;
 	}
 }

--- a/packages/integrations/src/mercadopago/mercadopago-sdk.port.ts
+++ b/packages/integrations/src/mercadopago/mercadopago-sdk.port.ts
@@ -23,6 +23,8 @@ export type MercadoPagoFetchPaymentNotificationOutput = {
 	gatewayPaymentId: string;
 	gatewayStatus: string;
 	gatewayStatusDetail: string | null;
+	gatewayPaymentMethodId: string | null;
+	gatewayPaymentTypeId: string | null;
 };
 
 export type MercadoPagoWebhookPayload = {
@@ -38,6 +40,9 @@ export interface MercadoPagoSdkPort {
 	fetchPaymentNotification(
 		input: MercadoPagoFetchPaymentNotificationInput,
 	): Promise<MercadoPagoFetchPaymentNotificationOutput>;
+	fetchPaymentByExternalReference(
+		externalReference: string,
+	): Promise<MercadoPagoFetchPaymentNotificationOutput | null>;
 	verifyWebhookSignature(input: {
 		payload: MercadoPagoWebhookPayload;
 		signature?: string;


### PR DESCRIPTION
## Summary

Payments could get stuck in `AWAITING_CONFIRMATION` forever when the Mercado Pago webhook never arrived (or arrived while the checkout was abandoned). This adds a reconciliation sweep plus the provider metadata needed to resolve it:

- New internal endpoint `POST payments/internal/reconcile-stale-checkouts` (guarded by `InternalApiKeyGuard`, intended to be called by the VPS cron only). It scans payments stuck in `AWAITING_CONFIRMATION` for 15+ minutes, fetches their current status from Mercado Pago, and confirms, fails, or refreshes them. An advisory lock makes concurrent runs skip instead of double-processing.
- Mercado Pago SDK adapter can now search a payment by `external_reference` (our internal payment id), covering payments that never received a gateway id.
- `Payment` records `gatewayPaymentMethodId` / `gatewayPaymentTypeId` from the provider (new columns + migration), populated by both the webhook and reconciliation paths.

In local dev with the dev gateway, the endpoint is a harmless no-op (nothing calls it, and the dev gateway rejects provider fetches).

Closes: none — groundwork for #98; also starts recording the actual provider payment method (#86).

## Verification

```text
cd apps/api
npx jest "src/modules/payments/.*\.spec\.ts$" --runInBand          # 93 passed
npx jest "test/integration/payments/.*\.integration\.spec\.ts$" --runInBand  # 19 passed
npx biome check apps/api/src/modules/payments apps/api/test packages/integrations/src/mercadopago
```

Skipped checks and remaining risk: `test/integration-db` and e2e suites (need the database up) were updated but not run locally — CI covers them. The VPS cron that calls the endpoint is not part of this PR; until it's scheduled, reconciliation never runs.

## Screenshots

None.

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)