### PR TITLE
feat(web): add Vercel Speed Insights

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
 		"@packages/shared": "workspace:*",
 		"@radix-ui/react-select": "^2.2.6",
 		"@vercel/analytics": "^2.0.1",
+		"@vercel/speed-insights": "^2.0.0",
 		"clsx": "^2.1.1",
 		"gsap": "^3.14.2",
 		"lenis": "^1.3.21",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
@@ -45,6 +46,7 @@ export default function RootLayout({
 			<body className="antialiased">
 				{children}
 				<Analytics />
+				<SpeedInsights />
 			</body>
 		</html>
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -349,6 +352,9 @@ packages:
 
   '@vercel/analytics@2.0.1':
     resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
@@ -5115,6 +5121,8 @@ packages:
 snapshots:
 
   '@vercel/analytics@2.0.1': {}
+
+  '@vercel/speed-insights@2.0.0': {}
 
   '@adobe/css-tools@4.4.4': {}
 


### PR DESCRIPTION
## Summary

- add `@vercel/speed-insights` to the web app
- render `<SpeedInsights />` from the root layout

## Verification

- Not run, as requested.

## Remaining risk

- Performance data collection is only verifiable after deployment and visiting the site.

## Breaking changes

None.