### PR TITLE
feat(web): use styled select for role and order fields

### DIFF
--- a/apps/web/jest.setup.ts
+++ b/apps/web/jest.setup.ts
@@ -1,5 +1,17 @@
 import '@testing-library/jest-dom';
 
+// ponytail: jsdom lacks the APIs Radix popovers probe; stubs are enough because
+// tests assert markup, not geometry.
+window.ResizeObserver ??= class {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+};
+Element.prototype.scrollIntoView ??= () => {};
+Element.prototype.hasPointerCapture ??= () => false;
+Element.prototype.setPointerCapture ??= () => {};
+Element.prototype.releasePointerCapture ??= () => {};
+
 Object.defineProperty(window, 'matchMedia', {
 	writable: true,
 	value: jest.fn().mockImplementation((query) => ({

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-create-user-form.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-create-user-form.tsx
@@ -1,8 +1,15 @@
 'use client';
 
 import { UserPlus } from 'lucide-react';
-import { useActionState, useEffect, useRef } from 'react';
+import { useActionState, useEffect, useId, useRef, useState } from 'react';
 import { getButtonClassName } from '@/shared/ui/components/button';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/shared/ui/components/select';
 import { fieldSurface } from '@/shared/ui/styles/classes';
 import { cn } from '@/shared/ui/utils/cn';
 import {
@@ -11,6 +18,8 @@ import {
 } from '../../actions/admin-actions';
 
 import { roleOptions } from '../users/admin-user-metadata';
+
+const DEFAULT_ROLE = 'CLIENT';
 
 export const AdminCreateUserForm = ({
 	onSuccess,
@@ -22,10 +31,13 @@ export const AdminCreateUserForm = ({
 		FormData
 	>(createAdminUserAction, {});
 	const formRef = useRef<HTMLFormElement>(null);
+	const roleId = useId();
+	const [role, setRole] = useState(DEFAULT_ROLE);
 
 	useEffect(() => {
 		if (state.success) {
 			formRef.current?.reset();
+			setRole(DEFAULT_ROLE);
 			onSuccess?.();
 		}
 	}, [state.success, onSuccess]);
@@ -59,22 +71,26 @@ export const AdminCreateUserForm = ({
 					required
 				/>
 			</label>
-			<label className="grid gap-2">
-				<span className="text-[10px] font-black uppercase tracking-widest text-white/35">
-					Perfil
-				</span>
-				<select
-					name="role"
-					className={cn(fieldSurface, 'bg-black/20')}
-					defaultValue="CLIENT"
+			<div className="grid gap-2">
+				<label
+					htmlFor={roleId}
+					className="text-[10px] font-black uppercase tracking-widest text-white/35"
 				>
-					{roleOptions.map((option) => (
-						<option key={option.value} value={option.value}>
-							{option.label}
-						</option>
-					))}
-				</select>
-			</label>
+					Perfil
+				</label>
+				<Select name="role" value={role} onValueChange={setRole}>
+					<SelectTrigger id={roleId} className="bg-black/20">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent className="z-[110]">
+						{roleOptions.map((option) => (
+							<SelectItem key={option.value} value={option.value}>
+								{option.label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
 			<div className="grid content-end gap-2 md:col-span-2">
 				<button
 					type="submit"

--- a/apps/web/src/modules/client-dashboard/presentation/new-ticket/support-ticket-panel.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-ticket/support-ticket-panel.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ClientDashboardOrder } from '../../model/orders';
 import { SupportTicketPanel } from './support-ticket-panel';
 
@@ -25,7 +26,8 @@ const buildOrder = (
 });
 
 describe('SupportTicketPanel', () => {
-	it('renders the ticket form fields and an option per order', () => {
+	it('renders the ticket form fields and an option per order', async () => {
+		const user = userEvent.setup();
 		render(
 			<SupportTicketPanel
 				action={jest.fn().mockResolvedValue({})}
@@ -40,6 +42,9 @@ describe('SupportTicketPanel', () => {
 				'Vincule um pedido quando o assunto for sobre um serviço específico.',
 			),
 		).toBeInTheDocument();
+		await user.click(
+			screen.getByRole('combobox', { name: /pedido relacionado/i }),
+		);
 		expect(screen.getAllByRole('option')).toHaveLength(2);
 		expect(screen.getByText('01 disponíveis')).toBeInTheDocument();
 	});
@@ -55,7 +60,28 @@ describe('SupportTicketPanel', () => {
 
 		expect(
 			screen.getByRole('combobox', { name: /pedido relacionado/i }),
-		).toHaveValue('order-1234abcd');
+		).toHaveTextContent('order-12 - Elo Boost');
+	});
+
+	it('clears the submitted order id when the general ticket is picked', async () => {
+		const user = userEvent.setup();
+		render(
+			<SupportTicketPanel
+				action={jest.fn().mockResolvedValue({})}
+				initialOrderId="order-1234abcd"
+				orders={[buildOrder()]}
+			/>,
+		);
+
+		const orderIdField = document.querySelector('input[name="orderId"]');
+		expect(orderIdField).toHaveValue('order-1234abcd');
+
+		await user.click(
+			screen.getByRole('combobox', { name: /pedido relacionado/i }),
+		);
+		await user.click(screen.getByRole('option', { name: 'Ticket geral' }));
+
+		expect(orderIdField).toHaveValue('');
 	});
 
 	it('shows the empty-orders helper when there are no orders', () => {

--- a/apps/web/src/modules/client-dashboard/presentation/new-ticket/support-ticket-panel.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/new-ticket/support-ticket-panel.tsx
@@ -1,9 +1,16 @@
 'use client';
 
 import { Clock3, FileText, Send } from 'lucide-react';
-import { useActionState } from 'react';
+import { useActionState, useId, useState } from 'react';
 import { DashboardSubmitButton } from '@/shared/dashboard/dashboard-submit-button';
 import { formatOrderRoute, formatServiceType } from '@/shared/format/orders';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/shared/ui/components/select';
 import { fieldSurface } from '@/shared/ui/styles/classes';
 import { cn } from '@/shared/ui/utils/cn';
 import type { CreateSupportTicketActionState } from '../../actions/order-actions';
@@ -18,42 +25,58 @@ type SupportTicketPanelProps = {
 	orders: ClientDashboardOrder[];
 };
 
+const GENERAL_TICKET = '__general__';
+
 export const SupportTicketPanel = ({
 	action,
 	initialOrderId,
 	orders,
 }: SupportTicketPanelProps) => {
 	const [state, formAction] = useActionState(action, {});
-	const selectedOrderId = orders.some((order) => order.id === initialOrderId)
-		? initialOrderId
-		: '';
+	const orderFieldId = useId();
+	const [orderId, setOrderId] = useState(
+		() => orders.find((order) => order.id === initialOrderId)?.id ?? '',
+	);
 
 	return (
 		<section className="dashboard-animate grid w-full overflow-hidden rounded-sm border border-white/10 bg-[#0b0b0d] lg:grid-cols-[minmax(0,1fr)_340px]">
 			<div className="p-5 sm:p-7">
 				<form action={formAction} className="grid gap-5">
-					<label className="grid gap-2">
-						<span className="text-[10px] font-black uppercase tracking-widest text-white/45">
-							Pedido relacionado
-						</span>
-						<select
-							name="orderId"
-							className={cn(fieldSurface, 'h-12 bg-white/[0.03] text-sm')}
-							defaultValue={selectedOrderId}
+					<div className="grid gap-2">
+						<label
+							htmlFor={orderFieldId}
+							className="text-[10px] font-black uppercase tracking-widest text-white/45"
 						>
-							<option value="">Ticket geral</option>
-							{orders.map((order) => (
-								<option key={order.id} value={order.id}>
-									{formatOrderOption(order)}
-								</option>
-							))}
-						</select>
+							Pedido relacionado
+						</label>
+						<input type="hidden" name="orderId" value={orderId} />
+						<Select
+							value={orderId || GENERAL_TICKET}
+							onValueChange={(value) =>
+								setOrderId(value === GENERAL_TICKET ? '' : value)
+							}
+						>
+							<SelectTrigger
+								id={orderFieldId}
+								className="h-12 bg-white/[0.03] text-sm"
+							>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value={GENERAL_TICKET}>Ticket geral</SelectItem>
+								{orders.map((order) => (
+									<SelectItem key={order.id} value={order.id}>
+										{formatOrderOption(order)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 						<p className="text-[10px] leading-relaxed text-white/35">
 							{orders.length > 0
 								? 'Vincule um pedido quando o assunto for sobre um serviço específico.'
 								: 'Você ainda não tem pedidos para vincular.'}
 						</p>
-					</label>
+					</div>
 
 					<div className="grid items-start gap-5 lg:grid-cols-[0.8fr_1.2fr]">
 						<label className="grid gap-2">


### PR DESCRIPTION
## Summary

Replaces the two remaining native `<select>` elements — the admin create-user role picker and the support ticket "Pedido relacionado" picker — with the shared Radix-based `Select`, so every dropdown in the dashboards now matches. No native `<select>` is left in `apps/web/src`.

Because the Radix trigger is a `<button>`, implicit labeling no longer works: each field wraps in a `div` with an explicit `htmlFor` / `useId()` pairing.

## Behavior notes

- **Role field is controlled.** Radix renders its hidden native input with `defaultValue` and has no form-reset listener (verified in `@radix-ui/react-select@2.2.6`). With an uncontrolled select, the `form.reset()` after a successful create reverted the submitted value to `CLIENT` while the trigger still displayed the previously picked role. State now resets alongside the form.
- **Order field keeps a hidden input.** Radix items cannot take `""` as a value, so "Ticket geral" uses a `__general__` sentinel that maps back to an empty `orderId`. The server action contract is unchanged.

## Tests

- New case asserting that picking the general ticket clears the submitted `orderId`, so the sentinel never reaches the server.
- Fixed the preselected-order expectation, which compared against an id longer than the eight characters the option label renders.
- jsdom lacks pointer capture, `scrollIntoView`, and `ResizeObserver`, which Radix and floating-ui probe; stubbed once in `jest.setup.ts` so any Radix popover is testable.

Not run: the web test suite, per request. `tsc --noEmit` and `biome check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)