### PR TITLE
feat(web): add account step to order wizard

### DIFF
--- a/apps/web/src/modules/client-dashboard/presentation/new-order/account-step.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/account-step.tsx
@@ -1,0 +1,244 @@
+import { ChevronRight, Eye, EyeOff, ShieldCheck } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/shared/ui/components/button';
+import { Input } from '@/shared/ui/components/input';
+import { Label } from '@/shared/ui/components/label';
+
+export type AccountInput = {
+	login: string;
+	summonerName: string;
+	password: string;
+	passwordConfirmation: string;
+};
+
+type AccountStepProps = {
+	accountInput: AccountInput;
+	onBack: () => void;
+	onChange: (key: keyof AccountInput, value: string) => void;
+	onNext: () => void;
+	onNextIntent?: () => void;
+};
+
+type PasswordFieldProps = {
+	description: string;
+	error?: string;
+	id: string;
+	label: string;
+	name: string;
+	onBlur: () => void;
+	onChange: (value: string) => void;
+	value: string;
+};
+
+const PasswordField = ({
+	description,
+	error,
+	id,
+	label,
+	name,
+	onBlur,
+	onChange,
+	value,
+}: PasswordFieldProps) => {
+	const [isVisible, setIsVisible] = useState(false);
+	const helpId = `${id}-help`;
+
+	return (
+		<div className="space-y-3">
+			<Label htmlFor={id}>
+				{label} <span aria-hidden="true">*</span>
+			</Label>
+			<div className="relative">
+				<Input
+					id={id}
+					name={name}
+					type={isVisible ? 'text' : 'password'}
+					value={value}
+					onChange={(event) => onChange(event.target.value)}
+					onBlur={onBlur}
+					autoComplete="new-password"
+					minLength={8}
+					maxLength={128}
+					aria-invalid={Boolean(error)}
+					aria-describedby={helpId}
+					className="h-12 pr-12 text-base md:text-sm"
+					required
+				/>
+				<button
+					type="button"
+					className="absolute right-0 top-0 flex h-12 w-12 cursor-pointer items-center justify-center text-white/60 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-hextech-cyan"
+					onClick={() => setIsVisible((current) => !current)}
+					aria-label={isVisible ? `Ocultar ${label}` : `Mostrar ${label}`}
+				>
+					{isVisible ? (
+						<EyeOff className="h-5 w-5" aria-hidden="true" />
+					) : (
+						<Eye className="h-5 w-5" aria-hidden="true" />
+					)}
+				</button>
+			</div>
+			<p
+				id={helpId}
+				className={error ? 'text-sm text-danger' : 'text-sm text-white/55'}
+				role={error ? 'alert' : undefined}
+			>
+				{error ?? description}
+			</p>
+		</div>
+	);
+};
+
+export const AccountStep = ({
+	accountInput,
+	onBack,
+	onChange,
+	onNext,
+	onNextIntent,
+}: AccountStepProps) => {
+	const [touchedFields, setTouchedFields] = useState<
+		Partial<Record<keyof AccountInput, boolean>>
+	>({});
+	const hasValidLoginLength =
+		accountInput.login.length >= 8 && accountInput.login.length <= 64;
+	const hasValidPasswordLength =
+		accountInput.password.length >= 8 && accountInput.password.length <= 128;
+	const passwordsMatch =
+		accountInput.password === accountInput.passwordConfirmation;
+	const canContinue =
+		hasValidLoginLength &&
+		hasValidPasswordLength &&
+		accountInput.summonerName.trim().length > 0 &&
+		passwordsMatch;
+	const markAsTouched = (field: keyof AccountInput) => {
+		setTouchedFields((current) => ({ ...current, [field]: true }));
+	};
+
+	return (
+		<div className="space-y-8">
+			<div className="space-y-2">
+				<h2 className="text-xl font-black uppercase tracking-[0.2em]">Conta</h2>
+				<p className="text-sm leading-relaxed text-white/65">
+					Informe os dados da conta que receberá o boost.
+				</p>
+			</div>
+
+			<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+				<div className="space-y-3">
+					<Label htmlFor="account-login">
+						Login <span aria-hidden="true">*</span>
+					</Label>
+					<Input
+						id="account-login"
+						name="accountLogin"
+						value={accountInput.login}
+						onChange={(event) => onChange('login', event.target.value)}
+						onBlur={() => markAsTouched('login')}
+						autoComplete="off"
+						minLength={8}
+						maxLength={64}
+						aria-invalid={touchedFields.login && !hasValidLoginLength}
+						aria-describedby="account-login-help"
+						className="h-12 text-base md:text-sm"
+						required
+					/>
+					<p
+						id="account-login-help"
+						className={
+							touchedFields.login && !hasValidLoginLength
+								? 'text-sm text-danger'
+								: 'text-sm text-white/55'
+						}
+						role={
+							touchedFields.login && !hasValidLoginLength ? 'alert' : undefined
+						}
+					>
+						Use entre 8 e 64 caracteres.
+					</p>
+				</div>
+				<div className="space-y-3">
+					<Label htmlFor="summoner-name">
+						Nome de invocador <span aria-hidden="true">*</span>
+					</Label>
+					<Input
+						id="summoner-name"
+						name="summonerName"
+						value={accountInput.summonerName}
+						onChange={(event) => onChange('summonerName', event.target.value)}
+						autoComplete="off"
+						className="h-12 text-base md:text-sm"
+						required
+					/>
+				</div>
+				<PasswordField
+					id="account-password"
+					name="accountPassword"
+					label="Senha"
+					value={accountInput.password}
+					onChange={(value) => onChange('password', value)}
+					onBlur={() => markAsTouched('password')}
+					description="Use entre 8 e 128 caracteres."
+					error={
+						touchedFields.password && !hasValidPasswordLength
+							? 'A senha deve ter entre 8 e 128 caracteres.'
+							: undefined
+					}
+				/>
+				<PasswordField
+					id="account-password-confirmation"
+					name="accountPasswordConfirmation"
+					label="Confirmar senha"
+					value={accountInput.passwordConfirmation}
+					onChange={(value) => onChange('passwordConfirmation', value)}
+					onBlur={() => markAsTouched('passwordConfirmation')}
+					description="Repita a senha."
+					error={
+						touchedFields.passwordConfirmation && !passwordsMatch
+							? 'As senhas não coincidem.'
+							: undefined
+					}
+				/>
+			</div>
+
+			<aside className="border border-hextech-gold/30 bg-hextech-gold/5 p-4">
+				<div className="flex items-center gap-2 text-hextech-gold">
+					<ShieldCheck className="h-5 w-5" aria-hidden="true" />
+					<h3 className="text-sm font-black uppercase tracking-widest">
+						Cuidados com sua senha
+					</h3>
+				</div>
+				<ol className="mt-4 space-y-3 text-sm leading-relaxed text-white/75">
+					<li className="border-b border-white/10 pb-3">
+						<span className="mr-2 font-black text-hextech-gold">1.</span>
+						Antes de iniciar o boost, recomendamos que você use uma senha nova.
+					</li>
+					<li>
+						<span className="mr-2 font-black text-hextech-gold">2.</span>
+						Quando o boost terminar, crie outra senha nova e exclusiva.
+					</li>
+				</ol>
+			</aside>
+
+			<div className="mt-8 flex flex-col gap-3 border-t border-white/10 pt-6 sm:flex-row sm:justify-end">
+				<Button
+					variant="outline"
+					size="lg"
+					className="w-full sm:w-auto"
+					onClick={onBack}
+				>
+					Voltar
+				</Button>
+				<Button
+					size="lg"
+					onClick={onNext}
+					onFocus={onNextIntent}
+					onMouseEnter={onNextIntent}
+					className="w-full sm:w-auto"
+					disabled={!canContinue}
+				>
+					Revisar Pedido
+					<ChevronRight className="ml-2 h-4 w-4" aria-hidden="true" />
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/checkout-summary.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/checkout-summary.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { Target } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { formatBRL } from '@/shared/format/currency';
 import { gsap, useGSAP } from '@/shared/ui/animation/gsap';
 import { Button } from '@/shared/ui/components/button';
@@ -34,13 +33,7 @@ type CheckoutSummaryProps = {
 	quotePreviewError?: string | null;
 };
 
-const AnimatedCurrency = ({
-	className,
-	value,
-}: {
-	className?: string;
-	value: number | null;
-}) => {
+const Currency = ({ value }: { value: number | null }) => {
 	const textRef = useRef<HTMLSpanElement>(null);
 	const previousValue = useRef(value ?? 0);
 
@@ -48,6 +41,12 @@ const AnimatedCurrency = ({
 		() => {
 			if (value === null) {
 				if (textRef.current) textRef.current.textContent = '...';
+				return;
+			}
+
+			if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+				if (textRef.current) textRef.current.textContent = formatBRL(value);
+				previousValue.current = value;
 				return;
 			}
 
@@ -64,20 +63,13 @@ const AnimatedCurrency = ({
 				},
 				onComplete: () => {
 					previousValue.current = value;
-					if (textRef.current) {
-						textRef.current.textContent = formatBRL(value);
-					}
 				},
 			});
 		},
 		{ scope: textRef, dependencies: [value] },
 	);
 
-	return (
-		<span ref={textRef} className={className}>
-			{value === null ? '...' : formatBRL(value)}
-		</span>
-	);
+	return <span ref={textRef}>{value === null ? '...' : formatBRL(value)}</span>;
 };
 
 const CheckoutItemRow = ({
@@ -85,60 +77,33 @@ const CheckoutItemRow = ({
 	value,
 	priceLabel,
 	className,
-	containerClassName,
-	labelClassName,
-	valueClassName,
 }: {
 	label: string;
-	value: number;
+	value: number | null;
 	priceLabel?: string;
 	className?: string;
-	containerClassName?: string;
-	labelClassName?: string;
-	valueClassName?: string;
-}) => {
-	return (
-		<motion.div
-			layout
-			initial={{ opacity: 0, x: -15, height: 0, marginBottom: 0 }}
-			animate={{ opacity: 1, x: 0, height: 'auto', marginBottom: 4 }}
-			exit={{ opacity: 0, x: 15, height: 0, marginBottom: 0 }}
-			transition={{
-				type: 'spring',
-				stiffness: 300,
-				damping: 30,
-				opacity: { duration: 0.2 },
-			}}
-			className={cn(
-				'overflow-hidden flex justify-between gap-3 text-xs items-center',
-				containerClassName || className,
+}) => (
+	<div
+		className={cn('flex items-center justify-between gap-3 text-sm', className)}
+	>
+		<span className="text-white/65">{label}</span>
+		<span className="text-right font-bold text-white/85">
+			{value === null ? (
+				<Currency value={null} />
+			) : value === 0 ? (
+				'Grátis'
+			) : (
+				<>
+					{priceLabel ? (
+						<span className="mr-1.5 text-hextech-gold">{priceLabel}</span>
+					) : null}
+					{value < 0 ? '- ' : ''}
+					<Currency value={Math.abs(value)} />
+				</>
 			)}
-		>
-			<span className={cn('text-white/40', labelClassName)}>{label}</span>
-			<span className={cn('font-black text-white/70', valueClassName)}>
-				{value === 0 ? (
-					'Grátis'
-				) : (
-					<span className="flex items-center gap-1.5">
-						{priceLabel && (
-							<span className="text-hextech-gold">{priceLabel}</span>
-						)}
-						<span
-							className={cn(
-								priceLabel ? 'text-[10px] opacity-40 font-medium' : '',
-							)}
-						>
-							{priceLabel && '('}
-							{value < 0 ? '- ' : ''}
-							<AnimatedCurrency value={Math.abs(value)} />
-							{priceLabel && ')'}
-						</span>
-					</span>
-				)}
-			</span>
-		</motion.div>
-	);
-};
+		</span>
+	</div>
+);
 
 export const CheckoutSummary = ({
 	isQuotePreviewPending = false,
@@ -149,12 +114,10 @@ export const CheckoutSummary = ({
 }: CheckoutSummaryProps) => {
 	const [couponDraft, setCouponDraft] = useState(orderInput.couponCode ?? '');
 	const allExtras = quotePreview?.extras ?? [];
-
-	const paidExtrasTotal = useMemo(
-		() => allExtras.reduce((total, extra) => total + extra.price, 0),
-		[allExtras],
+	const paidExtrasTotal = allExtras.reduce(
+		(total, extra) => total + extra.price,
+		0,
 	);
-
 	const appliedCouponCode =
 		orderInput.couponCode && quotePreview && quotePreview.discountAmount > 0
 			? orderInput.couponCode
@@ -173,116 +136,88 @@ export const CheckoutSummary = ({
 	};
 
 	return (
-		<aside className="w-full lg:sticky lg:top-24 lg:w-80">
-			<Card className="overflow-hidden border-white/10 shadow-panel">
+		<aside
+			className="w-full lg:sticky lg:top-24 lg:w-80"
+			aria-label="Resumo do checkout"
+		>
+			<Card className="overflow-hidden border-white/10">
 				<div className="h-1 w-full bg-[var(--rank-accent)]" />
 				<CardHeader>
-					<CardTitle>Resumo de Checkout</CardTitle>
-					<CardDescription>Cálculo em tempo real</CardDescription>
+					<CardTitle className="text-sm">Resumo de Checkout</CardTitle>
+					<CardDescription className="text-sm text-white/60">
+						Valores atualizados em tempo real
+					</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-4">
-					<motion.div layout className="space-y-3">
-						<div className="flex justify-between text-xs">
-							<span className="text-white/40 uppercase tracking-widest">
-								Subtotal
-							</span>
-							<AnimatedCurrency
-								className="font-black"
-								value={quotePreview?.subtotal ?? null}
-							/>
-						</div>
+					<div className="space-y-3">
+						<CheckoutItemRow
+							label="Subtotal"
+							value={quotePreview?.subtotal ?? null}
+						/>
 
-						<div className="flex justify-between text-xs">
-							<span className="text-white/40 uppercase tracking-widest">
-								Taxa de Extras
-							</span>
-							<span className="font-black text-hextech-gold">
+						<div className="flex items-center justify-between gap-3 text-sm">
+							<span className="text-white/65">Taxa de extras</span>
+							<span className="text-right font-bold text-hextech-gold">
 								{paidExtrasTotal > 0 ? (
-									<AnimatedCurrency value={paidExtrasTotal} />
+									<Currency value={paidExtrasTotal} />
 								) : allExtras.length > 0 ? (
-									'Extras Selecionados'
+									'Extras selecionados'
 								) : (
 									'Sem extras'
 								)}
 							</span>
 						</div>
 
-						<AnimatePresence mode="popLayout" initial={false}>
-							{allExtras.length > 0 && (
-								<motion.div
-									key="extras-container"
-									initial={{ opacity: 0, scale: 0.95 }}
-									animate={{ opacity: 1, scale: 1 }}
-									exit={{ opacity: 0, scale: 0.95 }}
-									className="space-y-1 rounded-sm bg-white/[0.02] p-3"
-								>
-									{allExtras.map((extra) => (
-										<CheckoutItemRow
-											key={extra.type}
-											label={getExtraLabel(extra.type)}
-											value={extra.price}
-											priceLabel={
-												EXTRA_OPTIONS_BY_ID.get(extra.type)?.priceLabel
-											}
-											className="text-[10px] text-white/45"
-										/>
-									))}
-								</motion.div>
-							)}
-						</AnimatePresence>
+						{allExtras.length > 0 ? (
+							<div className="space-y-2 rounded-sm bg-white/[0.03] p-3">
+								{allExtras.map((extra) => (
+									<CheckoutItemRow
+										key={extra.type}
+										label={getExtraLabel(extra.type)}
+										value={extra.price}
+										priceLabel={EXTRA_OPTIONS_BY_ID.get(extra.type)?.priceLabel}
+									/>
+								))}
+							</div>
+						) : null}
 
-						<AnimatePresence mode="popLayout">
-							{quotePreview && quotePreview.discountAmount > 0 && (
-								<CheckoutItemRow
-									containerClassName="space-y-1 rounded-sm border border-emerald-400/10 bg-emerald-500/[0.04] p-3"
-									label={
-										appliedCouponCode
-											? `Cupom ${appliedCouponCode}`
-											: 'Desconto'
-									}
-									value={-quotePreview.discountAmount}
-									labelClassName={cn(
-										'min-w-0 truncate uppercase tracking-widest',
-										appliedCouponCode
-											? 'font-bold text-emerald-300'
-											: 'text-white/40',
-									)}
-									valueClassName="whitespace-nowrap font-black text-emerald-400"
-								/>
-							)}
-						</AnimatePresence>
+						{quotePreview && quotePreview.discountAmount > 0 ? (
+							<CheckoutItemRow
+								className="rounded-sm border border-success/20 bg-success/5 p-3"
+								label={
+									appliedCouponCode ? `Cupom ${appliedCouponCode}` : 'Desconto'
+								}
+								value={-quotePreview.discountAmount}
+							/>
+						) : null}
 
-						<motion.div
-							layout
-							className="pt-2 border-t border-white/5 flex justify-between"
-						>
-							<span className="text-xs font-black uppercase tracking-[0.2em] text-[var(--rank-accent)]">
+						<div className="flex items-center justify-between border-t border-white/10 pt-3">
+							<span className="text-sm font-black uppercase tracking-widest text-[var(--rank-accent)]">
 								Total
 							</span>
-							<span className="text-xl font-black text-white">
+							<span
+								className="text-xl font-black text-white"
+								aria-live="polite"
+							>
 								{quotePreview ? (
-									<AnimatedCurrency value={quotePreview.totalAmount} />
+									<Currency value={quotePreview.totalAmount} />
 								) : isQuotePreviewPending ? (
 									'Calculando...'
 								) : (
 									'Indisponível'
 								)}
 							</span>
-						</motion.div>
+						</div>
 
-						{quotePreviewError && (
-							<motion.p
-								initial={{ opacity: 0, y: 5 }}
-								animate={{ opacity: 1, y: 0 }}
-								className="text-[10px] text-red-400 uppercase tracking-widest"
-							>
+						{quotePreviewError ? (
+							<p className="text-sm text-red-300" role="alert">
 								{quotePreviewError}
-							</motion.p>
-						)}
-					</motion.div>
+							</p>
+						) : null}
+					</div>
 
-					<div className="space-y-2 pt-4 border-t border-white/5">
-						<Label htmlFor="coupon-code">Cupom de Desconto</Label>
+					<div className="space-y-2 border-t border-white/10 pt-4">
+						<Label htmlFor="coupon-code">Cupom de desconto</Label>
 						<div className="flex gap-2">
 							<Input
 								id="coupon-code"
@@ -297,11 +232,11 @@ export const CheckoutSummary = ({
 									applyCouponCode();
 								}}
 								placeholder="CÓDIGO"
-								className="uppercase font-mono"
+								className="h-12 font-mono text-base uppercase md:text-sm"
 							/>
 							<Button
 								type="button"
-								size="sm"
+								size="lg"
 								variant="outline"
 								disabled={isCouponApplyDisabled}
 								onClick={applyCouponCode}
@@ -311,11 +246,11 @@ export const CheckoutSummary = ({
 						</div>
 					</div>
 				</CardContent>
-				<CardFooter className="bg-white/[0.02] border-t border-white/5 py-4">
-					<div className="flex items-center gap-2 opacity-40">
-						<Target className="w-3 h-3" />
-						<span className="text-[8px] font-black uppercase tracking-widest">
-							Garantia de Entrega EloNew
+				<CardFooter className="border-t border-white/10 bg-white/[0.02] py-4">
+					<div className="flex items-center gap-2 text-white/60">
+						<Target className="h-4 w-4" aria-hidden="true" />
+						<span className="text-xs font-bold uppercase tracking-widest">
+							Garantia de entrega EloNew
 						</span>
 					</div>
 				</CardFooter>

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/details-step.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/details-step.tsx
@@ -1,6 +1,6 @@
 import type { OrderExtraType } from '@packages/shared/orders/order-extra';
 import { CheckCircle2, ChevronRight } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { type MouseEvent, useRef } from 'react';
 import { gsap, useGSAP } from '@/shared/ui/animation/gsap';
 import { Badge } from '@/shared/ui/components/badge';
 import { Button } from '@/shared/ui/components/button';
@@ -20,6 +20,7 @@ import { EXTRAS, QUEUES, SERVERS } from '../../model/new-order-options';
 import type { StartCheckoutInput } from '../../server/order-contracts';
 
 type DetailsStepProps = {
+	favoriteBoosterName?: string;
 	orderInput: StartCheckoutInput;
 	onBack: () => void;
 	onNext: () => void;
@@ -28,46 +29,43 @@ type DetailsStepProps = {
 		value: StartCheckoutInput[Key],
 	) => void;
 	onToggleExtra: (extraId: OrderExtraType) => void;
+	onFavoriteBoosterNameChange?: (name: string) => void;
 	onNextIntent?: () => void;
 };
 
 const FILTERED_EXTRAS = EXTRAS.filter((extra) => extra.id !== 'mmr_nerfed');
 
 export const DetailsStep = ({
+	favoriteBoosterName = '',
 	orderInput,
 	onBack,
 	onNext,
 	onChange,
 	onToggleExtra,
+	onFavoriteBoosterNameChange,
 	onNextIntent,
 }: DetailsStepProps) => {
-	const [favoriteBoosterName, setFavoriteBoosterName] = useState('');
 	const containerRef = useRef<HTMLDivElement>(null);
 	const mmrWarningRef = useRef<HTMLDivElement>(null);
-	const boosterInputRefs = useRef<Record<string, HTMLDivElement | null>>({});
+	const favoriteBoosterRef = useRef<HTMLDivElement>(null);
+	const isFavoriteBoosterSelected =
+		orderInput.extras.includes('favorite_booster');
+	const isNextDisabled =
+		isFavoriteBoosterSelected && !favoriteBoosterName.trim();
 
-	const isFavoriteBoosterSelected = useMemo(
-		() => orderInput.extras.includes('favorite_booster'),
-		[orderInput.extras],
-	);
-	const isNextDisabled = useMemo(
-		() => isFavoriteBoosterSelected && !favoriteBoosterName.trim(),
-		[isFavoriteBoosterSelected, favoriteBoosterName],
-	);
-
+	const shouldShowMmrWarning = orderInput.lpGain <= 17;
 	const { contextSafe } = useGSAP({ scope: containerRef });
-
-	const handleToggleWithAnimation = contextSafe(
-		(id: OrderExtraType, event: React.MouseEvent) => {
-			const card = (event.currentTarget as HTMLElement).closest(
-				'.extra-option-card',
-			);
-			if (card) {
-				gsap.fromTo(
-					card,
-					{ scale: 0.97 },
-					{ scale: 1, duration: 0.4, ease: 'back.out(4)' },
-				);
+	const handleToggleExtra = contextSafe(
+		(id: OrderExtraType, event: MouseEvent<HTMLButtonElement>) => {
+			if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+				const card = event.currentTarget.closest('.extra-option-card');
+				if (card) {
+					gsap.fromTo(
+						card,
+						{ scale: 0.97 },
+						{ scale: 1, duration: 0.4, ease: 'back.out(4)' },
+					);
+				}
 			}
 			onToggleExtra(id);
 		},
@@ -75,6 +73,7 @@ export const DetailsStep = ({
 
 	useGSAP(
 		() => {
+			if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 			gsap.from('.extra-option-card', {
 				y: 20,
 				opacity: 0,
@@ -86,61 +85,38 @@ export const DetailsStep = ({
 		{ scope: containerRef },
 	);
 
-	const shouldShowMmrWarning = orderInput.lpGain <= 17;
-
 	useGSAP(
 		() => {
-			if (shouldShowMmrWarning) {
-				gsap.fromTo(
-					mmrWarningRef.current,
-					{ height: 0, opacity: 0, marginTop: 0 },
-					{
-						height: 'auto',
-						opacity: 1,
-						marginTop: 16,
-						duration: 0.4,
-						ease: 'power3.out',
-					},
-				);
-			} else {
-				gsap.to(mmrWarningRef.current, {
-					height: 0,
-					opacity: 0,
-					marginTop: 0,
-					duration: 0.3,
-					ease: 'power3.in',
-				});
-			}
+			if (
+				!shouldShowMmrWarning ||
+				window.matchMedia('(prefers-reduced-motion: reduce)').matches
+			)
+				return;
+			gsap.from(mmrWarningRef.current, {
+				autoAlpha: 0,
+				y: -8,
+				duration: 0.25,
+				ease: 'power2.out',
+			});
 		},
-		{ dependencies: [shouldShowMmrWarning] },
+		{ scope: containerRef, dependencies: [shouldShowMmrWarning] },
 	);
 
 	useGSAP(
 		() => {
-			const el = boosterInputRefs.current.favorite_booster;
-			if (isFavoriteBoosterSelected) {
-				gsap.fromTo(
-					el,
-					{ height: 0, opacity: 0, marginTop: 0 },
-					{
-						height: 'auto',
-						opacity: 1,
-						marginTop: 12,
-						duration: 0.4,
-						ease: 'back.out(1.2)',
-					},
-				);
-			} else {
-				gsap.to(el, {
-					height: 0,
-					opacity: 0,
-					marginTop: 0,
-					duration: 0.3,
-					ease: 'power3.in',
-				});
-			}
+			if (
+				!isFavoriteBoosterSelected ||
+				window.matchMedia('(prefers-reduced-motion: reduce)').matches
+			)
+				return;
+			gsap.from(favoriteBoosterRef.current, {
+				autoAlpha: 0,
+				y: -8,
+				duration: 0.3,
+				ease: 'back.out(1.2)',
+			});
 		},
-		{ dependencies: [isFavoriteBoosterSelected] },
+		{ scope: containerRef, dependencies: [isFavoriteBoosterSelected] },
 	);
 
 	return (
@@ -149,7 +125,7 @@ export const DetailsStep = ({
 				<h2 className="text-xl font-black uppercase tracking-[0.2em]">
 					Detalhes e Extras
 				</h2>
-				<p className="text-white/40 text-xs">
+				<p className="text-sm leading-relaxed text-white/65">
 					Configure os detalhes técnicos do seu pedido.
 				</p>
 			</div>
@@ -161,7 +137,7 @@ export const DetailsStep = ({
 						value={orderInput.server}
 						onValueChange={(value: string) => onChange('server', value)}
 					>
-						<SelectTrigger id="server">
+						<SelectTrigger id="server" className="h-12 text-base md:text-sm">
 							<SelectValue placeholder="Selecione um servidor" />
 						</SelectTrigger>
 						<SelectContent>
@@ -179,7 +155,7 @@ export const DetailsStep = ({
 						value={orderInput.desiredQueue}
 						onValueChange={(value: string) => onChange('desiredQueue', value)}
 					>
-						<SelectTrigger id="queue">
+						<SelectTrigger id="queue" className="h-12 text-base md:text-sm">
 							<SelectValue placeholder="Selecione uma fila" />
 						</SelectTrigger>
 						<SelectContent>
@@ -200,33 +176,35 @@ export const DetailsStep = ({
 						value={orderInput.lpGain}
 						onChange={(value) => onChange('lpGain', value)}
 						placeholder="20"
+						className="[&_button]:h-12 [&_button]:w-12 [&_input]:h-12 [&_input]:text-base md:[&_input]:text-sm"
 					/>
 				</div>
 			</div>
 
 			<div className="space-y-4">
-				<div className="flex items-center justify-between">
-					<Label>Personalize sua experiência</Label>
+				<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+					<h3 className="text-sm font-black uppercase tracking-widest text-white/80">
+						Personalize sua experiência
+					</h3>
 					{shouldShowMmrWarning && (
-						<span className="text-[10px] font-black uppercase tracking-widest text-hextech-cyan animate-pulse">
+						<span className="text-xs font-black uppercase tracking-widest text-hextech-cyan">
 							Taxa MMR Nerfado Aplicada
 						</span>
 					)}
 				</div>
 
-				<div
-					ref={mmrWarningRef}
-					className="overflow-hidden opacity-0"
-					style={{ height: 0 }}
-				>
-					<div className="rounded-sm border border-hextech-cyan/20 bg-hextech-cyan/5 p-3">
-						<p className="text-[10px] leading-relaxed text-hextech-cyan/80">
+				{shouldShowMmrWarning ? (
+					<div
+						ref={mmrWarningRef}
+						className="rounded-sm border border-hextech-cyan/20 bg-hextech-cyan/5 p-3"
+					>
+						<p className="text-sm leading-relaxed text-white/75">
 							Se seu ganho de PDL é menor ou igual a 17, isso aumenta a
 							dificuldade para nossos boosters. A taxa de MMR Nerfado foi
 							aplicada automaticamente.
 						</p>
 					</div>
-				</div>
+				) : null}
 
 				<div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
 					{FILTERED_EXTRAS.map((extra) => {
@@ -236,7 +214,7 @@ export const DetailsStep = ({
 						return (
 							<div key={extra.id} className="extra-option-card flex flex-col">
 								<SelectableOption
-									onClick={(e) => handleToggleWithAnimation(extra.id, e)}
+									onClick={(event) => handleToggleExtra(extra.id, event)}
 									layout="row"
 									selected={isSelected}
 									className="flex-1 items-start gap-4 text-left min-h-20"
@@ -251,17 +229,20 @@ export const DetailsStep = ({
 											)}
 										>
 											{isSelected ? (
-												<CheckCircle2 className="w-3 h-3 text-black" />
+												<CheckCircle2
+													className="h-3 w-3 text-black"
+													aria-hidden="true"
+												/>
 											) : null}
 										</div>
 										<div className="min-w-0 space-y-1">
-											<span className="block text-[10px] font-black uppercase tracking-widest">
+											<span className="block text-xs font-black uppercase tracking-widest">
 												{extra.label}
 											</span>
 											<span
 												className={cn(
-													'block text-[10px] leading-relaxed',
-													isSelected ? 'text-white/60' : 'text-white/35',
+													'block text-sm leading-relaxed',
+													isSelected ? 'text-white/75' : 'text-white/60',
 												)}
 											>
 												{extra.description}
@@ -275,24 +256,15 @@ export const DetailsStep = ({
 										{extra.priceLabel}
 									</Badge>
 								</SelectableOption>
-								{isFavoriteBooster ? (
-									<div
-										ref={(el) => {
-											boosterInputRefs.current.favorite_booster = el;
-										}}
-										className="overflow-hidden opacity-0"
-										style={{ height: 0 }}
-									>
+								{isFavoriteBooster && isFavoriteBoosterSelected ? (
+									<div ref={favoriteBoosterRef} className="mt-3">
 										<div className="rounded-sm border border-white/10 bg-black/20 p-3">
-											<div className="flex items-center justify-between">
-												<Label
-													htmlFor="favorite-booster-name"
-													className="text-[10px]"
-												>
+											<div className="flex items-center justify-between gap-3">
+												<Label htmlFor="favorite-booster-name">
 													Nome do Booster Favorito{' '}
 													<span className="text-hextech-cyan">*</span>
 												</Label>
-												<span className="text-[10px] text-white/20">
+												<span className="text-xs text-white/55">
 													{favoriteBoosterName.length}/50
 												</span>
 											</div>
@@ -301,12 +273,11 @@ export const DetailsStep = ({
 												name="favoriteBoosterName"
 												value={favoriteBoosterName}
 												onChange={(event) =>
-													setFavoriteBoosterName(
-														event.target.value.slice(0, 50),
-													)
+													onFavoriteBoosterNameChange?.(event.target.value)
 												}
+												maxLength={50}
 												placeholder="Digite o nome do booster"
-												className="mt-2"
+												className="mt-2 h-12 text-base md:text-sm"
 											/>
 										</div>
 									</div>
@@ -317,19 +288,25 @@ export const DetailsStep = ({
 				</div>
 			</div>
 
-			<div className="flex justify-end gap-4 pt-6 border-t border-white/5 mt-8">
-				<Button variant="outline" className="px-8" onClick={onBack}>
+			<div className="mt-8 flex flex-col gap-3 border-t border-white/10 pt-6 sm:flex-row sm:justify-end">
+				<Button
+					variant="outline"
+					size="lg"
+					className="w-full sm:w-auto"
+					onClick={onBack}
+				>
 					Voltar
 				</Button>
 				<Button
+					size="lg"
 					onClick={onNext}
 					onFocus={onNextIntent}
 					onMouseEnter={onNextIntent}
-					className="group px-8"
+					className="w-full sm:w-auto"
 					disabled={isNextDisabled}
 				>
-					Revisar Pedido
-					<ChevronRight className="ml-2 h-4 w-4" />
+					Próximo Passo
+					<ChevronRight className="ml-2 h-4 w-4" aria-hidden="true" />
 				</Button>
 			</div>
 		</div>

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/new-order-wizard.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/new-order-wizard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { OrderExtraType } from '@packages/shared/orders/order-extra';
-import { AnimatePresence } from 'motion/react';
 import dynamic from 'next/dynamic';
 import type { CSSProperties } from 'react';
 import { useCallback, useRef, useState } from 'react';
@@ -9,6 +8,7 @@ import { gsap, useGSAP } from '@/shared/ui/animation/gsap';
 import { createInitialCheckoutInput } from '../../model/checkout-defaults';
 import { getRankOption } from '../../model/rank-options';
 import type { StartCheckoutInput } from '../../server/order-contracts';
+import type { AccountInput } from './account-step';
 import { CheckoutSummary } from './checkout-summary';
 import { StepIndicator } from './step-indicator';
 import { useCheckoutSubmit } from './use-checkout-submit';
@@ -19,20 +19,31 @@ const loadServiceStep = () =>
 	import('./service-step').then((module) => module.ServiceStep);
 const loadDetailsStep = () =>
 	import('./details-step').then((module) => module.DetailsStep);
+const loadAccountStep = () =>
+	import('./account-step').then((module) => module.AccountStep);
 const loadReviewStep = () =>
 	import('./review-step').then((module) => module.ReviewStep);
 
 const ServiceStep = dynamic(loadServiceStep);
 const DetailsStep = dynamic(loadDetailsStep);
+const AccountStep = dynamic(loadAccountStep);
 const ReviewStep = dynamic(loadReviewStep);
 
 const INITIAL_STEP = 1;
+const INITIAL_ACCOUNT_INPUT: AccountInput = {
+	login: '',
+	summonerName: '',
+	password: '',
+	passwordConfirmation: '',
+};
 
 export const NewOrderWizard = () => {
 	const [step, setStep] = useState(INITIAL_STEP);
 	const [orderInput, setOrderInput] = useState<StartCheckoutInput>(
 		createInitialCheckoutInput,
 	);
+	const [accountInput, setAccountInput] = useState(INITIAL_ACCOUNT_INPUT);
+	const [favoriteBoosterName, setFavoriteBoosterName] = useState('');
 	const [hasAcceptedTerms, setHasAcceptedTerms] = useState(false);
 	const selectedRank = getRankOption(orderInput.desiredLeague);
 	const initialRank = useRef(selectedRank);
@@ -49,12 +60,18 @@ export const NewOrderWizard = () => {
 		void loadDetailsStep();
 	}, []);
 
+	const preloadAccountStep = useCallback(() => {
+		void loadAccountStep();
+	}, []);
+
 	const preloadReviewStep = useCallback(() => {
 		void loadReviewStep();
 	}, []);
 
 	useGSAP(
 		() => {
+			if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
 			gsap.to(wizardRef.current, {
 				'--rank-accent': selectedRank.accent,
 				'--rank-accent-soft': selectedRank.accentSoft,
@@ -94,14 +111,34 @@ export const NewOrderWizard = () => {
 		[],
 	);
 
-	const toggleExtra = useCallback((id: OrderExtraType) => {
-		setOrderInput((previousInput) => ({
-			...previousInput,
-			extras: previousInput.extras.includes(id)
-				? previousInput.extras.filter((extra) => extra !== id)
-				: [...previousInput.extras, id],
-		}));
-	}, []);
+	const toggleExtra = useCallback(
+		(id: OrderExtraType) => {
+			if (
+				id === 'favorite_booster' &&
+				orderInput.extras.includes('favorite_booster')
+			) {
+				setFavoriteBoosterName('');
+			}
+
+			setOrderInput((previousInput) => ({
+				...previousInput,
+				extras: previousInput.extras.includes(id)
+					? previousInput.extras.filter((extra) => extra !== id)
+					: [...previousInput.extras, id],
+			}));
+		},
+		[orderInput.extras],
+	);
+
+	const updateAccountInput = useCallback(
+		(key: keyof AccountInput, value: string) => {
+			setAccountInput((previousInput) => ({
+				...previousInput,
+				[key]: value,
+			}));
+		},
+		[],
+	);
 
 	const handleCouponCodeChange = useCallback(
 		(couponCode: string) => {
@@ -120,7 +157,7 @@ export const NewOrderWizard = () => {
 					'--rank-accent': initialRank.current.accent,
 					'--rank-accent-soft': initialRank.current.accentSoft,
 					background:
-						'linear-gradient(145deg, var(--rank-accent-soft), transparent 34%), #09090b',
+						'linear-gradient(145deg, var(--rank-accent-soft), transparent 34%), var(--color-background)',
 				} as CSSProperties
 			}
 		>
@@ -128,7 +165,7 @@ export const NewOrderWizard = () => {
 				<div className="flex-1 space-y-10">
 					<StepIndicator step={step} />
 
-					<AnimatePresence mode="wait">
+					<div>
 						{step === 1 ? (
 							<WizardStepTransition stepKey="step1">
 								<ServiceStep
@@ -143,22 +180,38 @@ export const NewOrderWizard = () => {
 						{step === 2 ? (
 							<WizardStepTransition stepKey="step2">
 								<DetailsStep
+									favoriteBoosterName={favoriteBoosterName}
 									orderInput={orderInput}
 									onBack={() => setStep(1)}
 									onNext={() => setStep(3)}
-									onNextIntent={preloadReviewStep}
+									onNextIntent={preloadAccountStep}
 									onChange={updateOrderInput}
 									onToggleExtra={toggleExtra}
+									onFavoriteBoosterNameChange={setFavoriteBoosterName}
 								/>
 							</WizardStepTransition>
 						) : null}
 
 						{step === 3 ? (
 							<WizardStepTransition stepKey="step3">
+								<AccountStep
+									accountInput={accountInput}
+									onBack={() => setStep(2)}
+									onChange={updateAccountInput}
+									onNext={() => setStep(4)}
+									onNextIntent={preloadReviewStep}
+								/>
+							</WizardStepTransition>
+						) : null}
+
+						{step === 4 ? (
+							<WizardStepTransition stepKey="step4">
 								<ReviewStep
+									accountInput={accountInput}
+									favoriteBoosterName={favoriteBoosterName}
 									orderInput={orderInput}
 									hasAcceptedTerms={hasAcceptedTerms}
-									onBack={() => setStep(2)}
+									onBack={() => setStep(3)}
 									onCheckout={handleCheckout}
 									onTermsChange={setHasAcceptedTerms}
 									isSubmitting={isPending}
@@ -166,7 +219,7 @@ export const NewOrderWizard = () => {
 								/>
 							</WizardStepTransition>
 						) : null}
-					</AnimatePresence>
+					</div>
 				</div>
 
 				<CheckoutSummary

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/rank-route-picker.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/rank-route-picker.tsx
@@ -93,9 +93,21 @@ const RankPanel = ({
 		selectedLeague,
 		selectedDivision,
 	);
+	const animateRankImage = (button: HTMLButtonElement, scale: number) => {
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+		gsap.to(button.querySelector('img'), {
+			scale,
+			duration: 0.2,
+			ease: 'power2.out',
+			overwrite: 'auto',
+		});
+	};
 
 	useGSAP(
 		() => {
+			if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
 			gsap.to(panelRef.current, {
 				'--rank-accent': selectedRank.accent,
 				'--rank-accent-soft': selectedRank.accentSoft,
@@ -110,7 +122,7 @@ const RankPanel = ({
 	return (
 		<section
 			ref={panelRef}
-			className="relative overflow-hidden rounded-sm border border-white/10 bg-[#0d0d0f]/80 p-4"
+			className="relative overflow-hidden rounded-sm border border-white/10 bg-surface/80 p-4"
 			aria-labelledby={`${field}-rank-title`}
 			style={
 				{
@@ -135,21 +147,21 @@ const RankPanel = ({
 						>
 							{copy[field].title}
 						</h3>
-						<p className="mt-1 text-[10px] text-white/40">
+						<p className="mt-1 text-sm text-white/60">
 							{copy[field].description}
 						</p>
 					</div>
 					<div className="text-right">
-						<p className="text-[10px] font-black uppercase tracking-[0.16em] text-white">
+						<p className="text-xs font-black uppercase tracking-[0.16em] text-white">
 							{selectedRank.label}
 						</p>
-						<p className="text-[10px] text-white/45">
+						<p className="text-xs text-white/65">
 							{getRankDivisionLabel(selectedDivision)}
 						</p>
 					</div>
 				</div>
 
-				<div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8">
+				<div className="grid grid-cols-4 gap-2 xl:grid-cols-8">
 					{RANK_OPTIONS.map((rank) => {
 						const isSelected =
 							selectedLeague === rank.value && hasValidSelection;
@@ -177,8 +189,18 @@ const RankPanel = ({
 								aria-pressed={isSelected}
 								disabled={isDisabled}
 								onClick={() => onLeagueChange(rank.value)}
+								onFocus={(event) => animateRankImage(event.currentTarget, 1.05)}
+								onBlur={(event) =>
+									animateRankImage(event.currentTarget, isSelected ? 1.05 : 1)
+								}
+								onPointerEnter={(event) =>
+									animateRankImage(event.currentTarget, 1.05)
+								}
+								onPointerLeave={(event) =>
+									animateRankImage(event.currentTarget, isSelected ? 1.05 : 1)
+								}
 								className={cn(
-									'group flex min-h-[118px] cursor-pointer flex-col items-center justify-between rounded-sm border p-2 text-center transition-colors duration-200 focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-25',
+									'group flex min-h-24 cursor-pointer flex-col items-center justify-between rounded-sm border p-1.5 text-center transition-colors duration-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--rank-accent)] disabled:cursor-not-allowed disabled:opacity-40 sm:min-h-[118px] sm:p-2',
 									isSelected
 										? 'border-[var(--rank-accent)] bg-white/[0.07] text-white'
 										: 'border-white/10 bg-black/20 text-white/45 hover:border-white/25 hover:text-white',
@@ -196,11 +218,12 @@ const RankPanel = ({
 									height={96}
 									sizes="64px"
 									className={cn(
-										'h-16 w-16 object-contain transition-transform duration-200',
-										isSelected ? 'scale-105' : 'group-hover:scale-105',
+										'h-12 w-12 object-contain sm:h-16 sm:w-16',
+										isSelected && 'brightness-110',
 									)}
+									style={{ transform: `scale(${isSelected ? 1.05 : 1})` }}
 								/>
-								<span className="text-[9px] font-black uppercase tracking-[0.14em]">
+								<span className="text-xs font-black uppercase tracking-[0.08em]">
 									{rank.label}
 								</span>
 							</button>
@@ -231,7 +254,7 @@ const RankPanel = ({
 									disabled={isDisabled}
 									onClick={() => onDivisionChange(division)}
 									className={cn(
-										'h-10 cursor-pointer border-r border-white/10 text-[10px] font-black uppercase tracking-[0.18em] transition-colors last:border-r-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--rank-accent)] disabled:cursor-not-allowed disabled:text-white/15',
+										'h-11 cursor-pointer border-r border-white/10 text-xs font-black uppercase tracking-[0.18em] transition-colors last:border-r-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--rank-accent)] disabled:cursor-not-allowed disabled:text-white/30',
 										isSelected
 											? 'bg-[var(--rank-accent)] text-black'
 											: 'text-white/50 hover:bg-white/5 hover:text-white',
@@ -255,8 +278,9 @@ const RankPanel = ({
 							onChange={(value) =>
 								onDivisionChange(normalizeMasterPdlDivision(value))
 							}
+							className="[&_button]:h-12 [&_button]:w-12 [&_input]:h-12 [&_input]:text-base md:[&_input]:text-sm"
 						/>
-						<p className="text-[10px] text-white/35">
+						<p className="text-sm leading-relaxed text-white/60">
 							Master não usa divisões I, II, III ou IV. Informe entre{' '}
 							{MASTER_PDL_MIN} e {MASTER_PDL_MAX} PDL.
 						</p>
@@ -350,7 +374,7 @@ export const RankRoutePicker = ({
 				}
 			/>
 			{canSelectDesiredRank ? null : (
-				<p className="text-[10px] text-red-300 uppercase tracking-widest">
+				<p className="text-sm text-red-300" role="alert">
 					Escolha um rank desejado acima do rank atual.
 				</p>
 			)}

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/review-step.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/review-step.tsx
@@ -1,15 +1,21 @@
 import {
 	ArrowRight,
+	CalendarClock,
 	ChevronRight,
+	Gamepad2,
+	Gauge,
 	Globe,
+	KeyRound,
 	Layers,
 	type LucideIcon,
 	Shield,
+	TrendingUp,
+	UserRound,
 	Users,
 	Zap,
 } from 'lucide-react';
-import { motion } from 'motion/react';
 import Image from 'next/image';
+import { formatDateTime } from '@/shared/format/date';
 import { Badge } from '@/shared/ui/components/badge';
 import { Button } from '@/shared/ui/components/button';
 import {
@@ -30,8 +36,11 @@ import {
 	type RankOption,
 } from '../../model/rank-options';
 import type { StartCheckoutInput } from '../../server/order-contracts';
+import type { AccountInput } from './account-step';
 
 type ReviewStepProps = {
+	accountInput: AccountInput;
+	favoriteBoosterName: string;
 	orderInput: StartCheckoutInput;
 	hasAcceptedTerms: boolean;
 	onBack: () => void;
@@ -42,26 +51,42 @@ type ReviewStepProps = {
 };
 
 const DetailItem = ({
+	className,
 	icon: Icon,
 	label,
 	value,
+	preserveCase = false,
 }: {
+	className?: string;
 	icon: LucideIcon;
 	label: string;
 	value: string;
+	preserveCase?: boolean;
 }) => (
-	<div className="flex flex-col gap-1.5 p-3 rounded-sm bg-white/[0.03] border border-white/5">
+	<div
+		className={cn(
+			'flex flex-col gap-2 rounded-sm border border-white/10 bg-white/[0.03] p-4',
+			className,
+		)}
+	>
 		<div className="flex items-center gap-2">
-			<Icon className="w-3.5 h-3.5 text-hextech-cyan" />
-			<span className="text-[10px] text-white/40 uppercase tracking-widest font-bold">
+			<Icon className="h-4 w-4 text-hextech-cyan" aria-hidden="true" />
+			<span className="text-xs font-bold uppercase tracking-widest text-white/60">
 				{label}
 			</span>
 		</div>
-		<p className="text-xs font-black uppercase text-white/90 truncate">
+		<p
+			className={cn(
+				'break-words text-sm font-black text-white/90',
+				preserveCase ? 'normal-case' : 'uppercase',
+			)}
+		>
 			{value}
 		</p>
 	</div>
 );
+
+const maskPassword = (password: string) => '•'.repeat(password.length);
 
 const RankDisplay = ({
 	rank,
@@ -75,42 +100,24 @@ const RankDisplay = ({
 	isDesired?: boolean;
 }) => {
 	return (
-		<div className="flex flex-col items-center gap-3 flex-1 group">
-			<div className="relative cursor-default">
-				<div
-					className={cn(
-						'absolute inset-0 blur-2xl rounded-full pointer-events-none transition-all duration-300 group-hover:opacity-40 group-hover:scale-[1.2]',
-						isDesired ? 'opacity-20' : 'opacity-0',
-					)}
-					style={{ backgroundColor: rank.accent }}
-				/>
-				<div
-					className={cn(
-						'relative transition-all duration-300 ease-out group-hover:-translate-y-2 group-hover:scale-105 group-hover:brightness-125 group-hover:drop-shadow-[0_0_20px_rgba(255,255,255,0.2)]',
-						isDesired
-							? 'drop-shadow-[0_0_15px_rgba(255,255,255,0.1)]'
-							: 'drop-shadow-[0_0_0_rgba(255,255,255,0)]',
-					)}
-				>
-					<Image
-						src={rank.image}
-						alt={rank.label}
-						width={80}
-						height={80}
-						className="relative"
-					/>
-				</div>
-			</div>
-			<div className="text-center relative z-10">
+		<div className="group flex flex-1 flex-col items-center gap-3">
+			<Image
+				src={rank.image}
+				alt={rank.label}
+				width={80}
+				height={80}
+				className="transition duration-300 ease-out group-hover:-translate-y-1 group-hover:scale-105 group-hover:brightness-110 motion-reduce:transform-none motion-reduce:transition-none"
+			/>
+			<div className="text-center">
 				<p
 					className={cn(
-						'text-[10px] uppercase tracking-widest font-bold mb-0.5',
-						isDesired ? 'text-hextech-cyan' : 'text-white/40',
+						'mb-1 text-xs font-bold uppercase tracking-widest',
+						isDesired ? 'text-hextech-cyan' : 'text-white/60',
 					)}
 				>
 					{label}
 				</p>
-				<p className="text-xs font-black uppercase text-white">
+				<p className="text-sm font-black uppercase text-white">
 					{rank.label} {getRankDivisionLabel(division)}
 				</p>
 			</div>
@@ -119,6 +126,8 @@ const RankDisplay = ({
 };
 
 export const ReviewStep = ({
+	accountInput,
+	favoriteBoosterName,
 	orderInput,
 	hasAcceptedTerms,
 	onBack,
@@ -136,42 +145,36 @@ export const ReviewStep = ({
 	return (
 		<div className="space-y-8">
 			<div className="space-y-2">
-				<h2 className="text-2xl font-black uppercase tracking-[0.25em] text-white">
+				<h2 className="text-xl font-black uppercase tracking-[0.2em] text-white">
 					Revisão Final
 				</h2>
-				<p className="text-white/40 text-xs font-medium">
+				<p className="text-sm leading-relaxed text-white/65">
 					Confirme os detalhes do seu pedido antes de prosseguir para o
 					pagamento seguro.
 				</p>
 			</div>
 
-			<Card className="border-hextech-cyan/20 bg-[#0d0d0f]/60 backdrop-blur-sm overflow-hidden">
-				<div
-					className="absolute inset-0 opacity-10 pointer-events-none"
-					style={{
-						background: `radial-gradient(circle at 50% 0%, ${desiredRank.accent}, transparent 70%)`,
-					}}
-				/>
-
-				<CardHeader className="relative border-b border-white/5 pb-4">
+			<Card className="overflow-hidden border-white/10 bg-surface">
+				<CardHeader className="border-b border-white/10 pb-4">
 					<CardTitle className="flex items-center gap-3 text-sm tracking-widest uppercase">
-						<div className="p-1.5 rounded-full bg-hextech-cyan/10">
-							<Zap className="w-4 h-4 text-hextech-cyan shadow-[0_0_10px_rgba(14,165,233,0.5)]" />
-						</div>
+						<Zap className="h-4 w-4 text-hextech-cyan" aria-hidden="true" />
 						Resumo do Plano
 					</CardTitle>
 				</CardHeader>
 
-				<CardContent className="relative p-6 space-y-8">
-					<div className="flex items-center justify-between gap-4 py-4 px-2 bg-white/[0.02] rounded-lg border border-white/5 relative overflow-hidden">
+				<CardContent className="space-y-8 p-4 sm:p-6">
+					<div className="flex items-center justify-between gap-4 rounded-sm border border-white/10 bg-white/[0.02] px-2 py-4">
 						<RankDisplay
 							rank={currentRank}
 							label="Atual"
 							division={orderInput.currentDivision}
 						/>
 
-						<div className="flex flex-col items-center justify-center pointer-events-none z-0">
-							<ArrowRight className="w-5 h-5 text-white/10" />
+						<div className="pointer-events-none flex flex-col items-center justify-center">
+							<ArrowRight
+								className="h-5 w-5 text-white/40"
+								aria-hidden="true"
+							/>
 						</div>
 
 						<RankDisplay
@@ -202,9 +205,67 @@ export const ReviewStep = ({
 						/>
 					</div>
 
+					<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+						<DetailItem
+							icon={Gauge}
+							label="PDL atual"
+							value={`${orderInput.currentLp} PDL`}
+						/>
+						<DetailItem
+							icon={TrendingUp}
+							label="Ganho por vitória"
+							value={`${orderInput.lpGain} PDL`}
+						/>
+						<DetailItem
+							className={favoriteBoosterName ? undefined : 'sm:col-span-2'}
+							icon={CalendarClock}
+							label="Prazo"
+							value={formatDateTime(orderInput.deadline)}
+							preserveCase
+						/>
+						{favoriteBoosterName ? (
+							<DetailItem
+								icon={UserRound}
+								label="Booster favorito"
+								value={favoriteBoosterName}
+								preserveCase
+							/>
+						) : null}
+					</div>
+
 					<div className="space-y-3">
 						<div className="flex items-center gap-2">
-							<span className="text-[10px] text-white/40 uppercase tracking-widest font-bold">
+							<span className="text-xs font-bold uppercase tracking-widest text-white/60">
+								Dados da Conta
+							</span>
+							<div className="h-px flex-1 bg-white/5" />
+						</div>
+						<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+							<DetailItem
+								icon={UserRound}
+								label="Login"
+								value={accountInput.login}
+								preserveCase
+							/>
+							<DetailItem
+								icon={Gamepad2}
+								label="Nome de invocador"
+								value={accountInput.summonerName}
+								preserveCase
+							/>
+							<DetailItem
+								className="sm:col-span-2"
+								icon={KeyRound}
+								label="Senha"
+								value={maskPassword(accountInput.password)}
+								preserveCase
+							/>
+						</div>
+					</div>
+
+					<div className="space-y-3">
+						<div className="flex items-center gap-2">
+							<span className="text-xs font-bold uppercase tracking-widest text-white/60">
 								Extras Ativos
 							</span>
 							<div className="h-px flex-1 bg-white/5" />
@@ -214,13 +275,13 @@ export const ReviewStep = ({
 								<Badge
 									key={id}
 									variant="outline"
-									className="bg-white/5 border-white/10 text-[10px] py-1 px-3 uppercase tracking-wider font-bold text-white/70 hover:bg-white/10 transition-colors"
+									className="border-white/10 bg-white/5 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white/75"
 								>
 									{EXTRA_OPTIONS_BY_ID.get(id)?.label ?? id}
 								</Badge>
 							))}
 							{orderInput.extras.length === 0 ? (
-								<p className="text-[10px] text-white/20 italic font-medium">
+								<p className="text-sm text-white/60">
 									Nenhum extra selecionado para este pedido.
 								</p>
 							) : null}
@@ -229,31 +290,28 @@ export const ReviewStep = ({
 				</CardContent>
 			</Card>
 
-			<div className="flex flex-col items-center gap-8 pt-4">
-				<div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-white/[0.02] border border-white/5 w-full">
+			<div className="flex flex-col items-center gap-6 pt-4">
+				<div className="flex w-full items-start gap-3 rounded-sm border border-white/10 bg-white/[0.02] px-4 py-4">
 					<Checkbox
 						id="terms-confirmation"
 						name="termsConfirmation"
 						checked={hasAcceptedTerms}
 						onChange={(event) => onTermsChange(event.target.checked)}
-						className="shrink-0"
+						className="mt-0.5 h-5 w-5 shrink-0"
 					/>
 					<label
 						htmlFor="terms-confirmation"
-						className="text-[10px] leading-relaxed text-white/40 uppercase tracking-widest cursor-pointer select-none hover:text-white/60 transition-colors"
+						className="cursor-pointer select-none text-sm leading-relaxed text-white/70"
 					>
-						Eu concordo plenamente com os{' '}
-						<span className="text-hextech-cyan font-bold hover:underline">
-							Termos de Serviço
-						</span>{' '}
-						da EloNew e confirmo que todos os dados acima estão corretos.
+						Eu concordo com os Termos de Serviço da EloNew e confirmo que todos
+						os dados acima estão corretos.
 					</label>
 				</div>
 
-				<div className="flex flex-col sm:flex-row gap-4 w-full">
+				<div className="flex w-full flex-col gap-3 sm:flex-row">
 					<Button
 						variant="outline"
-						className="flex-1 h-14 border-white/10 hover:bg-white/5 uppercase tracking-[0.2em] text-[10px] font-black"
+						className="h-14 flex-1 border-white/10 text-xs"
 						onClick={onBack}
 					>
 						Ajustar Pedido
@@ -261,41 +319,31 @@ export const ReviewStep = ({
 					<Button
 						type="button"
 						variant="primary"
-						className={cn(
-							'flex-[2] h-14 bg-emerald-500 text-xs font-black text-black uppercase tracking-[0.2em] transition-colors duration-200 hover:bg-emerald-400',
-							(isSubmitting || !hasAcceptedTerms) &&
-								'opacity-50 grayscale pointer-events-none',
-						)}
+						className="h-14 flex-[2] text-xs"
 						onClick={onCheckout}
 						disabled={isSubmitting || !hasAcceptedTerms}
 					>
 						{isSubmitting ? (
 							<span className="flex items-center gap-2">
-								<motion.div
-									animate={{ rotate: 360 }}
-									transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-								>
-									<Zap className="w-4 h-4" />
-								</motion.div>
+								<Zap className="h-4 w-4" aria-hidden="true" />
 								Processando...
 							</span>
 						) : (
 							<span className="flex items-center justify-center gap-2">
 								Finalizar e Pagar
-								<ChevronRight className="h-5 w-5" />
+								<ChevronRight className="h-5 w-5" aria-hidden="true" />
 							</span>
 						)}
 					</Button>
 				</div>
 
 				{error ? (
-					<motion.p
-						initial={{ opacity: 0, y: 10 }}
-						animate={{ opacity: 1, y: 0 }}
-						className="text-[10px] text-red-400 font-black uppercase tracking-widest px-4 py-2 bg-red-400/10 border border-red-400/20 rounded-sm"
+					<p
+						className="w-full rounded-sm border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm font-medium text-red-300"
+						role="alert"
 					>
 						{error}
-					</motion.p>
+					</p>
 				) : null}
 			</div>
 		</div>

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/service-step.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/service-step.tsx
@@ -44,7 +44,7 @@ export const ServiceStep = ({
 				<h2 className="text-xl font-black uppercase tracking-[0.2em]">
 					Selecione o Serviço
 				</h2>
-				<p className="text-white/40 text-xs">
+				<p className="text-sm leading-relaxed text-white/65">
 					Escolha a modalidade de subida desejada.
 				</p>
 			</div>
@@ -66,6 +66,7 @@ export const ServiceStep = ({
 							selected={isSelected}
 						>
 							<Icon
+								aria-hidden="true"
 								className={cn(
 									'w-8 h-8 mb-4 transition-colors',
 									isSelected
@@ -76,7 +77,7 @@ export const ServiceStep = ({
 							<h3 className="font-black uppercase tracking-widest text-xs mb-1">
 								{type.label}
 							</h3>
-							<p className="text-[10px] text-white/40 leading-relaxed">
+							<p className="text-sm leading-relaxed text-white/60">
 								{type.description}
 							</p>
 						</SelectableOption>
@@ -86,16 +87,18 @@ export const ServiceStep = ({
 
 			<RankRoutePicker orderInput={orderInput} onChange={onChange} />
 
-			<div className="flex justify-end pt-6 border-t border-white/5 mt-8">
+			<div className="mt-8 flex justify-end border-t border-white/10 pt-6">
 				<Button
 					type="button"
+					size="lg"
+					className="w-full sm:w-auto"
 					onClick={onNext}
 					onFocus={onNextIntent}
 					onMouseEnter={onNextIntent}
 					disabled={!canContinue}
 				>
 					Próximo Passo
-					<ChevronRight className="ml-2 h-4 w-4" />
+					<ChevronRight className="ml-2 h-4 w-4" aria-hidden="true" />
 				</Button>
 			</div>
 		</div>

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/step-indicator.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/step-indicator.tsx
@@ -1,3 +1,4 @@
+import { Check } from 'lucide-react';
 import { cn } from '@/shared/ui/utils/cn';
 
 type StepIndicatorProps = {
@@ -7,45 +8,69 @@ type StepIndicatorProps = {
 const STEPS = [
 	{ number: 1, label: 'Serviço' },
 	{ number: 2, label: 'Detalhes' },
-	{ number: 3, label: 'Revisão' },
+	{ number: 3, label: 'Conta' },
+	{ number: 4, label: 'Revisão' },
 ] as const;
 
 export const StepIndicator = ({ step }: StepIndicatorProps) => {
+	const currentStep = STEPS[step - 1] ?? STEPS[0];
+
 	return (
-		<ul
-			className="flex flex-wrap items-center gap-3"
-			aria-label="Progresso do pedido"
-		>
-			{STEPS.map((currentStep) => (
-				<li key={currentStep.number} className="flex items-center gap-2">
-					<div
-						className={cn(
-							'w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-black transition-all duration-300 border',
-							step >= currentStep.number
-								? 'bg-hextech-cyan border-hextech-cyan text-white'
-								: 'bg-white/5 border-white/10 text-white/20',
-						)}
-					>
-						{currentStep.number}
-					</div>
-					<span
-						className={cn(
-							'text-[10px] font-black uppercase tracking-[0.16em] transition-colors',
-							step >= currentStep.number ? 'text-white' : 'text-white/25',
-						)}
-					>
-						{currentStep.label}
-					</span>
-					{currentStep.number < STEPS.length ? (
-						<div
-							className={cn(
-								'w-8 h-px',
-								step > currentStep.number ? 'bg-hextech-cyan' : 'bg-white/10',
-							)}
-						/>
-					) : null}
-				</li>
-			))}
-		</ul>
+		<nav aria-label="Progresso do pedido" className="space-y-3">
+			<p className="text-sm font-medium text-white/70" aria-live="polite">
+				Etapa {step} de {STEPS.length}:{' '}
+				<span className="font-bold text-white">{currentStep.label}</span>
+			</p>
+			<ol className="grid grid-cols-4 gap-2">
+				{STEPS.map((item) => {
+					const isCurrent = step === item.number;
+					const isComplete = step > item.number;
+
+					return (
+						<li
+							key={item.number}
+							aria-label={`Etapa ${item.number}: ${item.label}`}
+							aria-current={isCurrent ? 'step' : undefined}
+							className="min-w-0"
+						>
+							<div
+								className={cn(
+									'h-1 rounded-sm bg-white/10',
+									(isCurrent || isComplete) && 'bg-hextech-cyan',
+								)}
+							/>
+							<div className="mt-2 flex items-center gap-2">
+								<span
+									className={cn(
+										'flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border text-xs font-black',
+										isCurrent &&
+											'border-hextech-cyan bg-hextech-cyan text-white',
+										isComplete &&
+											'border-hextech-cyan/50 bg-hextech-cyan/10 text-hextech-cyan',
+										!isCurrent &&
+											!isComplete &&
+											'border-white/15 bg-white/5 text-white/50',
+									)}
+								>
+									{isComplete ? (
+										<Check className="h-4 w-4" aria-hidden="true" />
+									) : (
+										item.number
+									)}
+								</span>
+								<span
+									className={cn(
+										'hidden truncate text-xs font-bold sm:block',
+										isCurrent || isComplete ? 'text-white' : 'text-white/50',
+									)}
+								>
+									{item.label}
+								</span>
+							</div>
+						</li>
+					);
+				})}
+			</ol>
+		</nav>
 	);
 };

--- a/apps/web/src/modules/client-dashboard/presentation/new-order/wizard-step-transition.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-order/wizard-step-transition.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode, useRef } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import { gsap, useGSAP } from '@/shared/ui/animation/gsap';
 
 type WizardStepTransitionProps = {
@@ -14,14 +14,24 @@ export const WizardStepTransition = ({
 }: WizardStepTransitionProps) => {
 	const containerRef = useRef<HTMLDivElement>(null);
 
+	useEffect(() => {
+		if (!stepKey) return;
+		const heading = containerRef.current?.querySelector<HTMLElement>('h2');
+		heading?.setAttribute('tabindex', '-1');
+		heading?.focus();
+	}, [stepKey]);
+
 	useGSAP(
 		() => {
+			if (
+				!stepKey ||
+				window.matchMedia('(prefers-reduced-motion: reduce)').matches
+			)
+				return;
+
 			gsap.fromTo(
 				containerRef.current,
-				{
-					autoAlpha: 0,
-					y: 20,
-				},
+				{ autoAlpha: 0, y: 20 },
 				{
 					autoAlpha: 1,
 					y: 0,

--- a/apps/web/src/shared/ui/styles/classes.ts
+++ b/apps/web/src/shared/ui/styles/classes.ts
@@ -7,7 +7,7 @@ export const disabledState = 'disabled:cursor-not-allowed disabled:opacity-50';
 
 export const labelText = {
 	control:
-		'text-[10px] font-black uppercase tracking-[0.2em] leading-none text-white/40',
+		'text-xs font-black uppercase tracking-[0.16em] leading-none text-white/65',
 	nav: 'text-[10px] font-black uppercase tracking-[0.3em]',
 	eyebrow: 'text-[10px] font-black uppercase tracking-[0.4em]',
 };
@@ -19,7 +19,7 @@ export const panelSurface = {
 };
 
 export const fieldSurface = cn(
-	'flex h-10 w-full rounded-sm border border-white/10 bg-white/5 px-3 py-2 text-xs text-white ring-offset-black transition-all duration-200',
+	'flex h-11 w-full rounded-sm border border-white/10 bg-white/5 px-3 py-2 text-sm text-white ring-offset-black transition-all duration-200',
 	'placeholder:text-white/20 focus-visible:border-hextech-cyan',
 	focusRing,
 	'disabled:cursor-not-allowed disabled:opacity-50',


### PR DESCRIPTION
## Summary
- add an account credentials step between order details and review
- validate login and password lengths and show account data in the final review
- improve wizard accessibility, responsive layout, readability, and GSAP motion
- clear stale favorite-booster data and fully mask passwords in review

## Scope
- frontend only; account credentials are not yet submitted or persisted by checkout
- no frontend tests added, per request

## Verification
- `pnpm biome:fix:all`
- `pnpm web exec tsc --noEmit`
- `pnpm web build`
- `git diff --check`
- manual browser verification of the Elo hover/focus GSAP transform