### PR TITLE
ci: run API e2e suite and fix stale webhook expectation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: API integration tests
         run: pnpm api test:integration
 
+      - name: API e2e tests
+        run: pnpm api test:e2e
+
       - name: Web tests
         run: pnpm web test
 

--- a/apps/api/test/payments.e2e-spec.ts
+++ b/apps/api/test/payments.e2e-spec.ts
@@ -279,7 +279,7 @@ describe('Payments (e2e)', () => {
 			.execute();
 	});
 
-	it('rejects Mercado Pago webhook payloads missing the provider event id', async () => {
+	it('acknowledges Mercado Pago webhook payloads missing the provider event id without processing them', async () => {
 		const token = signToken({ sub: 'client-2', role: 'CLIENT' });
 		const createdOrder = await createQuotedOrder(token);
 
@@ -302,7 +302,10 @@ describe('Payments (e2e)', () => {
 				action: 'payment.updated',
 				data: { id: 'payment-1' },
 			})
-			.expect(400)
+			.expect(200)
+			.expect(({ body }) => {
+				expect(body).toEqual({ processed: false });
+			})
 			.execute();
 	});
 


### PR DESCRIPTION
## Summary

The non-db API e2e suite (`test/jest-e2e.json`, 98 tests, ~22s, no containers) was never run by CI. Because of that, one test went silently stale: "rejects Mercado Pago webhook payloads missing the provider event id" still expected HTTP 400, but #97 deliberately changed malformed/legacy notification formats to be acknowledged with 200 + `{processed: false}` so Mercado Pago stops retrying them.

- Updated the stale test to assert the acknowledge contract (200, `{processed: false}`, renamed accordingly), mirroring the integration tests #97 added.
- Added an `API e2e tests` step (`pnpm api test:e2e`) to the existing checks job so the suite can't rot unnoticed again.

Closes: none (follow-up flagged in #100)

## Verification

```text
cd apps/api
npx jest --config ./test/jest-e2e.json --runInBand   # 8 suites, 98 tests, all passing
npx biome check apps/api/test/payments.e2e-spec.ts
```

Skipped checks and remaining risk: the CI step itself is exercised by this PR's own run — check that the new "API e2e tests" step appears and passes.

## Screenshots

None.

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)