### PR TITLE
fix(ci): serialize production deploys AND fix broken tests that was stucking ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
     needs: [checks, database]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    concurrency:
+      group: production-deploy
+      queue: max
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/apps/api/test/integration/auth/auth.integration.spec.ts
+++ b/apps/api/test/integration/auth/auth.integration.spec.ts
@@ -3,7 +3,7 @@ import { AUTH_SESSION_REPOSITORY_KEY } from '@modules/auth/application/ports/aut
 import { AuthController } from '@modules/auth/presentation/auth.controller';
 import { USER_REPOSITORY_KEY } from '@modules/users/application/ports/user-repository.port';
 import { UsersController } from '@modules/users/presentation/users.controller';
-import { Test } from '@nestjs/testing';
+import { Test, type TestingModule } from '@nestjs/testing';
 import { AppModule } from '../../../src/app.module';
 import { InMemoryAuthSessionRepository } from '../../support/in-memory/auth/in-memory-auth-session.repository';
 import { InMemoryUserRepository } from '../../support/in-memory/users/in-memory-user.repository';
@@ -12,9 +12,10 @@ import { createTestAppSettings } from '../../test-app-settings';
 describe('Auth module integration', () => {
 	let usersController: UsersController;
 	let authController: AuthController;
+	let moduleRef: TestingModule;
 
 	beforeEach(async () => {
-		const moduleRef = await Test.createTestingModule({
+		moduleRef = await Test.createTestingModule({
 			imports: [AppModule],
 		})
 			.overrideProvider(USER_REPOSITORY_KEY)
@@ -27,6 +28,10 @@ describe('Auth module integration', () => {
 
 		usersController = moduleRef.get(UsersController);
 		authController = moduleRef.get(AuthController);
+	});
+
+	afterEach(async () => {
+		await moduleRef.close();
 	});
 
 	it('logs in, rotates refresh tokens, and revokes them on logout', async () => {

--- a/apps/api/test/integration/system/api-health.integration.spec.ts
+++ b/apps/api/test/integration/system/api-health.integration.spec.ts
@@ -1,16 +1,21 @@
 import { ApiHealthController } from '@modules/system/presentation/health/api/api-health.controller';
 import { SystemModule } from '@modules/system/system.module';
-import { Test } from '@nestjs/testing';
+import { Test, type TestingModule } from '@nestjs/testing';
 
 describe('System module integration (api health)', () => {
 	let controller: ApiHealthController;
+	let moduleRef: TestingModule;
 
 	beforeEach(async () => {
-		const moduleRef = await Test.createTestingModule({
+		moduleRef = await Test.createTestingModule({
 			imports: [SystemModule],
 		}).compile();
 
 		controller = moduleRef.get(ApiHealthController);
+	});
+
+	afterEach(async () => {
+		await moduleRef.close();
 	});
 
 	it('returns ok status', async () => {

--- a/apps/api/test/integration/system/database-health.integration.spec.ts
+++ b/apps/api/test/integration/system/database-health.integration.spec.ts
@@ -1,16 +1,21 @@
 import { DatabaseHealthController } from '@modules/system/presentation/health/database/database-health.controller';
 import { SystemModule } from '@modules/system/system.module';
-import { Test } from '@nestjs/testing';
+import { Test, type TestingModule } from '@nestjs/testing';
 
 describe('System module integration (database health)', () => {
 	let controller: DatabaseHealthController;
+	let moduleRef: TestingModule;
 
 	beforeEach(async () => {
-		const moduleRef = await Test.createTestingModule({
+		moduleRef = await Test.createTestingModule({
 			imports: [SystemModule],
 		}).compile();
 
 		controller = moduleRef.get(DatabaseHealthController);
+	});
+
+	afterEach(async () => {
+		await moduleRef.close();
 	});
 
 	it('returns ok status', async () => {

--- a/apps/api/test/integration/system/web-health.integration.spec.ts
+++ b/apps/api/test/integration/system/web-health.integration.spec.ts
@@ -1,16 +1,21 @@
 import { WebHealthController } from '@modules/system/presentation/health/web/web-health.controller';
 import { SystemModule } from '@modules/system/system.module';
-import { Test } from '@nestjs/testing';
+import { Test, type TestingModule } from '@nestjs/testing';
 
 describe('System module integration (web health)', () => {
 	let controller: WebHealthController;
+	let moduleRef: TestingModule;
 
 	beforeEach(async () => {
-		const moduleRef = await Test.createTestingModule({
+		moduleRef = await Test.createTestingModule({
 			imports: [SystemModule],
 		}).compile();
 
 		controller = moduleRef.get(WebHealthController);
+	});
+
+	afterEach(async () => {
+		await moduleRef.close();
 	});
 
 	it('returns ok status', async () => {

--- a/apps/api/test/integration/system/workers-health.integration.spec.ts
+++ b/apps/api/test/integration/system/workers-health.integration.spec.ts
@@ -1,16 +1,21 @@
 import { WorkersHealthController } from '@modules/system/presentation/health/workers/workers-health.controller';
 import { SystemModule } from '@modules/system/system.module';
-import { Test } from '@nestjs/testing';
+import { Test, type TestingModule } from '@nestjs/testing';
 
 describe('System module integration (workers health)', () => {
 	let controller: WorkersHealthController;
+	let moduleRef: TestingModule;
 
 	beforeEach(async () => {
-		const moduleRef = await Test.createTestingModule({
+		moduleRef = await Test.createTestingModule({
 			imports: [SystemModule],
 		}).compile();
 
 		controller = moduleRef.get(WorkersHealthController);
+	});
+
+	afterEach(async () => {
+		await moduleRef.close();
 	});
 
 	it('returns ok status', async () => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,6 +74,7 @@ The workflow rejects tags whose commit is not contained in `main`, runs all CI
 lanes, applies Prisma migrations, stages a production frontend build in Vercel,
 rebuilds the VPS stack, verifies API health, and promotes the staged frontend.
 The remote Vercel build keeps Sensitive environment variables inside Vercel.
+Production deploy jobs share one queue and run one at a time.
 
 ## Verify
 


### PR DESCRIPTION
## Summary

- serialize production deployment jobs through one GitHub Actions concurrency queue
- close every Nest `TestingModule` created by the affected integration specs
- document that production deployments run one at a time

## Root cause

Release tags used distinct workflow concurrency groups, allowing production deploys to overlap. Separately, five integration specs did not close their Nest testing modules; CI finished all assertions but kept Node processes alive until cancellation.

## Verification

- API integration suite on Node 22: 10 suites and 37 tests passed, with a clean process exit
- targeted Biome check: passed
- `git diff --check`: passed

## Skipped checks and remaining risk

- API typecheck could not be validated from the isolated worktree because reused workspace dependency symlinks resolved outside it.
- `actionlint` is unavailable locally; GitHub Actions will perform the definitive workflow syntax validation.
- Production serialization can only be fully observed when multiple release deploy jobs overlap.

## Breaking changes

None.