### PR TITLE
fix(api): handle late Mercado Pago approvals after internal expiration

### DIFF
--- a/apps/api/src/modules/admin/application/ports/admin-governance.repository.ts
+++ b/apps/api/src/modules/admin/application/ports/admin-governance.repository.ts
@@ -9,7 +9,8 @@ export type AdminGovernanceActionType =
 	| 'USER_CREATE'
 	| 'USER_BLOCK'
 	| 'USER_UNBLOCK'
-	| 'ORDER_FORCE_CANCEL';
+	| 'ORDER_FORCE_CANCEL'
+	| 'PAYMENT_LATE_APPROVAL';
 
 export type AdminGovernanceActionInput = {
 	adminUserId: string;

--- a/apps/api/src/modules/payments/application/logging/payment-lifecycle.logger.ts
+++ b/apps/api/src/modules/payments/application/logging/payment-lifecycle.logger.ts
@@ -13,7 +13,7 @@ export type PaymentLifecycleLogEvent = {
 		| 'simulate_dev_outcome'
 		| 'mercadopago_webhook'
 		| 'reconcile_stale_checkout';
-	outcome?: 'success' | 'error' | 'skipped';
+	outcome?: 'success' | 'error' | 'skipped' | 'late_approved_after_expiration';
 	duration_ms?: number;
 	client_id?: string;
 	order_id?: string;
@@ -46,6 +46,7 @@ export type PaymentLifecycleLogEvent = {
 	failed_count?: number;
 	pending_updated_count?: number;
 	skipped_count?: number;
+	expired_count?: number;
 	gateway_error_count?: number;
 	error_type?: string;
 	error_message?: string;

--- a/apps/api/src/modules/payments/application/ports/payment-governance-action.port.ts
+++ b/apps/api/src/modules/payments/application/ports/payment-governance-action.port.ts
@@ -1,0 +1,10 @@
+export const PAYMENT_GOVERNANCE_ACTION_PORT_KEY = Symbol(
+	'PAYMENT_GOVERNANCE_ACTION_PORT_KEY',
+);
+
+export interface PaymentGovernanceActionPort {
+	recordLateApprovedAfterExpiration(input: {
+		paymentId: string;
+		orderId: string;
+	}): Promise<void>;
+}

--- a/apps/api/src/modules/payments/application/ports/payment-repository.port.ts
+++ b/apps/api/src/modules/payments/application/ports/payment-repository.port.ts
@@ -4,6 +4,7 @@ export const PAYMENT_REPOSITORY_KEY = Symbol('PAYMENT_REPOSITORY_KEY');
 
 export type StalePaymentReconciliationCandidate = {
 	payment: Payment;
+	createdAt: Date;
 };
 
 export interface PaymentRepositoryPort {

--- a/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.spec.ts
@@ -4,6 +4,7 @@ import type {
 	FetchPaymentNotificationOutput,
 	PaymentGatewayPort,
 } from '@modules/payments/application/ports/payment-gateway.port';
+import type { PaymentGovernanceActionPort } from '@modules/payments/application/ports/payment-governance-action.port';
 import type { PaymentWebhookSignatureVerifierPort } from '@modules/payments/application/ports/payment-webhook-signature-verifier.port';
 import type { ProcessedWebhookEventPort } from '@modules/payments/application/ports/processed-webhook-event.port';
 import { HandlePaymentConfirmedWebhookUseCase } from '@modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case';
@@ -25,6 +26,19 @@ class InMemoryProcessedWebhookEventPort implements ProcessedWebhookEventPort {
 
 	async markProcessed(eventId: string): Promise<void> {
 		this.processedEventIds.add(eventId);
+	}
+}
+
+class InMemoryPaymentGovernanceActionPort
+	implements PaymentGovernanceActionPort
+{
+	readonly recorded: Array<{ paymentId: string; orderId: string }> = [];
+
+	async recordLateApprovedAfterExpiration(input: {
+		paymentId: string;
+		orderId: string;
+	}): Promise<void> {
+		this.recorded.push(input);
 	}
 }
 
@@ -127,6 +141,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -172,6 +187,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 		paymentGatewayPort.notification = {
 			internalPaymentId: 'payment-2',
@@ -224,6 +240,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 		paymentGatewayPort.notification = {
 			internalPaymentId: 'payment-2b',
@@ -277,6 +294,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 		paymentGatewayPort.notification = {
 			internalPaymentId: 'payment-2c',
@@ -328,6 +346,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -374,6 +393,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -418,6 +438,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -460,6 +481,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			rejectingVerifier,
 			new InMemoryPaymentGatewayPort(),
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -490,6 +512,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -538,6 +561,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -587,6 +611,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await useCase.execute({
@@ -653,6 +678,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			orderCredentialCleanupPort,
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -702,6 +728,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			orderCredentialCleanupPort,
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -748,6 +775,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -785,6 +813,7 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 			new InMemoryOrderCredentialCleanupPort(),
 			new AcceptAllPaymentWebhookSignatureVerifier(),
 			paymentGatewayPort,
+			new InMemoryPaymentGovernanceActionPort(),
 		);
 
 		await expect(
@@ -799,5 +828,72 @@ describe('HandlePaymentConfirmedWebhookUseCase', () => {
 		await expect(
 			processedWebhookEventPort.has(processedWebhookKey('notification-9')),
 		).resolves.toBe(false);
+	});
+
+	it('acknowledges a late approval on a failed payment without touching the order', async () => {
+		const paymentRepository = new InMemoryPaymentRepository();
+		const processedWebhookEventPort = new InMemoryProcessedWebhookEventPort();
+		const orderPaymentConfirmationPort =
+			new InMemoryOrderPaymentConfirmationPort();
+		const paymentGatewayPort = new InMemoryPaymentGatewayPort();
+		const paymentGovernanceActionPort =
+			new InMemoryPaymentGovernanceActionPort();
+		const payment = Payment.create({
+			id: 'payment-10',
+			orderId: 'order-10',
+			grossAmount: 100,
+			paymentMethod: 'pix',
+		});
+		payment.fail();
+		paymentRepository.insert(payment);
+
+		const useCase = new HandlePaymentConfirmedWebhookUseCase(
+			paymentRepository,
+			processedWebhookEventPort,
+			orderPaymentConfirmationPort,
+			new InMemoryOrderCredentialCleanupPort(),
+			new AcceptAllPaymentWebhookSignatureVerifier(),
+			paymentGatewayPort,
+			paymentGovernanceActionPort,
+		);
+		paymentGatewayPort.notification = {
+			internalPaymentId: 'payment-10',
+			gatewayPaymentId: 'mp-payment-10',
+			gatewayStatus: 'approved',
+			gatewayStatusDetail: 'accredited',
+		};
+
+		await expect(
+			useCase.execute({
+				eventId: 'event-10',
+				topic: 'payment.updated',
+				notificationResourceId: 'notification-10',
+				requestId: 'request-10',
+				signature: 'signature-10',
+			}),
+		).resolves.toEqual({ processed: true });
+
+		const savedPayment = await paymentRepository.findById('payment-10');
+		expect(savedPayment?.status).toBe('failed');
+		expect(savedPayment?.gatewayId).toBe('mp-payment-10');
+		expect(savedPayment?.gatewayStatus).toBe('approved');
+		expect(orderPaymentConfirmationPort.orderIds).toEqual([]);
+		expect(paymentGovernanceActionPort.recorded).toEqual([
+			{ paymentId: 'payment-10', orderId: 'order-10' },
+		]);
+		await expect(
+			processedWebhookEventPort.has(processedWebhookKey('notification-10')),
+		).resolves.toBe(true);
+
+		await expect(
+			useCase.execute({
+				eventId: 'event-10',
+				topic: 'payment.updated',
+				notificationResourceId: 'notification-10',
+				requestId: 'request-10',
+				signature: 'signature-10',
+			}),
+		).resolves.toEqual({ processed: false });
+		expect(paymentGovernanceActionPort.recorded).toHaveLength(1);
 	});
 });

--- a/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.ts
+++ b/apps/api/src/modules/payments/application/use-cases/handle-payment-confirmed-webhook/handle-payment-confirmed-webhook.use-case.ts
@@ -16,6 +16,10 @@ import {
 	type PaymentGatewayPort,
 } from '@modules/payments/application/ports/payment-gateway.port';
 import {
+	PAYMENT_GOVERNANCE_ACTION_PORT_KEY,
+	type PaymentGovernanceActionPort,
+} from '@modules/payments/application/ports/payment-governance-action.port';
+import {
 	PAYMENT_REPOSITORY_KEY,
 	type PaymentRepositoryPort,
 } from '@modules/payments/application/ports/payment-repository.port';
@@ -33,6 +37,7 @@ import {
 	PaymentWebhookSignatureInvalidError,
 	PaymentWebhookTopicNotSupportedError,
 } from '@modules/payments/domain/payment.errors';
+import { PaymentStatus } from '@modules/payments/domain/payment-status';
 import { Inject, Injectable, Optional } from '@nestjs/common';
 
 type HandlePaymentConfirmedWebhookInput = {
@@ -64,6 +69,8 @@ export class HandlePaymentConfirmedWebhookUseCase {
 		private readonly paymentWebhookSignatureVerifier: PaymentWebhookSignatureVerifierPort,
 		@Inject(PAYMENT_GATEWAY_PORT_KEY)
 		private readonly paymentGatewayPort: PaymentGatewayPort,
+		@Inject(PAYMENT_GOVERNANCE_ACTION_PORT_KEY)
+		private readonly paymentGovernanceActionPort: PaymentGovernanceActionPort,
 		@Optional()
 		private readonly paymentLifecycleLogger?: PaymentLifecycleLogger,
 	) {}
@@ -137,6 +144,19 @@ export class HandlePaymentConfirmedWebhookUseCase {
 
 			const resolution = this.resolveNotification(notification.gatewayStatus);
 			logEvent.webhook_resolution = resolution;
+			if (resolution === 'confirm' && payment.status === PaymentStatus.FAILED) {
+				await this.paymentRepository.save(payment);
+				await this.paymentGovernanceActionPort.recordLateApprovedAfterExpiration(
+					{ paymentId: payment.id, orderId: payment.orderId },
+				);
+				logEvent.side_effects?.push('governance_action_recorded');
+				await this.processedWebhookEventPort.markProcessed(processedEventKey);
+
+				logEvent.outcome = 'late_approved_after_expiration';
+				logEvent.payment_status_after = payment.status;
+
+				return { processed: true };
+			}
 			if (resolution === 'confirm') payment.confirm();
 			if (resolution === 'fail') payment.fail();
 			await this.paymentRepository.save(payment);

--- a/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.spec.ts
+++ b/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.spec.ts
@@ -26,9 +26,13 @@ class PaymentRepositoryStub extends InMemoryPaymentRepository {
 		return await callback();
 	}
 
-	override insert(payment: Payment): void {
-		super.insert(payment);
-		this.candidates.push({ payment });
+	override insert(
+		payment: Payment,
+		_clientId?: string,
+		createdAt?: Date,
+	): void {
+		super.insert(payment, _clientId, createdAt);
+		this.candidates.push({ payment, createdAt: createdAt ?? new Date() });
 	}
 }
 
@@ -214,7 +218,10 @@ describe('ReconcileStaleCheckoutsUseCase', () => {
 		const staleCandidate = makePayment('payment-concurrent');
 		const currentPayment = makePayment('payment-concurrent');
 		currentPayment.confirm();
-		repository.candidates.push({ payment: staleCandidate });
+		repository.candidates.push({
+			payment: staleCandidate,
+			createdAt: new Date(),
+		});
 		await repository.save(currentPayment);
 		gateway.notifications.set(
 			'mp-payment-concurrent',
@@ -277,8 +284,54 @@ describe('ReconcileStaleCheckoutsUseCase', () => {
 			confirmedCount: 0,
 			failedCount: 0,
 			pendingUpdatedCount: 0,
+			expiredCount: 0,
 			skippedCount: 0,
 			gatewayErrorCount: 0,
 		});
+	});
+
+	it('expires checkouts without a provider payment after the expiry window', async () => {
+		const { repository, gateway, cleanup, useCase } = makeUseCase();
+		const payment = makePayment('payment-expired', null);
+		repository.insert(
+			payment,
+			undefined,
+			new Date(runAt.getTime() - 25 * 3_600_000),
+		);
+		gateway.notifications.clear();
+
+		const result = await useCase.execute({ now: runAt, limit: 50 });
+
+		expect(result).toMatchObject({
+			skipped: false,
+			scannedCount: 1,
+			expiredCount: 1,
+			skippedCount: 0,
+		});
+		expect(payment.status).toBe('failed');
+		expect(cleanup.orderIds).toEqual(['order-payment-expired']);
+		expect(gateway.externalReferences).toEqual(['payment-expired']);
+	});
+
+	it('keeps skipping recent checkouts without a provider payment', async () => {
+		const { repository, gateway, cleanup, useCase } = makeUseCase();
+		const payment = makePayment('payment-recent', null);
+		repository.insert(
+			payment,
+			undefined,
+			new Date(runAt.getTime() - 3_600_000),
+		);
+		gateway.notifications.clear();
+
+		const result = await useCase.execute({ now: runAt, limit: 50 });
+
+		expect(result).toMatchObject({
+			skipped: false,
+			scannedCount: 1,
+			expiredCount: 0,
+			skippedCount: 1,
+		});
+		expect(payment.status).toBe('awaiting_confirmation');
+		expect(cleanup.orderIds).toEqual([]);
 	});
 });

--- a/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.ts
+++ b/apps/api/src/modules/payments/application/use-cases/reconcile-stale-checkouts/reconcile-stale-checkouts.use-case.ts
@@ -19,12 +19,13 @@ import {
 import {
 	PAYMENT_REPOSITORY_KEY,
 	type PaymentRepositoryPort,
+	type StalePaymentReconciliationCandidate,
 } from '@modules/payments/application/ports/payment-repository.port';
-import type { Payment } from '@modules/payments/domain/payment.entity';
 import { PaymentStatus } from '@modules/payments/domain/payment-status';
 import { Inject, Injectable, Optional } from '@nestjs/common';
 
 const DEFAULT_STALE_AFTER_MINUTES = 15;
+const EXPIRE_UNSTARTED_AFTER_HOURS = 24;
 const RECONCILIATION_CONCURRENCY = 3;
 
 type ReconcileStaleCheckoutsInput = {
@@ -39,6 +40,7 @@ type ReconcileStaleCheckoutsOutput = {
 	confirmedCount: number;
 	failedCount: number;
 	pendingUpdatedCount: number;
+	expiredCount: number;
 	skippedCount: number;
 	gatewayErrorCount: number;
 };
@@ -80,6 +82,9 @@ export class ReconcileStaleCheckoutsUseCase {
 						const createdBefore = new Date(
 							input.now.getTime() - DEFAULT_STALE_AFTER_MINUTES * 60_000,
 						);
+						const expireCreatedBefore = new Date(
+							input.now.getTime() - EXPIRE_UNSTARTED_AFTER_HOURS * 3_600_000,
+						);
 						const candidates =
 							await this.paymentRepository.findStaleAwaitingCheckoutCandidates({
 								createdBefore,
@@ -95,7 +100,13 @@ export class ReconcileStaleCheckoutsUseCase {
 							await Promise.all(
 								candidates
 									.slice(index, index + RECONCILIATION_CONCURRENCY)
-									.map(({ payment }) => this.reconcilePayment(payment, counts)),
+									.map((candidate) =>
+										this.reconcilePayment(
+											candidate,
+											expireCreatedBefore,
+											counts,
+										),
+									),
 							);
 						}
 
@@ -127,9 +138,11 @@ export class ReconcileStaleCheckoutsUseCase {
 	}
 
 	private async reconcilePayment(
-		payment: Payment,
+		candidate: StalePaymentReconciliationCandidate,
+		expireCreatedBefore: Date,
 		counts: ReconciliationCounts,
 	): Promise<void> {
+		const { payment } = candidate;
 		let providerPayment: FetchPaymentNotificationOutput | null;
 		try {
 			providerPayment = payment.gatewayId
@@ -145,7 +158,26 @@ export class ReconcileStaleCheckoutsUseCase {
 		}
 
 		if (!providerPayment || providerPayment.internalPaymentId !== payment.id) {
-			counts.skippedCount++;
+			if (candidate.createdAt >= expireCreatedBefore) {
+				counts.skippedCount++;
+				return;
+			}
+
+			const currentPayment = await this.paymentRepository.findById(payment.id);
+			if (
+				!currentPayment ||
+				currentPayment.status !== PaymentStatus.AWAITING_CONFIRMATION
+			) {
+				counts.skippedCount++;
+				return;
+			}
+
+			await this.orderCredentialCleanupPort.clearCredentials(
+				currentPayment.orderId,
+			);
+			currentPayment.fail();
+			await this.paymentRepository.save(currentPayment);
+			counts.expiredCount++;
 			return;
 		}
 
@@ -218,6 +250,7 @@ export class ReconcileStaleCheckoutsUseCase {
 			confirmedCount: 0,
 			failedCount: 0,
 			pendingUpdatedCount: 0,
+			expiredCount: 0,
 			skippedCount: 0,
 			gatewayErrorCount: 0,
 		};
@@ -231,6 +264,7 @@ export class ReconcileStaleCheckoutsUseCase {
 		logEvent.confirmed_count = counts.confirmedCount;
 		logEvent.failed_count = counts.failedCount;
 		logEvent.pending_updated_count = counts.pendingUpdatedCount;
+		logEvent.expired_count = counts.expiredCount;
 		logEvent.skipped_count = counts.skippedCount;
 		logEvent.gateway_error_count = counts.gatewayErrorCount;
 	}

--- a/apps/api/src/modules/payments/infrastructure/adapters/payment-governance-action-from-prisma.adapter.ts
+++ b/apps/api/src/modules/payments/infrastructure/adapters/payment-governance-action-from-prisma.adapter.ts
@@ -1,0 +1,24 @@
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import type { PaymentGovernanceActionPort } from '@modules/payments/application/ports/payment-governance-action.port';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PaymentGovernanceActionFromPrismaAdapter
+	implements PaymentGovernanceActionPort
+{
+	constructor(private readonly prisma: PrismaService) {}
+
+	async recordLateApprovedAfterExpiration(input: {
+		paymentId: string;
+		orderId: string;
+	}): Promise<void> {
+		await this.prisma.adminGovernanceAction.create({
+			data: {
+				adminUserId: null,
+				actionType: 'PAYMENT_LATE_APPROVAL',
+				reason: `Mercado Pago approved payment ${input.paymentId} after internal expiration.`,
+				targetOrderId: input.orderId,
+			},
+		});
+	}
+}

--- a/apps/api/src/modules/payments/infrastructure/repositories/prisma-payment.repository.ts
+++ b/apps/api/src/modules/payments/infrastructure/repositories/prisma-payment.repository.ts
@@ -25,6 +25,7 @@ type PaymentRecord = {
 	gatewayPaymentMethodId: string | null;
 	gatewayPaymentTypeId: string | null;
 	checkoutUrl: string | null;
+	createdAt: Date;
 };
 
 function mapDomainPaymentMethodToPersisted(
@@ -81,8 +82,8 @@ type PaymentDelegate = {
 	}): Promise<PaymentRecord[]>;
 	upsert(args: {
 		where: { id: string };
-		create: PaymentRecord;
-		update: Omit<PaymentRecord, 'id' | 'orderId'>;
+		create: Omit<PaymentRecord, 'createdAt'>;
+		update: Omit<PaymentRecord, 'id' | 'orderId' | 'createdAt'>;
 	}): Promise<PaymentRecord>;
 };
 
@@ -171,6 +172,7 @@ export class PrismaPaymentRepository implements PaymentRepositoryPort {
 
 		return records.map((record) => ({
 			payment: this.mapRecordToDomain(record),
+			createdAt: record.createdAt,
 		}));
 	}
 

--- a/apps/api/src/modules/payments/payments.module.ts
+++ b/apps/api/src/modules/payments/payments.module.ts
@@ -9,6 +9,7 @@ import { ORDER_PAYMENT_AMOUNT_PORT_KEY } from '@modules/payments/application/por
 import { ORDER_PAYMENT_CONFIRMATION_PORT_KEY } from '@modules/payments/application/ports/order-payment-confirmation.port';
 import { ORDER_STATUS_PORT_KEY } from '@modules/payments/application/ports/order-status.port';
 import { PAYMENT_GATEWAY_PORT_KEY } from '@modules/payments/application/ports/payment-gateway.port';
+import { PAYMENT_GOVERNANCE_ACTION_PORT_KEY } from '@modules/payments/application/ports/payment-governance-action.port';
 import { PAYMENT_REPOSITORY_KEY } from '@modules/payments/application/ports/payment-repository.port';
 import { PAYMENT_WEBHOOK_SIGNATURE_VERIFIER_PORT_KEY } from '@modules/payments/application/ports/payment-webhook-signature-verifier.port';
 import { PROCESSED_WEBHOOK_EVENT_PORT_KEY } from '@modules/payments/application/ports/processed-webhook-event.port';
@@ -29,6 +30,7 @@ import { OrderCredentialCleanupFromOrdersAdapter } from '@modules/payments/infra
 import { OrderPaymentAmountFromPrismaAdapter } from '@modules/payments/infrastructure/adapters/order-payment-amount-from-prisma.adapter';
 import { OrderPaymentConfirmationFromOrdersAdapter } from '@modules/payments/infrastructure/adapters/order-payment-confirmation-from-orders.adapter';
 import { OrderStatusFromPrismaAdapter } from '@modules/payments/infrastructure/adapters/order-status-from-prisma.adapter';
+import { PaymentGovernanceActionFromPrismaAdapter } from '@modules/payments/infrastructure/adapters/payment-governance-action-from-prisma.adapter';
 import { PrismaPaymentRepository } from '@modules/payments/infrastructure/repositories/prisma-payment.repository';
 import { PrismaProcessedWebhookEventRepository } from '@modules/payments/infrastructure/repositories/prisma-processed-webhook-event.repository';
 import { PaymentsController } from '@modules/payments/presentation/payments.controller';
@@ -106,6 +108,15 @@ import { MERCADO_PAGO_SDK_PORT_KEY } from '@packages/integrations/mercadopago/me
 				orderPaymentAmountPort: OrderPaymentAmountFromPrismaAdapter,
 			): OrderPaymentAmountFromPrismaAdapter => orderPaymentAmountPort,
 			inject: [OrderPaymentAmountFromPrismaAdapter],
+		},
+		PaymentGovernanceActionFromPrismaAdapter,
+		{
+			provide: PAYMENT_GOVERNANCE_ACTION_PORT_KEY,
+			useFactory: (
+				paymentGovernanceActionPort: PaymentGovernanceActionFromPrismaAdapter,
+			): PaymentGovernanceActionFromPrismaAdapter =>
+				paymentGovernanceActionPort,
+			inject: [PaymentGovernanceActionFromPrismaAdapter],
 		},
 		OrderPaymentConfirmationFromOrdersAdapter,
 		{

--- a/apps/api/src/modules/payments/presentation/payments.controller.ts
+++ b/apps/api/src/modules/payments/presentation/payments.controller.ts
@@ -229,6 +229,7 @@ export class PaymentsController {
 		confirmedCount: number;
 		failedCount: number;
 		pendingUpdatedCount: number;
+		expiredCount: number;
 		skippedCount: number;
 		gatewayErrorCount: number;
 	}> {

--- a/apps/api/test/support/in-memory/payments/in-memory-payment.repository.ts
+++ b/apps/api/test/support/in-memory/payments/in-memory-payment.repository.ts
@@ -10,6 +10,7 @@ import { Inject, Injectable, Optional } from '@nestjs/common';
 @Injectable()
 export class InMemoryPaymentRepository implements PaymentRepositoryPort {
 	private readonly payments = new Map<string, Payment>();
+	private readonly createdAts = new Map<string, Date>();
 	private readonly clientIds = new Map<string, string>();
 	private readonly failOnSavePaymentIds = new Set<string>();
 
@@ -78,16 +79,19 @@ export class InMemoryPaymentRepository implements PaymentRepositoryPort {
 	}
 
 	async findStaleAwaitingCheckoutCandidates(): Promise<
-		Array<{ payment: Payment }>
+		Array<{ payment: Payment; createdAt: Date }>
 	> {
-		const candidates: Array<{ payment: Payment }> = [];
+		const candidates: Array<{ payment: Payment; createdAt: Date }> = [];
 		for (const payment of this.payments.values()) {
 			if (payment.status !== PaymentStatus.AWAITING_CONFIRMATION) continue;
 			if (this.orderRepository) {
 				const order = await this.orderRepository.findById(payment.orderId);
 				if (!order || order.status !== 'awaiting_payment') continue;
 			}
-			candidates.push({ payment });
+			candidates.push({
+				payment,
+				createdAt: this.createdAts.get(payment.id) ?? new Date(),
+			});
 		}
 
 		return candidates;
@@ -107,9 +111,10 @@ export class InMemoryPaymentRepository implements PaymentRepositoryPort {
 		return Promise.resolve();
 	}
 
-	insert(payment: Payment, clientId?: string): void {
+	insert(payment: Payment, clientId?: string, createdAt?: Date): void {
 		this.payments.set(payment.id, payment);
 		if (clientId !== undefined) this.clientIds.set(payment.id, clientId);
+		if (createdAt !== undefined) this.createdAts.set(payment.id, createdAt);
 	}
 
 	setFailOnSave(paymentId: string): void {

--- a/packages/database/prisma/migrations/20260709220000_governance_nullable_actor/migration.sql
+++ b/packages/database/prisma/migrations/20260709220000_governance_nullable_actor/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "admin_governance_actions" DROP CONSTRAINT "admin_governance_actions_adminUserId_fkey";
+
+-- AlterTable
+ALTER TABLE "admin_governance_actions" ALTER COLUMN "adminUserId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "admin_governance_actions" ADD CONSTRAINT "admin_governance_actions_adminUserId_fkey" FOREIGN KEY ("adminUserId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -483,8 +483,8 @@ model TicketMessage {
 
 model AdminGovernanceAction {
   id            String   @id @default(cuid())
-  adminUserId   String
-  adminUser     User     @relation("AdminGovernanceActor", fields: [adminUserId], references: [id])
+  adminUserId   String?
+  adminUser     User?    @relation("AdminGovernanceActor", fields: [adminUserId], references: [id])
   actionType    String
   reason        String
   targetUserId  String?


### PR DESCRIPTION
## Summary

When a payment we already marked as `failed` later receives an `approved` notification from Mercado Pago, the webhook threw `PaymentInvalidTransitionError` (failed → held is invalid), returned HTTP 400, and never recorded dedup — so Mercado Pago retried the same event indefinitely while the money sat unaccounted for.

Product rule implemented: **acknowledge and flag for human review.**

- Webhook: late approval on a `FAILED` payment now persists the fresh gateway details, records a `PAYMENT_LATE_APPROVAL` governance action (surfaces on the admin dashboard via `latestGovernanceAction`), marks the event processed (stops the retry storm), emits a `late_approved_after_expiration` lifecycle outcome, and returns 200. The payment stays `FAILED`; the order/booster flow is untouched — refund or manual fulfillment is a human decision.
- `admin_governance_actions.adminUserId` becomes nullable (one migration) since this action has no human actor. Payments gets its own small governance port + Prisma adapter rather than importing `AdminModule`.
- Reconciliation now also **expires abandoned checkouts**: `AWAITING_CONFIRMATION` payments older than 24h with no matching provider payment are failed and their order credentials cleared, reported via a new `expiredCount` (additive field; the VPS cron needs no change). This unblocks the 6 payments prod re-scans every 10 minutes today.
- The `Payment` state machine is deliberately unchanged — `FAILED` stays terminal.

Closes: #98

## Verification

```text
cd apps/api
npx tsc --noEmit -p tsconfig.json
npx jest "src/modules/payments/.*\.spec\.ts$" --runInBand          # 96 passed (3 new)
npx jest "test/integration/.*\.integration\.spec\.ts$" --runInBand # 37 passed
npx biome check apps/api packages/database
cd ../../packages/database && npx prisma migrate deploy            # applied against local dev DB
npx prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma  # no drift
```

Skipped checks and remaining risk: db-backed and e2e-db suites left to CI. Note: the non-db e2e suite (`jest-e2e.json`) is not run by CI at all and has one **pre-existing** failure on main ("rejects Mercado Pago webhook payloads missing the provider event id" expects 400, gets 200 since #97's ack-unsupported-formats change) — unrelated to this PR, worth its own issue.

## Screenshots

None.

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)