### PR TITLE
feat(api): harden order credential storage

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,8 +10,10 @@ import { TicketsModule } from '@modules/tickets/tickets.module';
 import { UsersModule } from '@modules/users/users.module';
 import { WalletModule } from '@modules/wallet/wallet.module';
 import { Module } from '@nestjs/common';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { ApiDomainErrorFilter } from './common/http/api-domain-error.filter';
+import { ApiMutationThrottlerGuard } from './common/http/api-mutation-throttler.guard';
+import { HttpThrottlingModule } from './common/http/http-throttling.module';
 import { LoggingModule } from './common/logging/logging.module';
 import { OutboxModule } from './common/outbox/outbox.module';
 import { PrismaModule } from './common/prisma/prisma.module';
@@ -20,6 +22,7 @@ import { AppSettingsModule } from './common/settings/app-settings.module';
 @Module({
 	imports: [
 		AppSettingsModule,
+		HttpThrottlingModule,
 		LoggingModule,
 		PrismaModule,
 		OutboxModule,
@@ -40,6 +43,10 @@ import { AppSettingsModule } from './common/settings/app-settings.module';
 		{
 			provide: APP_FILTER,
 			useClass: ApiDomainErrorFilter,
+		},
+		{
+			provide: APP_GUARD,
+			useClass: ApiMutationThrottlerGuard,
 		},
 	],
 })

--- a/apps/api/src/common/http/api-mutation-throttler.guard.spec.ts
+++ b/apps/api/src/common/http/api-mutation-throttler.guard.spec.ts
@@ -1,0 +1,112 @@
+import { ApiMutationThrottlerGuard } from '@app/common/http/api-mutation-throttler.guard';
+import { AppSettingsService } from '@app/common/settings/app-settings.service';
+import type { ExecutionContext } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ThrottlerException, ThrottlerModule } from '@nestjs/throttler';
+
+type RequestStub = {
+	method: string;
+	url: string;
+	ip: string;
+	headers: Record<string, string | string[] | undefined>;
+};
+
+const createContext = (request: Partial<RequestStub>): ExecutionContext => {
+	const fullRequest: RequestStub = {
+		method: 'POST',
+		url: '/orders/order-1/credentials',
+		ip: '10.0.0.1',
+		headers: {},
+		...request,
+	};
+
+	return {
+		getType: () => 'http',
+		getHandler: () => function testHandler() {},
+		getClass: () => class TestController {},
+		switchToHttp: () => ({
+			getRequest: () => fullRequest,
+			getResponse: () => ({ header: jest.fn() }),
+		}),
+	} as unknown as ExecutionContext;
+};
+
+describe('ApiMutationThrottlerGuard', () => {
+	const openModules: Array<{ close(): Promise<void> }> = [];
+
+	afterEach(async () => {
+		await Promise.all(openModules.splice(0).map((module) => module.close()));
+	});
+
+	const createGuard = async (limit: number) => {
+		const moduleRef = await Test.createTestingModule({
+			imports: [ThrottlerModule.forRoot([])],
+			providers: [
+				ApiMutationThrottlerGuard,
+				{
+					provide: AppSettingsService,
+					useValue: {
+						apiMutationThrottleLimit: limit,
+						apiMutationThrottleTtlSeconds: 60,
+					},
+				},
+			],
+		}).compile();
+		await moduleRef.init();
+		openModules.push(moduleRef);
+
+		return moduleRef.get(ApiMutationThrottlerGuard);
+	};
+
+	it('allows read requests regardless of volume', async () => {
+		const guard = await createGuard(1);
+
+		for (let i = 0; i < 5; i++)
+			await expect(
+				guard.canActivate(createContext({ method: 'GET' })),
+			).resolves.toBe(true);
+	});
+
+	it('skips internal worker routes', async () => {
+		const guard = await createGuard(1);
+
+		for (let i = 0; i < 5; i++)
+			await expect(
+				guard.canActivate(
+					createContext({
+						url: '/wallets/internal/release-matured-funds',
+					}),
+				),
+			).resolves.toBe(true);
+	});
+
+	it('throttles mutating requests beyond the configured limit', async () => {
+		const guard = await createGuard(2);
+
+		await expect(guard.canActivate(createContext({}))).resolves.toBe(true);
+		await expect(guard.canActivate(createContext({}))).resolves.toBe(true);
+		await expect(guard.canActivate(createContext({}))).rejects.toBeInstanceOf(
+			ThrottlerException,
+		);
+	});
+
+	it('tracks clients by cf-connecting-ip so tunnel traffic is not one bucket', async () => {
+		const guard = await createGuard(1);
+
+		await expect(
+			guard.canActivate(
+				createContext({ headers: { 'cf-connecting-ip': '203.0.113.1' } }),
+			),
+		).resolves.toBe(true);
+		await expect(
+			guard.canActivate(
+				createContext({ headers: { 'cf-connecting-ip': '203.0.113.2' } }),
+			),
+		).resolves.toBe(true);
+		await expect(
+			guard.canActivate(
+				createContext({ headers: { 'cf-connecting-ip': '203.0.113.1' } }),
+			),
+		).rejects.toBeInstanceOf(ThrottlerException);
+	});
+});

--- a/apps/api/src/common/http/api-mutation-throttler.guard.ts
+++ b/apps/api/src/common/http/api-mutation-throttler.guard.ts
@@ -1,0 +1,50 @@
+import {
+	ConfigurableThrottlerGuard,
+	type RouteThrottleConfig,
+} from '@app/common/http/configurable-throttler.guard';
+import { AppSettingsService } from '@app/common/settings/app-settings.service';
+import { type ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+	InjectThrottlerOptions,
+	InjectThrottlerStorage,
+	type ThrottlerModuleOptions,
+	type ThrottlerStorage,
+} from '@nestjs/throttler';
+
+const UNTHROTTLED_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+@Injectable()
+export class ApiMutationThrottlerGuard extends ConfigurableThrottlerGuard {
+	constructor(
+		@InjectThrottlerOptions()
+		options: ThrottlerModuleOptions,
+		@InjectThrottlerStorage()
+		storageService: ThrottlerStorage,
+		reflector: Reflector,
+		private readonly appSettings: AppSettingsService,
+	) {
+		super(options, storageService, reflector);
+	}
+
+	protected getThrottleConfig(
+		context: ExecutionContext,
+	): RouteThrottleConfig | null {
+		if (context.getType() !== 'http') return null;
+
+		const request = context.switchToHttp().getRequest<{
+			method: string;
+			url: string;
+		}>();
+		if (UNTHROTTLED_METHODS.has(request.method)) return null;
+		// Worker-to-API traffic authenticates with the internal API key and
+		// originates inside the compose network; throttling it could stall jobs.
+		if (request.url.includes('/internal/')) return null;
+
+		return {
+			name: 'api-mutations',
+			limit: this.appSettings.apiMutationThrottleLimit,
+			ttl: this.appSettings.apiMutationThrottleTtlSeconds * 1000,
+		};
+	}
+}

--- a/apps/api/src/common/http/configurable-throttler.guard.ts
+++ b/apps/api/src/common/http/configurable-throttler.guard.ts
@@ -50,4 +50,18 @@ export abstract class ConfigurableThrottlerGuard extends ThrottlerGuard {
 	protected abstract getThrottleConfig(
 		context: ExecutionContext,
 	): RouteThrottleConfig | null;
+
+	// Behind the Cloudflare tunnel every request reaches the container from the
+	// tunnel's address, so req.ip would put all clients in one throttle bucket.
+	// CF-Connecting-IP is set by Cloudflare and cannot be spoofed from outside
+	// because the tunnel is the only public ingress.
+	protected getTracker(req: Record<string, unknown>): Promise<string> {
+		const headers = req.headers as
+			| Record<string, string | string[] | undefined>
+			| undefined;
+		const header = headers?.['cf-connecting-ip'];
+		const clientIp = Array.isArray(header) ? header.at(0) : header;
+
+		return Promise.resolve(clientIp ?? (req.ip as string));
+	}
 }

--- a/apps/api/src/common/settings/app-settings.service.ts
+++ b/apps/api/src/common/settings/app-settings.service.ts
@@ -131,6 +131,18 @@ export class AppSettingsService {
 		});
 	}
 
