### PR TITLE
feat(web): add Vercel Analytics

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
 		"@packages/auth": "workspace:*",
 		"@packages/shared": "workspace:*",
 		"@radix-ui/react-select": "^2.2.6",
+		"@vercel/analytics": "^2.0.1",
 		"clsx": "^2.1.1",
 		"gsap": "^3.14.2",
 		"lenis": "^1.3.21",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from '@vercel/analytics/next';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
@@ -41,7 +42,10 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang="pt-BR" className={`${satoshi.variable}`}>
-			<body className="antialiased">{children}</body>
+			<body className="antialiased">
+				{children}
+				<Analytics />
+			</body>
 		</html>
 	);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -343,6 +346,9 @@ importers:
         version: 4.3.6
 
 packages:
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
@@ -5107,6 +5113,8 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@vercel/analytics@2.0.1': {}
 
   '@adobe/css-tools@4.4.4': {}
 


### PR DESCRIPTION
## Summary

- add `@vercel/analytics` to the web app
- render `<Analytics />` from the root layout

## Verification

- `git diff --check`
- Tests not run, as requested.

## Remaining risk

- Analytics collection is only verifiable after deployment and visiting the site.

## Breaking changes

None.