+	get apiMutationThrottleLimit() {
+		return this.config.getOrThrow('API_MUTATION_THROTTLE_LIMIT', {
+			infer: true,
+		});
+	}
+
+	get apiMutationThrottleTtlSeconds() {
+		return this.config.getOrThrow('API_MUTATION_THROTTLE_TTL_SECONDS', {
+			infer: true,
+		});
+	}
+
 	get authLoginThrottleLimit() {
 		return this.config.getOrThrow('AUTH_LOGIN_THROTTLE_LIMIT', {
 			infer: true,

--- a/apps/api/src/modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case.spec.ts
@@ -2,6 +2,7 @@ import type { OrderRepositoryPort } from '@modules/orders/application/ports/orde
 import { ClearOrderCredentialsUseCase } from '@modules/orders/application/use-cases/clear-order-credentials/clear-order-credentials.use-case';
 import { Order } from '@modules/orders/domain/order.entity';
 import { OrderNotFoundError } from '@modules/orders/domain/order.errors';
+import { persistedOrderCopy } from '../../../../../../test/support/in-memory/orders/in-memory-order.repository';
 
 class InMemoryOrderRepository implements OrderRepositoryPort {
 	private readonly orders = new Map<string, Order>();
@@ -20,11 +21,11 @@ class InMemoryOrderRepository implements OrderRepositoryPort {
 	}
 
 	async save(order: Order): Promise<void> {
-		this.orders.set(order.id, order);
+		this.orders.set(order.id, persistedOrderCopy(order));
 	}
 
 	insert(order: Order): void {
-		this.orders.set(order.id, order);
+		this.orders.set(order.id, persistedOrderCopy(order));
 	}
 }
 
@@ -44,7 +45,7 @@ describe('ClearOrderCredentialsUseCase', () => {
 		await useCase.execute({ orderId: 'order-1' });
 
 		const savedOrder = await repository.findById('order-1');
-		expect(savedOrder?.credentials).toBeNull();
+		expect(savedOrder?.hasCredentials).toBe(false);
 	});
 
 	it('is idempotent when credentials are already absent', async () => {
@@ -59,7 +60,7 @@ describe('ClearOrderCredentialsUseCase', () => {
 		).resolves.toBeUndefined();
 
 		const savedOrder = await repository.findById('order-2');
-		expect(savedOrder?.credentials).toBeNull();
+		expect(savedOrder?.hasCredentials).toBe(false);
 	});
 
 	it('throws when order does not exist', async () => {

--- a/apps/api/src/modules/orders/application/use-cases/complete-order/complete-order.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/complete-order/complete-order.use-case.spec.ts
@@ -10,6 +10,7 @@ import {
 	OrderInvalidTransitionError,
 	OrderNotFoundError,
 } from '@modules/orders/domain/order.errors';
+import { persistedOrderCopy } from '../../../../../../test/support/in-memory/orders/in-memory-order.repository';
 
 class InMemoryOrderRepository implements OrderRepositoryPort {
 	private readonly orders = new Map<string, Order>();
@@ -28,11 +29,11 @@ class InMemoryOrderRepository implements OrderRepositoryPort {
 	}
 
 	async save(order: Order): Promise<void> {
-		this.orders.set(order.id, order);
+		this.orders.set(order.id, persistedOrderCopy(order));
 	}
 
 	insert(order: Order): void {
-		this.orders.set(order.id, order);
+		this.orders.set(order.id, persistedOrderCopy(order));
 	}
 }
 
@@ -86,7 +87,7 @@ describe('CompleteOrderUseCase', () => {
 
 		const savedOrder = await repository.findById('order-1');
 		expect(savedOrder?.status).toBe('completed');
-		expect(savedOrder?.credentials).toBeNull();
+		expect(savedOrder?.hasCredentials).toBe(false);
 		expect(eventPublisher.events).toMatchObject([
 			{
 				type: 'order.completed',
@@ -135,7 +136,7 @@ describe('CompleteOrderUseCase', () => {
 		await expect(repository.findById('order-3')).resolves.toMatchObject({
 			id: 'order-3',
 			status: 'completed',
-			credentials: null,
+			hasCredentials: false,
 		});
 	});
 

--- a/apps/api/src/modules/orders/application/use-cases/get-order/get-order.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/get-order/get-order.use-case.spec.ts
@@ -51,6 +51,7 @@ describe('GetOrderUseCase', () => {
 		).resolves.toEqual({
 			id: 'order-1',
 			status: 'awaiting_payment',
+			hasCredentials: false,
 			subtotal: 25.2,
 			totalAmount: 25.2,
 			discountAmount: 0,

--- a/apps/api/src/modules/orders/application/use-cases/get-order/get-order.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/get-order/get-order.use-case.ts
@@ -14,6 +14,7 @@ type GetOrderInput = {
 type GetOrderOutput = {
 	id: string;
 	status: OrderStatus;
+	hasCredentials: boolean;
 	subtotal: number | null;
 	totalAmount: number | null;
 	discountAmount: number;
@@ -43,6 +44,7 @@ export class GetOrderUseCase {
 		return {
 			id: order.id,
 			status: order.status,
+			hasCredentials: order.hasCredentials,
 			subtotal: order.subtotal,
 			totalAmount: order.totalAmount,
 			discountAmount: order.discountAmount,

--- a/apps/api/src/modules/orders/application/use-cases/save-order-credentials/save-order-credentials.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/save-order-credentials/save-order-credentials.use-case.spec.ts
@@ -1,14 +1,19 @@
 import type { OrderRepositoryPort } from '@modules/orders/application/ports/order-repository.port';
 import { SaveOrderCredentialsUseCase } from '@modules/orders/application/use-cases/save-order-credentials/save-order-credentials.use-case';
-import { Order } from '@modules/orders/domain/order.entity';
+import {
+	Order,
+	type OrderCredentials,
+} from '@modules/orders/domain/order.entity';
 import {
 	OrderCredentialsPasswordMismatchError,
 	OrderCredentialsStorageNotAllowedError,
 	OrderNotFoundError,
 } from '@modules/orders/domain/order.errors';
+import { persistedOrderCopy } from '../../../../../../test/support/in-memory/orders/in-memory-order.repository';
 
 class InMemoryOrderRepository implements OrderRepositoryPort {
 	private readonly orders = new Map<string, Order>();
+	lastSavedPendingCredentials: OrderCredentials | null = null;
 
 	async create(order: Order): Promise<Order> {
 		this.orders.set(order.id, order);
@@ -27,11 +32,12 @@ class InMemoryOrderRepository implements OrderRepositoryPort {
 	}
 
 	async save(order: Order): Promise<void> {
-		this.orders.set(order.id, order);
+		this.lastSavedPendingCredentials = order.pendingCredentials;
+		this.orders.set(order.id, persistedOrderCopy(order));
 	}
 
 	insert(order: Order): void {
-		this.orders.set(order.id, order);
+		this.orders.set(order.id, persistedOrderCopy(order));
 	}
 }
 
@@ -52,12 +58,14 @@ describe('SaveOrderCredentialsUseCase', () => {
 			confirmPassword: 'secret',
 		});
 
-		const savedOrder = await repository.findById('order-1');
-		expect(savedOrder?.credentials).toEqual({
+		expect(repository.lastSavedPendingCredentials).toEqual({
 			login: 'login',
 			summonerName: 'summoner',
 			password: 'secret',
 		});
+		const savedOrder = await repository.findById('order-1');
+		expect(savedOrder?.hasCredentials).toBe(true);
+		expect(savedOrder?.pendingCredentials).toBeNull();
 	});
 
 	it('throws when passwords do not match', async () => {
@@ -136,12 +144,14 @@ describe('SaveOrderCredentialsUseCase', () => {
 			confirmPassword: 'secret-2',
 		});
 
-		const savedOrder = await repository.findById('order-4');
-		expect(savedOrder?.credentials).toEqual({
+		expect(repository.lastSavedPendingCredentials).toEqual({
 			login: 'login-2',
 			summonerName: 'summoner-2',
 			password: 'secret-2',
 		});
+		const savedOrder = await repository.findById('order-4');
+		expect(savedOrder?.hasCredentials).toBe(true);
+		expect(savedOrder?.pendingCredentials).toBeNull();
 	});
 
 	it('throws when a different client tries to store credentials', async () => {

--- a/apps/api/src/modules/orders/domain/order.entity.spec.ts
+++ b/apps/api/src/modules/orders/domain/order.entity.spec.ts
@@ -71,8 +71,35 @@ describe('Order domain rules', () => {
 		order.acceptByBooster();
 		order.complete();
 
-		expect(order.credentials).toBeNull();
+		expect(order.hasCredentials).toBe(false);
 		expect(order.status).toBe(OrderStatus.COMPLETED);
+	});
+
+	it('deletes credentials on cancellation', () => {
+		const order = Order.create('order-4b');
+
+		order.confirmPayment();
+		order.setCredentials({
+			login: 'login',
+			summonerName: 'summoner',
+			password: 'secret',
+		});
+		order.cancel();
+
+		expect(order.hasCredentials).toBe(false);
+		expect(order.status).toBe(OrderStatus.CANCELLED);
+	});
+
+	it('deletes stored credentials on cancellation of a rehydrated order', () => {
+		const order = Order.rehydrate({
+			id: 'order-4c',
+			status: OrderStatus.PENDING_BOOSTER,
+			hasStoredCredentials: true,
+		});
+
+		expect(order.hasCredentials).toBe(true);
+		order.cancel();
+		expect(order.hasCredentials).toBe(false);
 	});
 
 	it('allows setting credentials when order is in progress', () => {
@@ -87,11 +114,12 @@ describe('Order domain rules', () => {
 				password: 'secret',
 			}),
 		).not.toThrow();
-		expect(order.credentials).toEqual({
+		expect(order.pendingCredentials).toEqual({
 			login: 'login',
 			summonerName: 'summoner',
 			password: 'secret',
 		});
+		expect(order.hasCredentials).toBe(true);
 	});
 
 	it('keeps extras immutable when callers mutate the returned array', () => {

--- a/apps/api/src/modules/orders/domain/order.entity.ts
+++ b/apps/api/src/modules/orders/domain/order.entity.ts
@@ -55,7 +55,7 @@ export class Order {
 		private readonly currentCouponId: string | null,
 		private readonly currentPricingVersionId: string | null,
 		private currentStatus: OrderStatus,
-		private currentCredentials: OrderCredentials | null,
+		private pendingCredentialsValue: OrderCredentials | null,
 		private readonly currentRequestDetails: OrderRequestDetails | null,
 		private readonly currentSubtotal: number | null,
 		private readonly currentTotalAmount: number | null,
@@ -125,7 +125,7 @@ export class Order {
 		couponId?: string | null;
 		pricingVersionId?: string | null;
 		status: OrderStatus;
-		credentials?: OrderCredentials | null;
+		hasStoredCredentials?: boolean;
 		requestDetails?: OrderRequestDetails | null;
 		subtotal?: number | null;
 		totalAmount?: number | null;
@@ -133,14 +133,14 @@ export class Order {
 		extras?: OrderPricedExtra[];
 		completedAt?: Date | null;
 	}): Order {
-		return new Order(
+		const order = new Order(
 			input.id,
 			input.clientId ?? null,
 			input.boosterId ?? null,
 			input.couponId ?? null,
 			input.pricingVersionId ?? null,
 			input.status,
-			input.credentials ?? null,
+			null,
 			input.requestDetails ?? null,
 			input.subtotal ?? null,
 			input.totalAmount ?? null,
@@ -148,7 +148,11 @@ export class Order {
 			(input.extras ?? []).map((extra) => ({ ...extra })),
 			input.completedAt ?? null,
 		);
+		order.storedCredentials = input.hasStoredCredentials ?? false;
+		return order;
 	}
+
+	private storedCredentials = false;
 
 	get clientId(): string | null {
 		return this.currentClientId;
@@ -170,8 +174,12 @@ export class Order {
 		return this.currentStatus;
 	}
 
-	get credentials(): OrderCredentials | null {
-		return this.currentCredentials;
+	get hasCredentials(): boolean {
+		return this.storedCredentials || this.pendingCredentialsValue !== null;
+	}
+
+	get pendingCredentials(): OrderCredentials | null {
+		return this.pendingCredentialsValue;
 	}
 
 	get requestDetails(): OrderRequestDetails | null {
@@ -224,7 +232,7 @@ export class Order {
 
 	complete(now: Date = new Date()): void {
 		this.transitionTo(OrderStatus.COMPLETED);
-		this.currentCredentials = null;
+		this.clearCredentials();
 		this.currentCompletedAt = now;
 	}
 
@@ -236,17 +244,19 @@ export class Order {
 			throw new OrderCancellationNotAllowedError();
 
 		this.transitionTo(OrderStatus.CANCELLED);
+		this.clearCredentials();
 	}
 
 	setCredentials(credentials: OrderCredentials): void {
 		if (!CREDENTIALS_ALLOWED_STATUSES.has(this.currentStatus))
 			throw new OrderCredentialsStorageNotAllowedError();
 
-		this.currentCredentials = credentials;
+		this.pendingCredentialsValue = credentials;
 	}
 
 	clearCredentials(): void {
-		this.currentCredentials = null;
+		this.pendingCredentialsValue = null;
+		this.storedCredentials = false;
 	}
 
 	private transitionTo(nextStatus: OrderStatus): void {

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-order.repository.spec.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-order.repository.spec.ts
@@ -1,163 +1,263 @@
+import { Order } from '@modules/orders/domain/order.entity';
+import { OrderStatus } from '@modules/orders/domain/order-status';
 import { PrismaOrderRepository } from '@modules/orders/infrastructure/repositories/prisma-order.repository';
 import { OrderCredentialsCipherService } from '@modules/orders/infrastructure/security/order-credentials-cipher.service';
 
+const cipher = () =>
+	new OrderCredentialsCipherService({
+		orderCredentialsEncryptionKey:
+			'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+	} as never);
+
+const withTransaction = <T extends object>(prisma: T) =>
+	Object.assign(prisma, {
+		$transaction: (callback: (tx: T) => Promise<unknown>) => callback(prisma),
+	});
+
+const requestDetails = {
+	serviceType: 'elo_boost',
+	currentLeague: 'gold',
+	currentDivision: 'II',
+	currentLp: 50,
+	desiredLeague: 'platinum',
+	desiredDivision: 'IV',
+	server: 'br',
+	desiredQueue: 'solo_duo',
+	lpGain: 20,
+	deadline: new Date('2026-03-31T00:00:00.000Z'),
+} as const;
+
+const orderRecord = (credentials: object | null) => ({
+	id: 'order-1',
+	clientId: 'client-1',
+	boosterId: null,
+	couponId: null,
+	status: 'pending_booster',
+	serviceType: 'ELO_BOOST',
+	currentLeague: 'gold',
+	currentDivision: 'II',
+	currentLp: 50,
+	desiredLeague: 'platinum',
+	desiredDivision: 'IV',
+	server: 'br',
+	desiredQueue: 'solo_duo',
+	lpGain: 20,
+	deadline: new Date('2026-03-31T00:00:00.000Z'),
+	subtotal: null,
+	totalAmount: null,
+	discountAmount: 0,
+	completedAt: null,
+	extras: [],
+	credentials,
+});
+
 describe('PrismaOrderRepository', () => {
-	it('saves and rehydrates an order from persistence records', async () => {
-		const findUnique = jest.fn().mockResolvedValue({
-			id: 'order-1',
-			clientId: 'client-1',
-			boosterId: null,
-			couponId: null,
-			status: 'pending_booster',
-			serviceType: 'ELO_BOOST',
-			currentLeague: 'gold',
-			currentDivision: 'II',
-			currentLp: 50,
-			desiredLeague: 'platinum',
-			desiredDivision: 'IV',
-			server: 'br',
-			desiredQueue: 'solo_duo',
-			lpGain: 20,
-			deadline: new Date('2026-03-31T00:00:00.000Z'),
-			subtotal: null,
-			totalAmount: null,
-			discountAmount: 0,
-			extras: [],
-			credentials: {
-				login: 'login',
-				summonerName: 'summoner',
-				password: 'secret',
-			},
+	it('seals newly submitted credentials and never rehydrates plaintext', async () => {
+		const orderCredentialsCipher = cipher();
+		const sealedRecord = orderRecord({
+			login: orderCredentialsCipher.encryptField('order-1', 'login', 'login'),
+			summonerName: orderCredentialsCipher.encryptField(
+				'order-1',
+				'summonerName',
+				'summoner',
+			),
+			password: orderCredentialsCipher.encryptField(
+				'order-1',
+				'password',
+				'secret',
+			),
 		});
-		const upsert = jest.fn().mockResolvedValue(undefined);
-		const prisma = {
-			order: {
-				findUnique,
-				upsert,
-			},
-		};
-		const orderCredentialsCipher = new OrderCredentialsCipherService({
-			orderCredentialsEncryptionKey:
-				'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
-		} as never);
+		const findUnique = jest.fn().mockResolvedValue(sealedRecord);
+		const upsert = jest.fn().mockResolvedValue(sealedRecord);
+		const deleteMany = jest.fn();
+		const prisma = withTransaction({
+			order: { findUnique, upsert },
+			orderCredentials: { deleteMany },
+		});
 
 		const repository = new PrismaOrderRepository(
 			prisma as never,
 			orderCredentialsCipher,
 		);
-		await repository.save({
+		const order = Order.rehydrate({
 			id: 'order-1',
 			clientId: 'client-1',
-			status: 'pending_booster',
-			requestDetails: {
-				serviceType: 'elo_boost',
-				currentLeague: 'gold',
-				currentDivision: 'II',
-				currentLp: 50,
-				desiredLeague: 'platinum',
-				desiredDivision: 'IV',
-				server: 'br',
-				desiredQueue: 'solo_duo',
-				lpGain: 20,
-				deadline: new Date('2026-03-31T00:00:00.000Z'),
-			},
-			credentials: {
-				login: 'login',
-				summonerName: 'summoner',
-				password: 'secret',
-			},
-		} as never);
+			status: OrderStatus.PENDING_BOOSTER,
+			requestDetails,
+		});
+		order.setCredentials({
+			login: 'login',
+			summonerName: 'summoner',
+			password: 'secret',
+		});
+		await repository.save(order);
 
-		await expect(repository.findById('order-1')).resolves.toMatchObject({
+		expect(deleteMany).not.toHaveBeenCalled();
+		const sealedFields = {
+			login: expect.stringMatching(/^v2:/),
+			summonerName: expect.stringMatching(/^v2:/),
+			password: expect.stringMatching(/^v2:/),
+		};
+		expect(upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { id: 'order-1' },
+				create: expect.objectContaining({
+					credentials: { create: sealedFields },
+				}),
+				update: expect.objectContaining({
+					credentials: {
+						upsert: { create: sealedFields, update: sealedFields },
+					},
+				}),
+			}),
+		);
+
+		const written = upsert.mock.calls[0][0].create.credentials.create;
+		expect(
+			orderCredentialsCipher.decryptField(
+				'order-1',
+				'password',
+				written.password,
+			),
+		).toBe('secret');
+
+		const rehydrated = await repository.findById('order-1');
+		expect(rehydrated?.hasCredentials).toBe(true);
+		expect(rehydrated?.pendingCredentials).toBeNull();
+	});
+
+	it('leaves stored credentials untouched when saving an unmodified order', async () => {
+		const upsert = jest.fn().mockResolvedValue(undefined);
+		const deleteMany = jest.fn();
+		const prisma = withTransaction({
+			order: { findUnique: jest.fn(), upsert },
+			orderCredentials: { deleteMany },
+		});
+		const repository = new PrismaOrderRepository(prisma as never, cipher());
+
+		const order = Order.rehydrate({
 			id: 'order-1',
 			clientId: 'client-1',
-			status: 'pending_booster',
-			requestDetails: {
-				serviceType: 'elo_boost',
-				currentLeague: 'gold',
-				currentDivision: 'II',
-				currentLp: 50,
-				desiredLeague: 'platinum',
-				desiredDivision: 'IV',
-				server: 'br',
-				desiredQueue: 'solo_duo',
-				lpGain: 20,
-				deadline: new Date('2026-03-31T00:00:00.000Z'),
-			},
-			credentials: {
-				login: 'login',
-				summonerName: 'summoner',
-				password: 'secret',
-			},
+			status: OrderStatus.PENDING_BOOSTER,
+			requestDetails,
+			hasStoredCredentials: true,
 		});
-		expect(upsert).toHaveBeenCalledWith({
-			where: { id: 'order-1' },
-			create: expect.objectContaining({
-				id: 'order-1',
-				clientId: 'client-1',
-				boosterId: undefined,
-				couponId: undefined,
-				status: 'pending_booster',
-				serviceType: 'ELO_BOOST',
-				currentLeague: 'gold',
-				currentDivision: 'II',
-				currentLp: 50,
-				desiredLeague: 'platinum',
-				desiredDivision: 'IV',
-				server: 'br',
-				desiredQueue: 'solo_duo',
-				lpGain: 20,
-				deadline: new Date('2026-03-31T00:00:00.000Z'),
-				subtotal: undefined,
-				totalAmount: undefined,
-				discountAmount: undefined,
-				extras: undefined,
-				credentials: {
-					create: {
-						login: expect.stringMatching(/^v1:/),
-						summonerName: expect.stringMatching(/^v1:/),
-						password: expect.stringMatching(/^v1:/),
-					},
-				},
-			}),
-			update: expect.objectContaining({
-				clientId: 'client-1',
-				boosterId: undefined,
-				couponId: undefined,
-				status: 'pending_booster',
-				serviceType: 'ELO_BOOST',
-				currentLeague: 'gold',
-				currentDivision: 'II',
-				currentLp: 50,
-				desiredLeague: 'platinum',
-				desiredDivision: 'IV',
-				server: 'br',
-				desiredQueue: 'solo_duo',
-				lpGain: 20,
-				deadline: new Date('2026-03-31T00:00:00.000Z'),
-				subtotal: undefined,
-				totalAmount: undefined,
-				discountAmount: undefined,
-				extras: {
-					deleteMany: {},
-					create: [],
-				},
-				credentials: {
-					upsert: {
-						create: {
-							login: expect.stringMatching(/^v1:/),
-							summonerName: expect.stringMatching(/^v1:/),
-							password: expect.stringMatching(/^v1:/),
-						},
-						update: {
-							login: expect.stringMatching(/^v1:/),
-							summonerName: expect.stringMatching(/^v1:/),
-							password: expect.stringMatching(/^v1:/),
-						},
-					},
-				},
-			}),
+		await repository.save(order);
+
+		expect(deleteMany).not.toHaveBeenCalled();
+		const args = upsert.mock.calls[0][0];
+		expect(args.create.credentials).toBeUndefined();
+		expect(args.update.credentials).toBeUndefined();
+	});
+
+	it('deletes stored credentials when the order no longer has them', async () => {
+		const upsert = jest.fn().mockResolvedValue(undefined);
+		const deleteMany = jest.fn().mockResolvedValue({ count: 1 });
+		const prisma = withTransaction({
+			order: { findUnique: jest.fn(), upsert },
+			orderCredentials: { deleteMany },
 		});
+		const repository = new PrismaOrderRepository(prisma as never, cipher());
+
+		const order = Order.rehydrate({
+			id: 'order-1',
+			clientId: 'client-1',
+			status: OrderStatus.PENDING_BOOSTER,
+			requestDetails,
+			hasStoredCredentials: true,
+		});
+		order.clearCredentials();
+		await repository.save(order);
+
+		expect(deleteMany).toHaveBeenCalledWith({
+			where: { orderId: 'order-1' },
+		});
+	});
+
+	it('replaces stored credentials when new ones are submitted for the same order', async () => {
+		const upsert = jest.fn().mockResolvedValue(undefined);
+		const deleteMany = jest.fn();
+		const prisma = withTransaction({
+			order: { findUnique: jest.fn(), upsert },
+			orderCredentials: { deleteMany },
+		});
+		const repository = new PrismaOrderRepository(prisma as never, cipher());
+
+		const order = Order.rehydrate({
+			id: 'order-1',
+			clientId: 'client-1',
+			status: OrderStatus.PENDING_BOOSTER,
+			requestDetails,
+			hasStoredCredentials: true,
+		});
+		order.setCredentials({
+			login: 'new-login',
+			summonerName: 'new-summoner',
+			password: 'new-secret',
+		});
+		await repository.save(order);
+
+		expect(deleteMany).not.toHaveBeenCalled();
+		const args = upsert.mock.calls[0][0];
+		expect(args.update.credentials.upsert.update).toEqual({
+			login: expect.stringMatching(/^v2:/),
+			summonerName: expect.stringMatching(/^v2:/),
+			password: expect.stringMatching(/^v2:/),
+		});
+	});
+
+	it('leaves stored credentials untouched when saving a booster rejection', async () => {
+		const upsert = jest.fn().mockResolvedValue(undefined);
+		const deleteMany = jest.fn();
+		const rejectionUpsert = jest.fn().mockResolvedValue(undefined);
+		const prisma = withTransaction({
+			order: { findUnique: jest.fn(), upsert },
+			orderCredentials: { deleteMany },
+			orderBoosterRejection: { upsert: rejectionUpsert },
+		});
+		const repository = new PrismaOrderRepository(prisma as never, cipher());
+
+		const order = Order.rehydrate({
+			id: 'order-1',
+			clientId: 'client-1',
+			status: OrderStatus.PENDING_BOOSTER,
+			requestDetails,
+			hasStoredCredentials: true,
+		});
+		await repository.saveBoosterRejection(order, 'booster-1');
+
+		expect(rejectionUpsert).toHaveBeenCalled();
+		expect(deleteMany).not.toHaveBeenCalled();
+		const args = upsert.mock.calls[0][0];
+		expect(args.create.credentials).toBeUndefined();
+		expect(args.update.credentials).toBeUndefined();
+	});
+
+	it('rejects sealing credentials for an order without a persisted id', async () => {
+		const upsert = jest.fn();
+		const deleteMany = jest.fn();
+		const prisma = withTransaction({
+			order: { findUnique: jest.fn(), upsert },
+			orderCredentials: { deleteMany },
+		});
+		const repository = new PrismaOrderRepository(prisma as never, cipher());
+
+		const order = Order.rehydrate({
+			id: '',
+			clientId: 'client-1',
+			status: OrderStatus.PENDING_BOOSTER,
+			requestDetails,
+		});
+		order.setCredentials({
+			login: 'login',
+			summonerName: 'summoner',
+			password: 'secret',
+		});
+
+		await expect(repository.save(order)).rejects.toThrow(
+			'Cannot encrypt an order credential without an order id.',
+		);
+		expect(upsert).not.toHaveBeenCalled();
 	});
 
 	it('returns null when order is missing', async () => {
@@ -167,13 +267,7 @@ describe('PrismaOrderRepository', () => {
 				upsert: jest.fn(),
 			},
 		};
-		const repository = new PrismaOrderRepository(
-			prisma as never,
-			new OrderCredentialsCipherService({
-				orderCredentialsEncryptionKey:
-					'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
-			} as never),
-		);
+		const repository = new PrismaOrderRepository(prisma as never, cipher());
 
 		await expect(repository.findById('missing-order')).resolves.toBeNull();
 	});
@@ -187,13 +281,7 @@ describe('PrismaOrderRepository', () => {
 				upsert: jest.fn(),
 			},
 		};
-		const repository = new PrismaOrderRepository(
-			prisma as never,
-			new OrderCredentialsCipherService({
-				orderCredentialsEncryptionKey:
-					'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
-			} as never),
-		);
+		const repository = new PrismaOrderRepository(prisma as never, cipher());
 
 		await expect(repository.findById('order-1')).rejects.toThrow(
 			'Invalid order status persisted: invalid_status',

--- a/apps/api/src/modules/orders/infrastructure/repositories/prisma-order.repository.ts
+++ b/apps/api/src/modules/orders/infrastructure/repositories/prisma-order.repository.ts
@@ -10,7 +10,6 @@ import type {
 import type { OrderRepositoryPort } from '@modules/orders/application/ports/order-repository.port';
 import {
 	Order,
-	type OrderCredentials,
 	type OrderRequestDetails,
 } from '@modules/orders/domain/order.entity';
 import { OrderStatus } from '@modules/orders/domain/order-status';
@@ -257,7 +256,7 @@ export class PrismaOrderRepository
 				...this.mapPricing(order),
 				completedAt: order.completedAt,
 				extras: this.mapExtrasCreate(order.extras),
-				credentials: this.mapCredentialsCreate(order.credentials),
+				credentials: this.mapCredentialsCreate(order),
 			},
 			include: { credentials: true, extras: true },
 		});
@@ -397,7 +396,9 @@ export class PrismaOrderRepository
 	}
 
 	async save(order: Order): Promise<void> {
-		await this.saveWithClient(order, this.getClient());
+		await this.prisma.$transaction(async (tx) => {
+			await this.saveWithClient(order, tx as unknown as OrderPrismaClient);
+		});
 	}
 
 	async saveBoosterRejection(order: Order, boosterId: string): Promise<void> {
@@ -424,9 +425,9 @@ export class PrismaOrderRepository
 		order: Order,
 		client: OrderPrismaClient,
 	): Promise<void> {
-		const credentialsCreate = this.mapCredentialsCreate(order.credentials);
-		const credentialsUpdate = this.mapCredentialsUpdate(order.credentials);
-		if (!order.credentials) {
+		const credentialsCreate = this.mapCredentialsCreate(order);
+		const credentialsUpdate = this.mapCredentialsUpdate(order);
+		if (!order.hasCredentials) {
 			await client.orderCredentials.deleteMany({
 				where: { orderId: order.id },
 			});
@@ -478,7 +479,7 @@ export class PrismaOrderRepository
 			couponId: record.couponId,
 			pricingVersionId: record.pricingVersionId,
 			status: ensurePersistedEnum(OrderStatus, record.status, 'order status'),
-			credentials: this.mapCredentialsFromRecord(record.credentials),
+			hasStoredCredentials: record.credentials !== null,
 			requestDetails: this.mapRequestDetailsFromRecord(record),
 			subtotal: record.subtotal,
 			totalAmount: record.totalAmount,
@@ -591,19 +592,34 @@ export class PrismaOrderRepository
 		};
 	}
 
-	private mapCredentialsFromRecord(
-		record: OrderRecord['credentials'],
-	): OrderCredentials | null {
-		if (!record) return null;
+	private sealCredentials(order: Order): {
+		login: string;
+		summonerName: string;
+		password: string;
+	} | null {
+		const credentials = order.pendingCredentials;
+		if (!credentials) return null;
 
 		return {
-			login: this.orderCredentialsCipher.decrypt(record.login),
-			summonerName: this.orderCredentialsCipher.decrypt(record.summonerName),
-			password: this.orderCredentialsCipher.decrypt(record.password),
+			login: this.orderCredentialsCipher.encryptField(
+				order.id,
+				'login',
+				credentials.login,
+			),
+			summonerName: this.orderCredentialsCipher.encryptField(
+				order.id,
+				'summonerName',
+				credentials.summonerName,
+			),
+			password: this.orderCredentialsCipher.encryptField(
+				order.id,
+				'password',
+				credentials.password,
+			),
 		};
 	}
 
-	private mapCredentialsCreate(credentials: OrderCredentials | null):
+	private mapCredentialsCreate(order: Order):
 		| {
 				create: {
 					login: string;
@@ -612,20 +628,13 @@ export class PrismaOrderRepository
 				};
 		  }
 		| undefined {
-		if (!credentials) return undefined;
+		const sealed = this.sealCredentials(order);
+		if (!sealed) return undefined;
 
-		return {
-			create: {
-				login: this.orderCredentialsCipher.encrypt(credentials.login),
-				summonerName: this.orderCredentialsCipher.encrypt(
-					credentials.summonerName,
-				),
-				password: this.orderCredentialsCipher.encrypt(credentials.password),
-			},
-		};
+		return { create: sealed };
 	}
 
-	private mapCredentialsUpdate(credentials: OrderCredentials | null):
+	private mapCredentialsUpdate(order: Order):
 		| {
 				upsert: {
 					create: {
@@ -641,26 +650,10 @@ export class PrismaOrderRepository
 				};
 		  }
 		| undefined {
-		if (!credentials) return undefined;
+		const sealed = this.sealCredentials(order);
+		if (!sealed) return undefined;
 
-		return {
-			upsert: {
-				create: {
-					login: this.orderCredentialsCipher.encrypt(credentials.login),
-					summonerName: this.orderCredentialsCipher.encrypt(
-						credentials.summonerName,
-					),
-					password: this.orderCredentialsCipher.encrypt(credentials.password),
-				},
-				update: {
-					login: this.orderCredentialsCipher.encrypt(credentials.login),
-					summonerName: this.orderCredentialsCipher.encrypt(
-						credentials.summonerName,
-					),
-					password: this.orderCredentialsCipher.encrypt(credentials.password),
-				},
-			},
-		};
+		return { upsert: { create: sealed, update: sealed } };
 	}
 
 	private mapRequestDetails(requestDetails: OrderRequestDetails | null): {

--- a/apps/api/src/modules/orders/infrastructure/security/order-credentials-cipher.service.spec.ts
+++ b/apps/api/src/modules/orders/infrastructure/security/order-credentials-cipher.service.spec.ts
@@ -1,5 +1,9 @@
+import { createCipheriv } from 'node:crypto';
 import { OrderCredentialsCipherService } from '@modules/orders/infrastructure/security/order-credentials-cipher.service';
-import { ORDER_CREDENTIALS_ENCRYPTION_KEY_ERROR_MESSAGE } from '@packages/config/env/order-credentials-encryption-key';
+import {
+	decodeOrderCredentialsEncryptionKey,
+	ORDER_CREDENTIALS_ENCRYPTION_KEY_ERROR_MESSAGE,
+} from '@packages/config/env/order-credentials-encryption-key';
 
 describe('OrderCredentialsCipherService', () => {
 	const appSettings = {
@@ -9,17 +13,136 @@ describe('OrderCredentialsCipherService', () => {
 
 	it('encrypts and decrypts credential fields', () => {
 		const service = new OrderCredentialsCipherService(appSettings as never);
-		const encryptedValue = service.encrypt('secret-db');
+		const encryptedValue = service.encryptField(
+			'order-1',
+			'password',
+			'secret-db',
+		);
 
 		expect(encryptedValue).not.toBe('secret-db');
-		expect(encryptedValue.startsWith('v1:')).toBe(true);
-		expect(service.decrypt(encryptedValue)).toBe('secret-db');
+		expect(encryptedValue.startsWith('v2:')).toBe(true);
+		expect(service.decryptField('order-1', 'password', encryptedValue)).toBe(
+			'secret-db',
+		);
+	});
+
+	it('rejects encrypting empty values and empty order ids', () => {
+		const service = new OrderCredentialsCipherService(appSettings as never);
+
+		expect(() => service.encryptField('order-1', 'password', '')).toThrow(
+			'Cannot encrypt an empty order credential value.',
+		);
+		expect(() => service.encryptField('', 'password', 'secret')).toThrow(
+			'Cannot encrypt an order credential without an order id.',
+		);
+	});
+
+	it('rejects malformed sealed payloads', () => {
+		const service = new OrderCredentialsCipherService(appSettings as never);
+		const encryptedValue = service.encryptField(
+			'order-1',
+			'password',
+			'secret-db',
+		);
+		const [, iv, tag, ciphertext] = encryptedValue.split(':');
+
+		for (const malformed of [
+			`v2:${iv}:${tag}`,
+			`v2:${iv}:${tag}:${ciphertext}:extra`,
+			'v2:',
+			`v2::${tag}:${ciphertext}`,
+			`v2:${iv}::${ciphertext}`,
+		])
+			expect(() =>
+				service.decryptField('order-1', 'password', malformed),
+			).toThrow('Invalid encrypted order credentials payload.');
+	});
+
+	it('rejects ciphertext moved to another order or field', () => {
+		const service = new OrderCredentialsCipherService(appSettings as never);
+		const encryptedValue = service.encryptField(
+			'order-1',
+			'password',
+			'secret-db',
+		);
+
+		expect(() =>
+			service.decryptField('order-2', 'password', encryptedValue),
+		).toThrow();
+		expect(() =>
+			service.decryptField('order-1', 'login', encryptedValue),
+		).toThrow();
+	});
+
+	it('rejects tampered ciphertext', () => {
+		const service = new OrderCredentialsCipherService(appSettings as never);
+		const encryptedValue = service.encryptField(
+			'order-1',
+			'password',
+			'secret-db',
+		);
+		const [version, iv, tag, ciphertext] = encryptedValue.split(':');
+		const corrupted = Buffer.from(ciphertext, 'base64url');
+		corrupted[0] ^= 0xff;
+		const tampered = [version, iv, tag, corrupted.toString('base64url')].join(
+			':',
+		);
+
+		expect(() =>
+			service.decryptField('order-1', 'password', tampered),
+		).toThrow();
+	});
+
+	it('decrypts legacy v1 values without additional authenticated data', () => {
+		const service = new OrderCredentialsCipherService(appSettings as never);
+		const key = decodeOrderCredentialsEncryptionKey(
+			appSettings.orderCredentialsEncryptionKey,
+		);
+		const iv = Buffer.alloc(12, 1);
+		const cipher = createCipheriv('aes-256-gcm', key, iv);
+		const ciphertext = Buffer.concat([
+			cipher.update('legacy-secret', 'utf8'),
+			cipher.final(),
+		]);
+		const legacyValue = [
+			'v1',
+			iv.toString('base64url'),
+			cipher.getAuthTag().toString('base64url'),
+			ciphertext.toString('base64url'),
+		].join(':');
+
+		expect(service.decryptField('order-1', 'password', legacyValue)).toBe(
+			'legacy-secret',
+		);
+	});
+
+	it('round-trips legacy v1 values sealed from empty plaintext', () => {
+		const service = new OrderCredentialsCipherService(appSettings as never);
+		const key = decodeOrderCredentialsEncryptionKey(
+			appSettings.orderCredentialsEncryptionKey,
+		);
+		const iv = Buffer.alloc(12, 2);
+		const cipher = createCipheriv('aes-256-gcm', key, iv);
+		const ciphertext = Buffer.concat([
+			cipher.update('', 'utf8'),
+			cipher.final(),
+		]);
+		const legacyValue = [
+			'v1',
+			iv.toString('base64url'),
+			cipher.getAuthTag().toString('base64url'),
+			ciphertext.toString('base64url'),
+		].join(':');
+
+		expect(service.decryptField('order-1', 'password', legacyValue)).toBe('');
 	});
 
 	it('supports legacy plaintext reads during rollout', () => {
 		const service = new OrderCredentialsCipherService(appSettings as never);
 
-		expect(service.decrypt('legacy-plaintext')).toBe('legacy-plaintext');
+		expect(service.decryptField('order-1', 'login', 'legacy-plaintext')).toBe(
+			'legacy-plaintext',
+		);
 	});
 
 	it('rejects malformed encryption keys', () => {

--- a/apps/api/src/modules/orders/infrastructure/security/order-credentials-cipher.service.ts
+++ b/apps/api/src/modules/orders/infrastructure/security/order-credentials-cipher.service.ts
@@ -3,8 +3,11 @@ import { AppSettingsService } from '@app/common/settings/app-settings.service';
 import { Injectable } from '@nestjs/common';
 import { decodeOrderCredentialsEncryptionKey } from '@packages/config/env/order-credentials-encryption-key';
 
-const ENCRYPTED_VALUE_VERSION = 'v1';
+const LEGACY_VALUE_VERSION = 'v1';
+const ENCRYPTED_VALUE_VERSION = 'v2';
 const INITIALIZATION_VECTOR_LENGTH = 12;
+
+export type OrderCredentialField = 'login' | 'summonerName' | 'password';
 
 @Injectable()
 export class OrderCredentialsCipherService {
@@ -16,13 +19,25 @@ export class OrderCredentialsCipherService {
 		);
 	}
 
-	encrypt(value: string): string {
+	encryptField(
+		orderId: string,
+		field: OrderCredentialField,
+		value: string,
+	): string {
+		if (!orderId)
+			throw new Error(
+				'Cannot encrypt an order credential without an order id.',
+			);
+		if (!value)
+			throw new Error('Cannot encrypt an empty order credential value.');
+
 		const initializationVector = randomBytes(INITIALIZATION_VECTOR_LENGTH);
 		const cipher = createCipheriv(
 			'aes-256-gcm',
 			this.key,
 			initializationVector,
 		);
+		cipher.setAAD(this.additionalAuthenticatedData(orderId, field));
 		const ciphertext = Buffer.concat([
 			cipher.update(value, 'utf8'),
 			cipher.final(),
@@ -37,21 +52,33 @@ export class OrderCredentialsCipherService {
 		].join(':');
 	}
 
-	decrypt(value: string): string {
-		if (!value.startsWith(`${ENCRYPTED_VALUE_VERSION}:`)) return value;
+	decryptField(
+		orderId: string,
+		field: OrderCredentialField,
+		value: string,
+	): string {
+		if (value.startsWith(`${ENCRYPTED_VALUE_VERSION}:`))
+			return this.decryptSealed(
+				value,
+				this.additionalAuthenticatedData(orderId, field),
+			);
+		if (value.startsWith(`${LEGACY_VALUE_VERSION}:`))
+			return this.decryptSealed(value, null);
 
-		const [
-			version,
-			initializationVector,
-			authenticationTag,
-			ciphertext,
-			...rest
-		] = value.split(':');
+		// ponytail: legacy plaintext passthrough; drop once pre-encryption rows age out
+		return value;
+	}
+
+	private decryptSealed(
+		value: string,
+		additionalAuthenticatedData: Buffer | null,
+	): string {
+		const [, initializationVector, authenticationTag, ciphertext, ...rest] =
+			value.split(':');
 		if (
-			version !== ENCRYPTED_VALUE_VERSION ||
 			!initializationVector ||
 			!authenticationTag ||
-			!ciphertext ||
+			ciphertext === undefined ||
 			rest.length > 0
 		)
 			throw new Error('Invalid encrypted order credentials payload.');
@@ -61,11 +88,20 @@ export class OrderCredentialsCipherService {
 			this.key,
 			Buffer.from(initializationVector, 'base64url'),
 		);
+		if (additionalAuthenticatedData)
+			decipher.setAAD(additionalAuthenticatedData);
 		decipher.setAuthTag(Buffer.from(authenticationTag, 'base64url'));
 
 		return Buffer.concat([
 			decipher.update(Buffer.from(ciphertext, 'base64url')),
 			decipher.final(),
 		]).toString('utf8');
+	}
+
+	private additionalAuthenticatedData(
+		orderId: string,
+		field: OrderCredentialField,
+	): Buffer {
+		return Buffer.from(`order-credentials:${orderId}:${field}`, 'utf8');
 	}
 }

--- a/apps/api/src/modules/orders/presentation/orders.controller.ts
+++ b/apps/api/src/modules/orders/presentation/orders.controller.ts
@@ -248,6 +248,7 @@ export class OrdersController {
 	): Promise<{
 		id: string;
 		status: string;
+		hasCredentials: boolean;
 		subtotal: number | null;
 		totalAmount: number | null;
 		discountAmount: number;

--- a/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
+++ b/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
@@ -840,19 +840,16 @@ describe('Orders module integration (db)', () => {
 		expect(credentials).toMatchObject({
 			orderId: createdOrder.id,
 		});
-		expect(credentials?.login).not.toBe('login-db');
-		expect(credentials?.summonerName).not.toBe('summoner-db');
-		expect(credentials?.password).not.toBe('secret-db');
+		expect(credentials?.login).toMatch(/^v2:/);
+		expect(credentials?.summonerName).toMatch(/^v2:/);
+		expect(credentials?.password).toMatch(/^v2:/);
 
 		await expect(
 			orderRepository.findById(createdOrder.id),
 		).resolves.toMatchObject({
 			id: createdOrder.id,
-			credentials: {
-				login: 'login-db',
-				summonerName: 'summoner-db',
-				password: 'secret-db',
-			},
+			hasCredentials: true,
+			pendingCredentials: null,
 		});
 	});
 
@@ -888,6 +885,27 @@ describe('Orders module integration (db)', () => {
 			desiredLeague: 'platinum',
 			desiredDivision: 'IV',
 		});
+	});
+
+	it('deletes credentials after order cancellation', async () => {
+		const createdOrder = await createQuotedOrder();
+		await markOrderAsPaidUseCase.execute({ orderId: createdOrder.id });
+		await controller.saveCredentials(
+			createdOrder.id,
+			{
+				login: 'login-db',
+				summonerName: 'summoner-db',
+				password: 'secret-db',
+				confirmPassword: 'secret-db',
+			},
+			clientUser,
+		);
+		await controller.cancel(createdOrder.id, clientUser);
+
+		const credentials = await prisma.orderCredentials.findUnique({
+			where: { orderId: createdOrder.id },
+		});
+		expect(credentials).toBeNull();
 	});
 
 	it('rejects credentials before payment confirmation', async () => {

--- a/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
+++ b/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
@@ -190,6 +190,7 @@ describe('Orders module integration (db)', () => {
 		await expect(controller.get(createdOrder.id, clientUser)).resolves.toEqual({
 			id: createdOrder.id,
 			status: 'awaiting_payment',
+			hasCredentials: false,
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,
@@ -752,6 +753,7 @@ describe('Orders module integration (db)', () => {
 		await expect(controller.get(createdOrder.id, clientUser)).resolves.toEqual({
 			id: createdOrder.id,
 			status: 'in_progress',
+			hasCredentials: false,
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,

--- a/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
+++ b/apps/api/test/integration-db/orders/orders.db.integration.spec.ts
@@ -876,6 +876,7 @@ describe('Orders module integration (db)', () => {
 		await expect(controller.get(createdOrder.id, clientUser)).resolves.toEqual({
 			id: createdOrder.id,
 			status: 'completed',
+			hasCredentials: false,
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,

--- a/apps/api/test/integration/orders/orders.integration.spec.ts
+++ b/apps/api/test/integration/orders/orders.integration.spec.ts
@@ -160,6 +160,7 @@ describe('Orders module integration', () => {
 		await expect(controller.get(createdOrder.id, clientUser)).resolves.toEqual({
 			id: createdOrder.id,
 			status: 'awaiting_payment',
+			hasCredentials: false,
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,
@@ -366,6 +367,7 @@ describe('Orders module integration', () => {
 		await expect(controller.get(createdOrder.id, clientUser)).resolves.toEqual({
 			id: createdOrder.id,
 			status: 'completed',
+			hasCredentials: false,
 			subtotal: 2520,
 			totalAmount: 2520,
 			discountAmount: 0,

--- a/apps/api/test/load-test-env.ts
+++ b/apps/api/test/load-test-env.ts
@@ -17,3 +17,4 @@ process.env.WEB_SESSION_SECRET ??=
 	'a-very-secret-and-long-session-key-for-development-32chars';
 process.env.ORDER_CREDENTIALS_ENCRYPTION_KEY ??=
 	'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
+process.env.API_MUTATION_THROTTLE_LIMIT ??= '10000';

--- a/apps/api/test/orders.e2e-db.spec.ts
+++ b/apps/api/test/orders.e2e-db.spec.ts
@@ -119,6 +119,7 @@ describe('Orders (e2e db)', () => {
 			.expect(200, {
 				id: orderId,
 				status: 'awaiting_payment',
+				hasCredentials: false,
 				subtotal: 2520,
 				totalAmount: 2520,
 				discountAmount: 0,

--- a/apps/api/test/orders.e2e-spec.ts
+++ b/apps/api/test/orders.e2e-spec.ts
@@ -236,6 +236,7 @@ describe('Orders (e2e)', () => {
 			.expect(200, {
 				id: createdOrder.id,
 				status: 'awaiting_payment',
+				hasCredentials: false,
 				subtotal: 2520,
 				totalAmount: 2520,
 				discountAmount: 0,
@@ -401,6 +402,7 @@ describe('Orders (e2e)', () => {
 			.expect(200, {
 				id: createdOrder.id,
 				status: 'in_progress',
+				hasCredentials: false,
 				subtotal: 2520,
 				totalAmount: 2520,
 				discountAmount: 0,

--- a/apps/api/test/support/in-memory/orders/in-memory-order.repository.ts
+++ b/apps/api/test/support/in-memory/orders/in-memory-order.repository.ts
@@ -6,6 +6,23 @@ import type { OrderRepositoryPort } from '@modules/orders/application/ports/orde
 import { Order } from '@modules/orders/domain/order.entity';
 import { OrderStatus } from '@modules/orders/domain/order-status';
 
+export const persistedOrderCopy = (order: Order): Order =>
+	Order.rehydrate({
+		id: order.id,
+		clientId: order.clientId,
+		boosterId: order.boosterId,
+		couponId: order.couponId,
+		pricingVersionId: order.pricingVersionId,
+		status: order.status,
+		hasStoredCredentials: order.hasCredentials,
+		requestDetails: order.requestDetails,
+		subtotal: order.subtotal,
+		totalAmount: order.totalAmount,
+		discountAmount: order.discountAmount,
+		extras: order.extras,
+		completedAt: order.completedAt,
+	});
+
 export class InMemoryOrderRepository
 	implements OrderRepositoryPort, ClientOrderReaderPort
 {
@@ -22,12 +39,13 @@ export class InMemoryOrderRepository
 			couponId: order.couponId,
 			pricingVersionId: order.pricingVersionId,
 			status: order.status,
-			credentials: order.credentials,
+			hasStoredCredentials: order.hasCredentials,
 			requestDetails: order.requestDetails,
 			subtotal: order.subtotal,
 			totalAmount: order.totalAmount,
 			discountAmount: order.discountAmount,
 			extras: order.extras,
+			completedAt: order.completedAt,
 		});
 		this.orders.set(createdOrder.id, createdOrder);
 		this.createdAtByOrderId.set(
@@ -134,7 +152,7 @@ export class InMemoryOrderRepository
 	}
 
 	save(order: Order): Promise<void> {
-		this.orders.set(order.id, order);
+		this.orders.set(order.id, persistedOrderCopy(order));
 		if (!this.createdAtByOrderId.has(order.id)) {
 			this.createdAtByOrderId.set(
 				order.id,

--- a/apps/api/test/test-app-settings.ts
+++ b/apps/api/test/test-app-settings.ts
@@ -18,6 +18,8 @@ export function createTestAppSettings(
 		internalApiKey: 'test-internal-api-key',
 		orderCredentialsEncryptionKey:
 			'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+		apiMutationThrottleLimit: 10_000,
+		apiMutationThrottleTtlSeconds: 60,
 		authLoginThrottleLimit: 10,
 		authLoginThrottleTtlSeconds: 60,
 		authRefreshThrottleLimit: 10,

--- a/docs/tasks/third-party-credential-storage.md
+++ b/docs/tasks/third-party-credential-storage.md
@@ -1,0 +1,92 @@
+# Order Credentials Hardening
+
+Final scope, decided 2026-07-21. Earlier drafts of this document described a
+KMS-based (then RSA-envelope-based) store with a worker-only decrypt boundary. That
+design assumed an automated machine-to-machine consumer. This codebase's credentials
+are League account logins (`OrderCredentials`: login / summonerName / password) whose
+eventual consumer is a human booster reading them through the API — so the API must
+be able to decrypt, and the asymmetric API/worker key split is inapplicable. The
+decision was to harden the existing order-credentials flow instead.
+
+## Threat model
+
+Protects against: database dumps, leaked backups, leaked DB credentials, read-only
+SQL injection, and ciphertext being moved between rows/fields.
+
+Does not protect against: compromise of the API runtime or its encryption key
+(`ORDER_CREDENTIALS_ENCRYPTION_KEY`), or capture before encryption. This is an
+explicit, accepted tradeoff — the read path requires API-side decryption.
+
+## What was implemented (2026-07-21)
+
+### v2 sealed format with AAD
+
+`OrderCredentialsCipherService` (orders module, infrastructure/security) now produces
+`v2:<iv>:<tag>:<ciphertext>` values, AES-256-GCM with additional authenticated data
+`order-credentials:<orderId>:<field>`. v2 ciphertext copied to another order or field
+fails authentication. Encryption rejects empty values and empty order ids (an order
+id must exist before sealing, since the AAD binds to it — this also blocks the
+`create()`-with-generated-id trap where credentials would be sealed under the wrong
+AAD). Decryption accepts any segment layout the encryptor can produce and rejects
+malformed payloads.
+
+Reads still accept `v1:` values (pre-AAD) and raw plaintext (pre-encryption legacy);
+both fallbacks can be dropped once old rows age out — credentials only live from
+payment confirmation to order termination, so churn handles migration. Until then be
+precise about what the fallbacks cost: v1 rows carry no AAD, so cross-row/cross-field
+swaps of v1 ciphertext still decrypt undetected, and the plaintext passthrough
+returns any garbled non-`v1:`/`v2:` value as-is instead of erroring (it also means a
+DB-write attacker can plant plaintext that "decrypts" — the stated threat model only
+covers read access). Same env key as before; no schema change.
+
+### Plaintext no longer round-trips
+
+Previously every order load decrypted credentials into the `Order` entity and every
+save re-encrypted them. Now:
+
+- The entity holds plaintext only when freshly submitted (`setCredentials` →
+  `pendingCredentials`); rehydration from the database carries just a
+  `hasStoredCredentials` flag. Sealed values are never decrypted on load.
+- `PrismaOrderRepository.save` writes credentials only when `pendingCredentials` is
+  set; an unmodified order leaves the stored row untouched (no decrypt/re-encrypt
+  churn, and each field is sealed exactly once per save instead of twice).
+- `complete()`, `cancel()`, and `clearCredentials()` clear both, and save deletes the
+  row. Cancellation cleanup is new: previously a client who paid, submitted
+  credentials, then cancelled left the encrypted row on a terminal order forever.
+- `save()` runs the credentials delete and the order upsert in one transaction, so a
+  transient upsert failure can no longer strand an active order with its credentials
+  already deleted.
+- Nothing in the API currently decrypts stored credentials; `decryptField` exists for
+  the future booster read path.
+
+### Lifecycle
+
+Credentials are stored only after payment confirmation, deleted on payment failure
+(payments cleanup adapter), on order completion, and on order cancellation, and
+cascade-deleted with the order. Every terminal order state now clears credentials;
+order state is the expiry mechanism and no separate TTL was added.
+
+## Known limitations (accepted)
+
+- Deleting the row does not scrub historical database backups; the env key decrypts
+  any backup containing ciphertext. Mitigations: short backup retention, restricted
+  backup access, key rotation (v2 format is versioned; a v3 can change keys).
+- Plaintext/v1 read fallbacks remain until pre-hardening rows are gone (see
+  `ponytail:` marker in the cipher service).
+
+## Future work (when the booster read path is built)
+
+- Dedicated endpoint that decrypts on explicit request only, booster-authorized,
+  with an audit event per reveal (who, when, which order) and no credential values
+  in logs/traces/responses beyond the reveal payload itself.
+- Consider a reveal counter for anomaly detection at that point, not before.
+- Disable request-body logging for the save/reveal routes if request logging is ever
+  added.
+
+## Verification
+
+- Unit: cipher round-trip, cross-order/cross-field AAD rejection, tamper rejection,
+  v1 and plaintext fallbacks; repository seals-once/leaves-stored-untouched/deletes;
+  entity credential state transitions. (`apps/api`, orders module specs)
+- DB integration: `orders.db.integration` asserts stored values are `v2:` sealed,
+  never plaintext, deleted on completion, rejected before payment confirmation.

--- a/packages/config/src/env/env.schema.ts
+++ b/packages/config/src/env/env.schema.ts
@@ -116,6 +116,12 @@ export const envSchema = z
 			.default('http://localhost:3001'),
 		WEB_APP_URL: z.string().trim().url().default(DEFAULT_WEB_APP_URL),
 		ORDER_QUOTE_TTL_MINUTES: z.coerce.number().int().positive().default(60),
+		API_MUTATION_THROTTLE_LIMIT: z.coerce.number().int().positive().default(60),
+		API_MUTATION_THROTTLE_TTL_SECONDS: z.coerce
+			.number()
+			.int()
+			.positive()
+			.default(60),
 		AUTH_LOGIN_THROTTLE_LIMIT: z.coerce.number().int().positive().default(5),
 		AUTH_LOGIN_THROTTLE_TTL_SECONDS: z.coerce
 			.number()


### PR DESCRIPTION
## Summary

Hardens the existing `OrderCredentials` flow (client-submitted League account credentials) and closes all findings from a systematic security review:

- **v2 sealed format with AAD**: each field is AES-256-GCM encrypted bound to `order-credentials:<orderId>:<field>`, so ciphertext moved between rows/fields fails authentication. Legacy `v1`/plaintext values stay readable until pre-hardening rows age out of the order lifecycle.
- **No decrypt-on-load**: the `Order` entity holds plaintext only for freshly submitted credentials; rehydration carries a presence flag, saves never re-encrypt stored rows.
- **Lifecycle fixes**: credentials are now cleared on cancellation (previously a paid-then-cancelled order kept its encrypted row forever); the credentials delete and order upsert run in one transaction; encryption rejects empty values/ids.
- **`hasCredentials` in client order details** so the UI can show submission state (FR from `docs/tasks/client-order-details-improvements.md`).
- **Global mutation throttling** (default 60/min per client, skips reads and internal worker routes), tracked by `CF-Connecting-IP` — behind the Cloudflare tunnel `req.ip` is the tunnel address, which also silently broke the existing auth throttles (all clients shared one bucket); fixed in the shared guard base.
- Design doc: `docs/tasks/third-party-credential-storage.md`.

Closes no open issue (work originated from an in-repo security review).

## Verification

```bash
pnpm --filter api exec jest "src/.*\.spec\.ts$" --runInBand          # 373 passed
pnpm --filter api exec jest "test/integration/.*spec.ts$" --runInBand # 37 passed
bash scripts/api-db-test.sh ./test/jest-integration-db.json "orders.db.integration|payments.db.integration"  # 29 passed
pnpm --filter api exec jest --config ./test/jest-e2e.json --runInBand --forceExit  # 98 passed
pnpm exec tsc --noEmit -p apps/api/tsconfig.json
pnpm exec biome check apps/api packages/config
```

## Skipped checks and remaining risk

- The e2e suite passes 98/98 but the jest **process** can hang after the run in my local environment — reproducible on unmodified `main` (same hang), so it is pre-existing and environment-dependent (correlates with local dev docker services running), not introduced here. Worth an issue if CI shows it.
- Legacy plaintext/v1 read fallbacks remain by design until pre-hardening rows churn out (marked with a `ponytail:` comment + doc note); dropping them is a follow-up after the next release.
- Prod env can tune `API_MUTATION_THROTTLE_LIMIT` / `API_MUTATION_THROTTLE_TTL_SECONDS`; defaults (60/min) are generous for current traffic.

## Breaking changes

None. New env vars have defaults; `GET /orders/:orderId` gains an additive field; existing v1-encrypted rows remain readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8Y72yuDby5JV1fprBvYPZ