### PR TITLE
fix: resolve dashboard feedback

### DIFF
--- a/apps/api/src/modules/admin/application/ports/admin-dashboard-reader.port.ts
+++ b/apps/api/src/modules/admin/application/ports/admin-dashboard-reader.port.ts
@@ -67,6 +67,15 @@ export type AdminSupportTicketSnapshot = {
 	latestMessageAt: Date | null;
 };
 
+export type AdminWithdrawalRequestSnapshot = {
+	id: string;
+	boosterId: string;
+	boosterUsername: string;
+	amount: number;
+	payoutPixKey: string | null;
+	createdAt: Date;
+};
+
 export interface AdminDashboardReaderPort {
 	getMetrics(): Promise<AdminMetricsSnapshot>;
 	listUsers(input: {
@@ -78,4 +87,7 @@ export interface AdminDashboardReaderPort {
 	listSupportTickets(input: {
 		limit: number;
 	}): Promise<AdminSupportTicketSnapshot[]>;
+	listWithdrawalRequests(input: {
+		limit: number;
+	}): Promise<AdminWithdrawalRequestSnapshot[]>;
 }

--- a/apps/api/src/modules/admin/application/use-cases/get-admin-dashboard/get-admin-dashboard.use-case.spec.ts
+++ b/apps/api/src/modules/admin/application/use-cases/get-admin-dashboard/get-admin-dashboard.use-case.spec.ts
@@ -67,6 +67,16 @@ class AdminDashboardReaderStub implements AdminDashboardReaderPort {
 			latestMessageAt: new Date('2026-05-02T00:00:00.000Z'),
 		},
 	];
+	withdrawals = [
+		{
+			id: 'withdrawal-1',
+			boosterId: 'booster-1',
+			boosterUsername: 'Booster One',
+			amount: 2500,
+			payoutPixKey: 'booster@example.com',
+			createdAt: new Date('2026-05-03T00:00:00.000Z'),
+		},
+	];
 
 	getMetrics(): Promise<AdminMetricsSnapshot> {
 		return Promise.resolve(this.metrics);
@@ -88,6 +98,10 @@ class AdminDashboardReaderStub implements AdminDashboardReaderPort {
 
 	listSupportTickets(): Promise<AdminSupportTicketSnapshot[]> {
 		return Promise.resolve(this.tickets);
+	}
+
+	listWithdrawalRequests() {
+		return Promise.resolve(this.withdrawals);
 	}
 }
 
@@ -135,6 +149,21 @@ describe('GetAdminDashboardUseCase', () => {
 			expect.objectContaining({
 				id: 'ticket-1',
 				messageCount: 2,
+			}),
+		]);
+	});
+
+	it('returns withdrawal requests with the payout PIX key', async () => {
+		const useCase = new GetAdminDashboardUseCase(
+			new AdminDashboardReaderStub(),
+		);
+
+		await expect(
+			useCase.listWithdrawalRequests({ limit: 10 }),
+		).resolves.toEqual([
+			expect.objectContaining({
+				id: 'withdrawal-1',
+				payoutPixKey: 'booster@example.com',
 			}),
 		]);
 	});

--- a/apps/api/src/modules/admin/application/use-cases/get-admin-dashboard/get-admin-dashboard.use-case.ts
+++ b/apps/api/src/modules/admin/application/use-cases/get-admin-dashboard/get-admin-dashboard.use-case.ts
@@ -5,6 +5,7 @@ import {
 	type AdminOrderSnapshot,
 	type AdminSupportTicketSnapshot,
 	type AdminUserSnapshot,
+	type AdminWithdrawalRequestSnapshot,
 } from '@modules/admin/application/ports/admin-dashboard-reader.port';
 import { Inject, Injectable } from '@nestjs/common';
 
@@ -38,5 +39,11 @@ export class GetAdminDashboardUseCase {
 		limit: number;
 	}): Promise<AdminSupportTicketSnapshot[]> {
 		return await this.reader.listSupportTickets(input);
+	}
+
+	async listWithdrawalRequests(input: {
+		limit: number;
+	}): Promise<AdminWithdrawalRequestSnapshot[]> {
+		return await this.reader.listWithdrawalRequests(input);
 	}
 }

--- a/apps/api/src/modules/admin/infrastructure/repositories/prisma-admin-dashboard.reader.ts
+++ b/apps/api/src/modules/admin/infrastructure/repositories/prisma-admin-dashboard.reader.ts
@@ -1,9 +1,11 @@
 import { PrismaService } from '@app/common/prisma/prisma.service';
 import type {
+	AdminDashboardReaderPort,
 	AdminMetricsSnapshot,
 	AdminOrderSnapshot,
 	AdminSupportTicketSnapshot,
 	AdminUserSnapshot,
+	AdminWithdrawalRequestSnapshot,
 } from '@modules/admin/application/ports/admin-dashboard-reader.port';
 import { OrderStatus } from '@modules/orders/domain/order-status';
 import { PaymentStatus } from '@modules/payments/domain/payment-status';
@@ -66,6 +68,14 @@ type AdminTicketRecord = {
 	updatedAt: Date;
 	messages: Array<{ createdAt: Date }>;
 	_count: { messages: number };
+};
+
+type AdminWithdrawalRecord = {
+	id: string;
+	amount: number;
+	payoutPixKey: string | null;
+	createdAt: Date;
+	wallet: { booster: { id: string; username: string } };
 };
 
 type AdminDashboardPrismaClient = {
@@ -208,10 +218,31 @@ type AdminDashboardPrismaClient = {
 			take: number;
 		}): Promise<AdminTicketRecord[]>;
 	};
+	walletTransaction: {
+		findMany(args: {
+			where: {
+				type: 'DEBIT';
+				reason: 'withdrawal_request';
+			};
+			select: {
+				id: true;
+				amount: true;
+				payoutPixKey: true;
+				createdAt: true;
+				wallet: {
+					select: {
+						booster: { select: { id: true; username: true } };
+					};
+				};
+			};
+			orderBy: { createdAt: 'desc' };
+			take: number;
+		}): Promise<AdminWithdrawalRecord[]>;
+	};
 };
 
 @Injectable()
-export class PrismaAdminDashboardReader {
+export class PrismaAdminDashboardReader implements AdminDashboardReaderPort {
 	constructor(private readonly prisma: PrismaService) {}
 
 	async getMetrics(): Promise<AdminMetricsSnapshot> {
@@ -421,6 +452,39 @@ export class PrismaAdminDashboardReader {
 			updatedAt: record.updatedAt,
 			messageCount: record._count.messages,
 			latestMessageAt: record.messages[0]?.createdAt ?? null,
+		}));
+	}
+
+	async listWithdrawalRequests(input: {
+		limit: number;
+	}): Promise<AdminWithdrawalRequestSnapshot[]> {
+		const records = await this.getClient().walletTransaction.findMany({
+			where: {
+				type: 'DEBIT',
+				reason: 'withdrawal_request',
+			},
+			select: {
+				id: true,
+				amount: true,
+				payoutPixKey: true,
+				createdAt: true,
+				wallet: {
+					select: {
+						booster: { select: { id: true, username: true } },
+					},
+				},
+			},
+			orderBy: { createdAt: 'desc' },
+			take: input.limit,
+		});
+
+		return records.map((record) => ({
+			id: record.id,
+			boosterId: record.wallet.booster.id,
+			boosterUsername: record.wallet.booster.username,
+			amount: record.amount,
+			payoutPixKey: record.payoutPixKey,
+			createdAt: record.createdAt,
 		}));
 	}
 

--- a/apps/api/src/modules/admin/presentation/admin.controller.ts
+++ b/apps/api/src/modules/admin/presentation/admin.controller.ts
@@ -158,6 +158,15 @@ export class AdminController {
 		return await this.dashboard.listOrders({ limit: query.limit });
 	}
 
+	@Get('withdrawals')
+	async listWithdrawalRequests(
+		@Query(new ZodValidationPipe(adminListQuerySchema))
+		query: AdminListQuerySchemaInput,
+		@CurrentUser() _currentUser: AuthenticatedUser,
+	) {
+		return await this.dashboard.listWithdrawalRequests({ limit: query.limit });
+	}
+
 	@Get('orders/:orderId')
 	async getOrder(
 		@Param('orderId', new ZodValidationPipe(adminIdParamSchema))

--- a/apps/api/src/modules/orders/application/ports/order-event-publisher.port.ts
+++ b/apps/api/src/modules/orders/application/ports/order-event-publisher.port.ts
@@ -2,6 +2,7 @@ export const ORDER_EVENT_PUBLISHER_KEY = Symbol('ORDER_EVENT_PUBLISHER_KEY');
 
 export type OrderEventType =
 	| 'order.paid'
+	| 'order.credentials_saved'
 	| 'order.accepted'
 	| 'order.rejected'
 	| 'order.completed'

--- a/apps/api/src/modules/orders/application/use-cases/save-order-credentials/save-order-credentials.use-case.spec.ts
+++ b/apps/api/src/modules/orders/application/use-cases/save-order-credentials/save-order-credentials.use-case.spec.ts
@@ -1,3 +1,7 @@
+import type {
+	OrderEvent,
+	OrderEventPublisherPort,
+} from '@modules/orders/application/ports/order-event-publisher.port';
 import type { OrderRepositoryPort } from '@modules/orders/application/ports/order-repository.port';
 import { SaveOrderCredentialsUseCase } from '@modules/orders/application/use-cases/save-order-credentials/save-order-credentials.use-case';
 import {
@@ -45,6 +49,15 @@ class InMemoryOrderRepository implements OrderRepositoryPort {
 	}
 }
 
+class OrderEventPublisherSpy implements OrderEventPublisherPort {
+	readonly events: OrderEvent[] = [];
+
+	publish(event: OrderEvent): Promise<void> {
+		this.events.push(event);
+		return Promise.resolve();
+	}
+}
+
 describe('SaveOrderCredentialsUseCase', () => {
 	it('stores credentials after payment confirmation', async () => {
 		const repository = new InMemoryOrderRepository();
@@ -70,6 +83,33 @@ describe('SaveOrderCredentialsUseCase', () => {
 		const savedOrder = await repository.findById('order-1');
 		expect(savedOrder?.hasCredentials).toBe(true);
 		expect(savedOrder?.pendingCredentials).toBeNull();
+	});
+
+	it('publishes an order credentials saved event after persistence', async () => {
+		const repository = new InMemoryOrderRepository();
+		const publisher = new OrderEventPublisherSpy();
+		const order = Order.create('order-live', { clientId: 'client-1' });
+		order.confirmPayment();
+		repository.insert(order);
+		const useCase = new SaveOrderCredentialsUseCase(repository, publisher);
+
+		await useCase.execute({
+			orderId: 'order-live',
+			clientId: 'client-1',
+			login: 'login',
+			summonerName: 'summoner',
+			password: 'secret',
+			confirmPassword: 'secret',
+		});
+
+		expect(publisher.events).toEqual([
+			expect.objectContaining({
+				type: 'order.credentials_saved',
+				orderId: 'order-live',
+				clientId: 'client-1',
+				boosterId: null,
+			}),
+		]);
 	});
 
 	it('throws when passwords do not match', async () => {

--- a/apps/api/src/modules/orders/application/use-cases/save-order-credentials/save-order-credentials.use-case.ts
+++ b/apps/api/src/modules/orders/application/use-cases/save-order-credentials/save-order-credentials.use-case.ts
@@ -1,3 +1,8 @@
+import { createOrderEvent } from '@modules/orders/application/order-event.factory';
+import {
+	ORDER_EVENT_PUBLISHER_KEY,
+	type OrderEventPublisherPort,
+} from '@modules/orders/application/ports/order-event-publisher.port';
 import {
 	ORDER_REPOSITORY_KEY,
 	type OrderRepositoryPort,
@@ -6,7 +11,7 @@ import {
 	OrderCredentialsPasswordMismatchError,
 	OrderNotFoundError,
 } from '@modules/orders/domain/order.errors';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
 
 type SaveOrderCredentialsInput = {
 	orderId: string;
@@ -22,6 +27,9 @@ export class SaveOrderCredentialsUseCase {
 	constructor(
 		@Inject(ORDER_REPOSITORY_KEY)
 		private readonly orderRepository: OrderRepositoryPort,
+		@Optional()
+		@Inject(ORDER_EVENT_PUBLISHER_KEY)
+		private readonly orderEventPublisher?: OrderEventPublisherPort,
 	) {}
 
 	async execute(input: SaveOrderCredentialsInput): Promise<void> {
@@ -39,5 +47,8 @@ export class SaveOrderCredentialsUseCase {
 			password: input.password,
 		});
 		await this.orderRepository.saveCredentials(order);
+		await this.orderEventPublisher?.publish(
+			createOrderEvent('order.credentials_saved', order),
+		);
 	}
 }

--- a/apps/api/src/modules/orders/presentation/orders-events.controller.spec.ts
+++ b/apps/api/src/modules/orders/presentation/orders-events.controller.spec.ts
@@ -57,6 +57,23 @@ describe('OrdersEventsController', () => {
 		});
 	});
 
+	it('streams unassigned credentials saved events to boosters', async () => {
+		const bus = new InMemoryOrderEventBus();
+		const controller = new OrdersEventsController(bus);
+		const messagePromise = firstValueFrom(
+			controller.stream(makeUser('booster-1', Role.BOOSTER)).pipe(take(1)),
+		);
+
+		await bus.publish(
+			makeEvent({ type: 'order.credentials_saved', boosterId: null }),
+		);
+
+		await expect(messagePromise).resolves.toMatchObject({
+			type: 'order.credentials_saved',
+			data: { orderId: 'order-1' },
+		});
+	});
+
 	it('does not expose client ids in streamed payloads', async () => {
 		const bus = new InMemoryOrderEventBus();
 		const controller = new OrdersEventsController(bus);

--- a/apps/api/src/modules/orders/presentation/orders-events.controller.ts
+++ b/apps/api/src/modules/orders/presentation/orders-events.controller.ts
@@ -61,7 +61,10 @@ export class OrdersEventsController {
 			return event.clientId === currentUser.id;
 		if (currentUser.role !== Role.BOOSTER) return false;
 
-		if (event.type === 'order.paid') {
+		if (
+			event.type === 'order.paid' ||
+			event.type === 'order.credentials_saved'
+		) {
 			return event.boosterId === null || event.boosterId === currentUser.id;
 		}
 

--- a/apps/api/src/modules/ratings/application/use-cases/get-order-ratings/get-order-ratings.use-case.spec.ts
+++ b/apps/api/src/modules/ratings/application/use-cases/get-order-ratings/get-order-ratings.use-case.spec.ts
@@ -1,0 +1,43 @@
+import type { RatingOrderLookupPort } from '@modules/ratings/application/ports/rating-order-lookup.port';
+import type {
+	RatingRecord,
+	RatingRepositoryPort,
+} from '@modules/ratings/application/ports/rating-repository.port';
+import { GetOrderRatingsUseCase } from '@modules/ratings/application/use-cases/get-order-ratings/get-order-ratings.use-case';
+import { Role } from '@packages/auth/roles/role';
+
+describe('GetOrderRatingsUseCase', () => {
+	it('allows an admin to inspect ratings for an order', async () => {
+		const record: RatingRecord = {
+			id: 'rating-1',
+			orderId: 'order-1',
+			fromUserId: 'client-1',
+			toUserId: 'booster-1',
+			score: 5,
+			comment: 'Ótimo serviço',
+			createdAt: new Date('2026-08-04T01:34:36.000Z'),
+		};
+		const ratings = {
+			listForOrder: jest.fn().mockResolvedValue([record]),
+		} as unknown as RatingRepositoryPort;
+		const orders = {
+			findById: jest.fn().mockResolvedValue({
+				id: 'order-1',
+				clientId: 'client-1',
+				boosterId: 'booster-1',
+				status: 'completed',
+				completedAt: new Date('2026-08-04T01:33:52.000Z'),
+			}),
+		} as RatingOrderLookupPort;
+
+		const result = await new GetOrderRatingsUseCase(ratings, orders).execute({
+			orderId: 'order-1',
+			requesterId: 'admin-1',
+			requesterRole: Role.ADMIN,
+		});
+
+		expect(result).toEqual([
+			expect.objectContaining({ id: 'rating-1', score: 5 }),
+		]);
+	});
+});

--- a/apps/api/src/modules/ratings/application/use-cases/get-order-ratings/get-order-ratings.use-case.ts
+++ b/apps/api/src/modules/ratings/application/use-cases/get-order-ratings/get-order-ratings.use-case.ts
@@ -15,10 +15,12 @@ import {
 	RatingOrderNotFoundError,
 } from '@modules/ratings/domain/rating.errors';
 import { Inject, Injectable } from '@nestjs/common';
+import { Role } from '@packages/auth/roles/role';
 
 type GetOrderRatingsInput = {
 	orderId: string;
 	requesterId: string;
+	requesterRole: Role;
 };
 
 @Injectable()
@@ -34,6 +36,7 @@ export class GetOrderRatingsUseCase {
 		const order = await this.orders.findById(input.orderId);
 		if (!order) throw new RatingOrderNotFoundError();
 		if (
+			input.requesterRole !== Role.ADMIN &&
 			input.requesterId !== order.clientId &&
 			input.requesterId !== order.boosterId
 		)

--- a/apps/api/src/modules/ratings/presentation/ratings.controller.ts
+++ b/apps/api/src/modules/ratings/presentation/ratings.controller.ts
@@ -14,7 +14,6 @@ import {
 } from './ratings.request-schemas';
 
 @Controller('ratings')
-@Roles(Role.CLIENT, Role.BOOSTER)
 export class RatingsController {
 	constructor(
 		private readonly submitRating: SubmitRatingUseCase,
@@ -22,6 +21,7 @@ export class RatingsController {
 	) {}
 
 	@Post()
+	@Roles(Role.CLIENT, Role.BOOSTER)
 	async submit(
 		@Body(new ZodValidationPipe(submitRatingSchema))
 		body: SubmitRatingSchemaInput,
@@ -36,6 +36,7 @@ export class RatingsController {
 	}
 
 	@Get('orders/:orderId')
+	@Roles(Role.CLIENT, Role.BOOSTER, Role.ADMIN)
 	async listForOrder(
 		@Param('orderId', new ZodValidationPipe(orderIdParamSchema))
 		orderId: OrderIdParamSchemaInput,
@@ -44,6 +45,7 @@ export class RatingsController {
 		return await this.getOrderRatings.execute({
 			orderId,
 			requesterId: currentUser.id,
+			requesterRole: currentUser.role,
 		});
 	}
 }

--- a/apps/api/src/modules/wallet/application/use-cases/list-wallet-transactions/list-wallet-transactions.use-case.spec.ts
+++ b/apps/api/src/modules/wallet/application/use-cases/list-wallet-transactions/list-wallet-transactions.use-case.spec.ts
@@ -20,10 +20,10 @@ class InMemoryWalletTransactionReader implements WalletTransactionReaderPort {
 				(left, right) => right.createdAt.getTime() - left.createdAt.getTime(),
 			)
 			.slice(0, limit)
-			.map((transaction, index) => ({
-				...transaction,
-				id: `${transaction.reason}:${transaction.orderId ?? 'wallet'}:${transaction.createdAt.toISOString()}:${index}`,
-			}));
+			.map((transaction) => {
+				const { payoutPixKey: _payoutPixKey, ...snapshot } = transaction;
+				return snapshot;
+			});
 	}
 
 	insert(wallet: Wallet): void {
@@ -46,15 +46,16 @@ describe('ListWalletTransactionsUseCase', () => {
 		});
 		wallet.withdraw({
 			amount: 40,
+			payoutPixKey: 'booster@example.com',
 			requestedAt: new Date('2026-05-03T10:00:00.000Z'),
 		});
 		const reader = new InMemoryWalletTransactionReader();
 		reader.insert(wallet);
 		const useCase = new ListWalletTransactionsUseCase(reader);
 
-		await expect(
-			useCase.execute({ boosterId: 'booster-1', limit: 10 }),
-		).resolves.toEqual({
+		const result = await useCase.execute({ boosterId: 'booster-1', limit: 10 });
+
+		expect(result).toEqual({
 			transactions: [
 				expect.objectContaining({
 					type: 'debit',
@@ -69,6 +70,7 @@ describe('ListWalletTransactionsUseCase', () => {
 				}),
 			],
 		});
+		expect(result.transactions[0]).not.toHaveProperty('payoutPixKey');
 	});
 
 	it('caps the transaction limit', async () => {

--- a/apps/api/src/modules/wallet/application/use-cases/request-withdrawal/request-withdrawal.use-case.spec.ts
+++ b/apps/api/src/modules/wallet/application/use-cases/request-withdrawal/request-withdrawal.use-case.spec.ts
@@ -47,6 +47,7 @@ describe('RequestWithdrawalUseCase', () => {
 		await useCase.execute({
 			boosterId: 'booster-1',
 			amount: 1,
+			payoutPixKey: 'booster@example.com',
 			requestedAt: new Date('2026-03-12T13:00:00.000Z'),
 		});
 
@@ -57,6 +58,7 @@ describe('RequestWithdrawalUseCase', () => {
 				transactions: expect.arrayContaining([
 					expect.objectContaining({
 						amount: 1,
+						payoutPixKey: 'booster@example.com',
 						type: 'debit',
 						reason: 'withdrawal_request',
 					}),
@@ -82,6 +84,7 @@ describe('RequestWithdrawalUseCase', () => {
 			useCase.execute({
 				boosterId: 'booster-2',
 				amount: 10,
+				payoutPixKey: 'booster@example.com',
 				requestedAt: new Date('2026-03-12T13:00:00.000Z'),
 			}),
 		).rejects.toThrow(WalletInsufficientWithdrawableBalanceError);
@@ -98,6 +101,7 @@ describe('RequestWithdrawalUseCase', () => {
 			useCase.execute({
 				boosterId: 'booster-3',
 				amount: 0,
+				payoutPixKey: 'booster@example.com',
 				requestedAt: new Date('2026-03-12T13:00:00.000Z'),
 			}),
 		).rejects.toThrow(WalletInvalidAmountError);

--- a/apps/api/src/modules/wallet/application/use-cases/request-withdrawal/request-withdrawal.use-case.ts
+++ b/apps/api/src/modules/wallet/application/use-cases/request-withdrawal/request-withdrawal.use-case.ts
@@ -8,6 +8,7 @@ import { Inject, Injectable } from '@nestjs/common';
 type RequestWithdrawalInput = {
 	boosterId: string;
 	amount: number;
+	payoutPixKey: string;
 	requestedAt: Date;
 };
 
@@ -25,6 +26,7 @@ export class RequestWithdrawalUseCase {
 
 		wallet.withdraw({
 			amount: input.amount,
+			payoutPixKey: input.payoutPixKey,
 			requestedAt: input.requestedAt,
 		});
 

--- a/apps/api/src/modules/wallet/domain/wallet.entity.ts
+++ b/apps/api/src/modules/wallet/domain/wallet.entity.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import {
 	WalletInsufficientWithdrawableBalanceError,
 	WalletInvalidAmountError,
@@ -11,10 +12,12 @@ export type WalletTransactionReason = 'order_completion' | 'withdrawal_request';
 export type WalletTransactionReleaseSource = 'schedule' | 'admin';
 
 export type WalletTransaction = {
+	id: string;
 	orderId: string | null;
 	amount: number;
 	type: WalletTransactionType;
 	reason: WalletTransactionReason;
+	payoutPixKey: string | null;
 	availableAt: Date;
 	releasedAt: Date | null;
 	releasedBy: WalletTransactionReleaseSource | null;
@@ -35,6 +38,7 @@ type CreditLockedInput = {
 
 type WithdrawInput = {
 	amount: number;
+	payoutPixKey: string;
 	requestedAt: Date;
 };
 
@@ -71,10 +75,12 @@ export class Wallet {
 			Money.fromCents(input.amount),
 		).cents;
 		this.transactions.push({
+			id: randomUUID(),
 			orderId: input.orderId,
 			amount: input.amount,
 			type: 'credit',
 			reason: 'order_completion',
+			payoutPixKey: null,
 			availableAt: input.availableAt,
 			releasedAt: null,
 			releasedBy: null,
@@ -158,10 +164,12 @@ export class Wallet {
 			this.balanceWithdrawable,
 		).subtract(Money.fromCents(input.amount)).cents;
 		this.transactions.unshift({
+			id: randomUUID(),
 			orderId: null,
 			amount: input.amount,
 			type: 'debit',
 			reason: 'withdrawal_request',
+			payoutPixKey: input.payoutPixKey,
 			availableAt: input.requestedAt,
 			releasedAt: input.requestedAt,
 			releasedBy: null,

--- a/apps/api/src/modules/wallet/infrastructure/repositories/prisma-wallet.repository.ts
+++ b/apps/api/src/modules/wallet/infrastructure/repositories/prisma-wallet.repository.ts
@@ -19,10 +19,12 @@ type WalletRecord = {
 	balanceLocked: number;
 	balanceWithdrawable: number;
 	transactions: Array<{
+		id: string;
 		orderId: string | null;
 		amount: number;
 		type: 'CREDIT' | 'DEBIT';
 		reason: string;
+		payoutPixKey: string | null;
 		availableAt: Date;
 		releasedAt: Date | null;
 		releasedBy: 'SCHEDULE' | 'ADMIN' | null;
@@ -60,11 +62,13 @@ type WalletTransactionDelegate = {
 	deleteMany(args: { where: { walletId: string } }): Promise<{ count: number }>;
 	createMany(args: {
 		data: Array<{
+			id: string;
 			walletId: string;
 			orderId: string | null;
 			amount: number;
 			type: 'CREDIT' | 'DEBIT';
 			reason: string;
+			payoutPixKey: string | null;
 			availableAt: Date;
 			releasedAt: Date | null;
 			releasedBy: 'SCHEDULE' | 'ADMIN' | null;
@@ -75,7 +79,7 @@ type WalletTransactionDelegate = {
 		where: { walletId: string };
 		orderBy: { createdAt: 'desc' };
 		take: number;
-	}): Promise<Array<WalletRecord['transactions'][number] & { id: string }>>;
+	}): Promise<Array<WalletRecord['transactions'][number]>>;
 };
 
 type WalletPrismaClient = {
@@ -124,10 +128,11 @@ export class PrismaWalletRepository
 			take: limit,
 		});
 
-		return records.map((transaction) => ({
-			id: transaction.id,
-			...this.mapTransactionToDomain(transaction),
-		}));
+		return records.map((transaction) => {
+			const { payoutPixKey: _payoutPixKey, ...snapshot } =
+				this.mapTransactionToDomain(transaction);
+			return snapshot;
+		});
 	}
 
 	async save(wallet: Wallet): Promise<void> {
@@ -161,11 +166,13 @@ export class PrismaWalletRepository
 			deleteExisting,
 			client.walletTransaction.createMany({
 				data: wallet.transactions.map((transaction) => ({
+					id: transaction.id,
 					walletId: persistedWallet.id,
 					orderId: transaction.orderId,
 					amount: transaction.amount,
 					type: this.mapTransactionTypeToRecord(transaction.type),
 					reason: transaction.reason,
+					payoutPixKey: transaction.payoutPixKey,
 					availableAt: transaction.availableAt,
 					releasedAt: transaction.releasedAt,
 					releasedBy: this.mapReleaseSourceToRecord(transaction.releasedBy),
@@ -202,10 +209,12 @@ export class PrismaWalletRepository
 		transaction: WalletRecord['transactions'][number],
 	): WalletTransaction {
 		return {
+			id: transaction.id,
 			orderId: transaction.orderId,
 			amount: transaction.amount,
 			type: this.mapTransactionTypeToDomain(transaction.type),
 			reason: transaction.reason as WalletTransactionReason,
+			payoutPixKey: transaction.payoutPixKey,
 			availableAt: transaction.availableAt,
 			releasedAt: transaction.releasedAt,
 			releasedBy: this.mapReleaseSourceToDomain(transaction.releasedBy),

--- a/apps/api/src/modules/wallet/presentation/wallets.controller.ts
+++ b/apps/api/src/modules/wallet/presentation/wallets.controller.ts
@@ -120,7 +120,8 @@ export class WalletsController {
 		await this.requestWithdrawalUseCase.execute({
 			boosterId,
 			amount: body.amount,
-			requestedAt: new Date(body.requestedAt),
+			payoutPixKey: body.payoutPixKey,
+			requestedAt: new Date(),
 		});
 		return { success: true };
 	}

--- a/apps/api/src/modules/wallet/presentation/wallets.request-schemas.ts
+++ b/apps/api/src/modules/wallet/presentation/wallets.request-schemas.ts
@@ -36,7 +36,7 @@ export type ReleaseMaturedWalletFundsSchemaInput = z.infer<
 
 export const requestWithdrawalSchema = z.object({
 	amount: z.number().int().positive(),
-	requestedAt: z.string().datetime(),
+	payoutPixKey: z.string().trim().min(1).max(255),
 });
 
 export type RequestWithdrawalSchemaInput = z.infer<

--- a/apps/api/test/admin.e2e-spec.ts
+++ b/apps/api/test/admin.e2e-spec.ts
@@ -97,6 +97,19 @@ describe('Admin dashboard (e2e)', () => {
 				},
 			];
 		}
+
+		async listWithdrawalRequests() {
+			return [
+				{
+					id: 'withdrawal-1',
+					boosterId: 'booster-1',
+					boosterUsername: 'Booster One',
+					amount: 2500,
+					payoutPixKey: 'booster@example.com',
+					createdAt: new Date('2026-04-10T10:00:00.000Z'),
+				},
+			];
+		}
 	}
 
 	class AdminGovernanceRepositoryStub implements AdminGovernanceRepositoryPort {
@@ -209,6 +222,20 @@ describe('Admin dashboard (e2e)', () => {
 				expect(body).toEqual([expect.objectContaining({ id: 'ticket-1' })]);
 			})
 			.execute();
+
+		await requestHttp(app)
+			.get('/admin/withdrawals')
+			.set('Authorization', `Bearer ${token}`)
+			.expect(200)
+			.expect<Array<{ id: string; payoutPixKey: string }>>(({ body }) => {
+				expect(body).toEqual([
+					expect.objectContaining({
+						id: 'withdrawal-1',
+						payoutPixKey: 'booster@example.com',
+					}),
+				]);
+			})
+			.execute();
 	});
 
 	it.each([
@@ -221,6 +248,7 @@ describe('Admin dashboard (e2e)', () => {
 		['POST', '/admin/orders/order-1/release-booster-payment'],
 		['GET', '/admin/scheduled-jobs'],
 		['GET', '/admin/support/tickets'],
+		['GET', '/admin/withdrawals'],
 	])('rejects non-admin access for %s %s', async (method, path) => {
 		const token = signToken({ sub: 'client-1', role: Role.CLIENT });
 		const request = requestHttp(app)

--- a/apps/api/test/integration-db/wallet/wallet.db.integration.spec.ts
+++ b/apps/api/test/integration-db/wallet/wallet.db.integration.spec.ts
@@ -1,0 +1,113 @@
+import { PrismaModule } from '@app/common/prisma/prisma.module';
+import { PrismaService } from '@app/common/prisma/prisma.service';
+import { PrismaAdminDashboardReader } from '@modules/admin/infrastructure/repositories/prisma-admin-dashboard.reader';
+import { Wallet } from '@modules/wallet/domain/wallet.entity';
+import { PrismaWalletRepository } from '@modules/wallet/infrastructure/repositories/prisma-wallet.repository';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+
+describe('Wallet withdrawal persistence (db)', () => {
+	let moduleRef: TestingModule;
+	let prisma: PrismaService;
+	let boosterId: string | undefined;
+
+	beforeEach(async () => {
+		boosterId = undefined;
+		moduleRef = await Test.createTestingModule({
+			imports: [PrismaModule],
+		}).compile();
+		prisma = moduleRef.get(PrismaService);
+	});
+
+	afterEach(async () => {
+		if (boosterId) {
+			await prisma.walletTransaction.deleteMany({
+				where: { wallet: { boosterId } },
+			});
+			await prisma.wallet.deleteMany({ where: { boosterId } });
+			await prisma.user.deleteMany({ where: { id: boosterId } });
+		}
+		await moduleRef.close();
+	});
+
+	it('persists the PIX key and lists both new and legacy requests for admins', async () => {
+		const booster = await prisma.user.create({
+			data: {
+				username: 'withdrawal-booster',
+				email: 'withdrawal-booster@example.com',
+				role: 'BOOSTER',
+			},
+		});
+		boosterId = booster.id;
+		const wallet = Wallet.rehydrate({
+			boosterId: booster.id,
+			balanceLocked: 0,
+			balanceWithdrawable: 5000,
+			transactions: [],
+		});
+		wallet.withdraw({
+			amount: 2500,
+			payoutPixKey: 'booster@example.com',
+			requestedAt: new Date('2026-08-08T12:00:00.000Z'),
+		});
+
+		const walletRepository = new PrismaWalletRepository(prisma);
+		await walletRepository.save(wallet);
+		const persistedWallet = await prisma.wallet.findUniqueOrThrow({
+			where: { boosterId: booster.id },
+		});
+		await prisma.walletTransaction.create({
+			data: {
+				walletId: persistedWallet.id,
+				amount: 1000,
+				type: 'DEBIT',
+				reason: 'withdrawal_request',
+				availableAt: new Date('2026-08-07T12:00:00.000Z'),
+				releasedAt: new Date('2026-08-07T12:00:00.000Z'),
+				createdAt: new Date('2026-08-07T12:00:00.000Z'),
+			},
+		});
+		const boosterTransactions = await walletRepository.findRecentForBooster(
+			booster.id,
+			10,
+		);
+		expect(boosterTransactions?.[0]).not.toHaveProperty('payoutPixKey');
+
+		const adminReader = new PrismaAdminDashboardReader(prisma);
+		const initialRequests = await adminReader.listWithdrawalRequests({
+			limit: 10,
+		});
+		const boosterRequests = initialRequests.filter(
+			(request) => request.boosterId === booster.id,
+		);
+		expect(boosterRequests).toEqual([
+			expect.objectContaining({
+				amount: 2500,
+				payoutPixKey: 'booster@example.com',
+			}),
+			expect.objectContaining({ amount: 1000, payoutPixKey: null }),
+		]);
+
+		const originalRequestId = boosterRequests.find(
+			(request) => request.amount === 2500,
+		)?.id;
+		const rehydratedWallet = await walletRepository.findByBoosterId(booster.id);
+		expect(rehydratedWallet).not.toBeNull();
+		rehydratedWallet?.withdraw({
+			amount: 500,
+			payoutPixKey: 'second@example.com',
+			requestedAt: new Date('2026-08-09T12:00:00.000Z'),
+		});
+		if (rehydratedWallet) await walletRepository.save(rehydratedWallet);
+
+		const requestsAfterWalletSave = await adminReader.listWithdrawalRequests({
+			limit: 10,
+		});
+		expect(
+			requestsAfterWalletSave.find(
+				(request) =>
+					request.boosterId === booster.id && request.amount === 2500,
+			)?.id,
+		).toBe(originalRequestId);
+	});
+});

--- a/apps/api/test/integration/wallet/wallet.integration.spec.ts
+++ b/apps/api/test/integration/wallet/wallet.integration.spec.ts
@@ -77,7 +77,7 @@ describe('Wallet module integration', () => {
 				'booster-1',
 				{
 					amount: 10,
-					requestedAt: '2026-03-12T13:00:00.000Z',
+					payoutPixKey: 'booster@example.com',
 				},
 				boosterUser,
 			),

--- a/apps/api/test/ratings.e2e-db.spec.ts
+++ b/apps/api/test/ratings.e2e-db.spec.ts
@@ -10,8 +10,11 @@ describe('Ratings (e2e db)', () => {
 	let prisma: PrismaService;
 	let clientId: string;
 	let boosterId: string;
+	let adminId: string;
 
-	const createUser = async (role: 'CLIENT' | 'BOOSTER'): Promise<string> => {
+	const createUser = async (
+		role: 'CLIENT' | 'BOOSTER' | 'ADMIN',
+	): Promise<string> => {
 		const suffix = `${role}-${Date.now()}-${Math.random()}`;
 		const user = await prisma.user.create({
 			data: {
@@ -57,6 +60,7 @@ describe('Ratings (e2e db)', () => {
 
 		clientId = await createUser('CLIENT');
 		boosterId = await createUser('BOOSTER');
+		adminId = await createUser('ADMIN');
 	});
 
 	afterEach(async () => {
@@ -72,6 +76,7 @@ describe('Ratings (e2e db)', () => {
 		const orderId = await createCompletedOrder();
 		const clientToken = signToken({ sub: clientId, role: 'CLIENT' });
 		const boosterToken = signToken({ sub: boosterId, role: 'BOOSTER' });
+		const adminToken = signToken({ sub: adminId, role: 'ADMIN' });
 
 		await requestHttp(app)
 			.post('/ratings')
@@ -100,6 +105,15 @@ describe('Ratings (e2e db)', () => {
 		await requestHttp(app)
 			.get(`/ratings/orders/${orderId}`)
 			.set('Authorization', `Bearer ${clientToken}`)
+			.expect(200)
+			.expect<Array<{ fromUserId: string }>>(({ body }) => {
+				expect(body).toHaveLength(2);
+			})
+			.execute();
+
+		await requestHttp(app)
+			.get(`/ratings/orders/${orderId}`)
+			.set('Authorization', `Bearer ${adminToken}`)
 			.expect(200)
 			.expect<Array<{ fromUserId: string }>>(({ body }) => {
 				expect(body).toHaveLength(2);

--- a/apps/api/test/wallet.e2e-spec.ts
+++ b/apps/api/test/wallet.e2e-spec.ts
@@ -64,7 +64,7 @@ describe('Wallet (e2e)', () => {
 			.set('Authorization', `Bearer ${token}`)
 			.send({
 				amount: 10,
-				requestedAt: '2026-03-10T00:00:00.000Z',
+				payoutPixKey: 'booster@example.com',
 			})
 			.expect(400, {
 				message: 'Wallet does not have enough withdrawable balance.',

--- a/apps/api/test/wallets.e2e-spec.ts
+++ b/apps/api/test/wallets.e2e-spec.ts
@@ -12,6 +12,7 @@ import { InMemoryWalletRepository } from './support/in-memory/wallet/in-memory-w
 
 describe('Wallets (e2e)', () => {
 	let app: ApiHttpApp;
+	let walletRepository: InMemoryWalletRepository;
 	const scheduler = {
 		scheduleRelease: jest.fn().mockResolvedValue(undefined),
 	};
@@ -35,6 +36,7 @@ describe('Wallets (e2e)', () => {
 			.compile();
 
 		app = await createTestHttpApp(moduleRef);
+		walletRepository = moduleRef.get(WALLET_REPOSITORY_KEY);
 	});
 
 	afterEach(async () => {
@@ -68,7 +70,7 @@ describe('Wallets (e2e)', () => {
 			.execute();
 	});
 
-	it('rejects withdrawal payloads missing requestedAt', async () => {
+	it('rejects missing payout details and assigns the request timestamp', async () => {
 		const token = signToken({ sub: 'booster-1', role: Role.BOOSTER });
 
 		await requestHttp(app)
@@ -95,6 +97,7 @@ describe('Wallets (e2e)', () => {
 			.expect(200, { success: true })
 			.execute();
 
+		const requestedAfter = Date.now();
 		await requestHttp(app)
 			.post('/wallets/booster-1/withdrawals')
 			.set('Authorization', `Bearer ${token}`)
@@ -103,6 +106,26 @@ describe('Wallets (e2e)', () => {
 			})
 			.expect(400)
 			.execute();
+
+		await requestHttp(app)
+			.post('/wallets/booster-1/withdrawals')
+			.set('Authorization', `Bearer ${token}`)
+			.send({
+				amount: 10,
+				payoutPixKey: 'booster@example.com',
+				requestedAt: '2999-01-01T00:00:00.000Z',
+			})
+			.expect(200, { success: true })
+			.execute();
+
+		const wallet = await walletRepository.findByBoosterId('booster-1');
+		const withdrawal = wallet?.transactions.find(
+			(transaction) => transaction.reason === 'withdrawal_request',
+		);
+		expect(withdrawal?.createdAt.getTime()).toBeGreaterThanOrEqual(
+			requestedAfter,
+		);
+		expect(withdrawal?.createdAt.getTime()).toBeLessThanOrEqual(Date.now());
 	});
 
 	it('rejects malformed booster ids with bad request', async () => {
@@ -119,8 +142,23 @@ describe('Wallets (e2e)', () => {
 			.set('Authorization', `Bearer ${token}`)
 			.send({
 				amount: 10,
-				requestedAt: '2026-03-10T00:00:00.000Z',
+				payoutPixKey: 'booster@example.com',
 			})
+			.expect(400)
+			.execute();
+	});
+
+	it.each([
+		'',
+		'   ',
+		'x'.repeat(256),
+	])('rejects invalid payout PIX key %p', async (payoutPixKey) => {
+		const token = signToken({ sub: 'booster-1', role: Role.BOOSTER });
+
+		await requestHttp(app)
+			.post('/wallets/booster-1/withdrawals')
+			.set('Authorization', `Bearer ${token}`)
+			.send({ amount: 10, payoutPixKey })
 			.expect(400)
 			.execute();
 	});

--- a/apps/web/src/app/(dashboard)/admin/page.tsx
+++ b/apps/web/src/app/(dashboard)/admin/page.tsx
@@ -10,6 +10,7 @@ const Page = async () => {
 			orders={dashboard.orders}
 			tickets={dashboard.tickets}
 			users={dashboard.users}
+			withdrawals={dashboard.withdrawals}
 		/>
 	);
 };

--- a/apps/web/src/modules/admin-dashboard/presentation/order-details/admin-order-details-page.spec.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/order-details/admin-order-details-page.spec.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement } from 'react';
+import { getOrderRatings } from '@/shared/ratings/rating-actions';
+import {
+	getAdminOrder,
+	getAdminOrderChatMessages,
+	getAdminUserId,
+} from '../../actions/admin-actions';
+import { AdminOrderDetailsPage } from './admin-order-details-page';
+
+jest.mock('next/navigation', () => ({ notFound: jest.fn() }));
+jest.mock('@/shared/ratings/rating-actions', () => ({
+	getOrderRatings: jest.fn().mockResolvedValue([
+		{
+			id: 'rating-1',
+			orderId: 'order-1',
+			fromUserId: 'client-1',
+			toUserId: 'booster-1',
+			score: 5,
+			comment: 'Ótimo serviço',
+			createdAt: '2026-08-04T01:34:36.000Z',
+		},
+	]),
+}));
+jest.mock('../../actions/admin-actions', () => ({
+	getAdminOrder: jest.fn().mockResolvedValue({
+		id: 'order-1',
+		clientId: 'client-1',
+		status: 'completed',
+	}),
+	getAdminOrderChatMessages: jest
+		.fn()
+		.mockResolvedValue({ items: [], nextCursor: null }),
+	getAdminUserId: jest.fn().mockResolvedValue('admin-1'),
+}));
+
+describe('AdminOrderDetailsPage', () => {
+	it('loads ratings with every order detail', async () => {
+		const page = (await AdminOrderDetailsPage({
+			orderId: 'order-1',
+		})) as ReactElement<{ ratings: Array<{ id: string }> }>;
+
+		expect(getAdminOrder).toHaveBeenCalledWith('order-1');
+		expect(getAdminOrderChatMessages).toHaveBeenCalledWith('order-1');
+		expect(getAdminUserId).toHaveBeenCalledTimes(1);
+		expect(getOrderRatings).toHaveBeenCalledWith('order-1');
+		expect(page.props.ratings).toEqual([
+			expect.objectContaining({ id: 'rating-1' }),
+		]);
+	});
+});

--- a/apps/web/src/modules/admin-dashboard/presentation/order-details/admin-order-details-page.spec.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/order-details/admin-order-details-page.spec.tsx
@@ -1,3 +1,4 @@
+import { notFound } from 'next/navigation';
 import type { ReactElement } from 'react';
 import { getOrderRatings } from '@/shared/ratings/rating-actions';
 import {
@@ -7,7 +8,11 @@ import {
 } from '../../actions/admin-actions';
 import { AdminOrderDetailsPage } from './admin-order-details-page';
 
-jest.mock('next/navigation', () => ({ notFound: jest.fn() }));
+jest.mock('next/navigation', () => ({
+	notFound: jest.fn(() => {
+		throw new Error('NEXT_NOT_FOUND');
+	}),
+}));
 jest.mock('@/shared/ratings/rating-actions', () => ({
 	getOrderRatings: jest.fn().mockResolvedValue([
 		{
@@ -34,6 +39,10 @@ jest.mock('../../actions/admin-actions', () => ({
 }));
 
 describe('AdminOrderDetailsPage', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	it('loads ratings with every order detail', async () => {
 		const page = (await AdminOrderDetailsPage({
 			orderId: 'order-1',
@@ -46,5 +55,18 @@ describe('AdminOrderDetailsPage', () => {
 		expect(page.props.ratings).toEqual([
 			expect.objectContaining({ id: 'rating-1' }),
 		]);
+	});
+
+	it('stops loading related data when the order does not exist', async () => {
+		jest.mocked(getAdminOrder).mockResolvedValueOnce(null);
+
+		await expect(
+			AdminOrderDetailsPage({ orderId: 'missing-order' }),
+		).rejects.toThrow('NEXT_NOT_FOUND');
+
+		expect(notFound).toHaveBeenCalledTimes(1);
+		expect(getAdminOrderChatMessages).not.toHaveBeenCalled();
+		expect(getAdminUserId).not.toHaveBeenCalled();
+		expect(getOrderRatings).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/modules/admin-dashboard/presentation/order-details/admin-order-details-page.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/order-details/admin-order-details-page.tsx
@@ -328,13 +328,14 @@ export const AdminOrderDetailsView = ({
 export const AdminOrderDetailsPage = async ({
 	orderId,
 }: AdminOrderDetailsPageProps) => {
-	const [order, chat, currentUserId, ratings] = await Promise.all([
-		getAdminOrder(orderId),
+	const order = await getAdminOrder(orderId);
+	if (!order) notFound();
+
+	const [chat, currentUserId, ratings] = await Promise.all([
 		getAdminOrderChatMessages(orderId),
 		getAdminUserId(),
 		getOrderRatings(orderId),
 	]);
-	if (!order) notFound();
 
 	return (
 		<AdminOrderDetailsView

--- a/apps/web/src/modules/admin-dashboard/presentation/order-details/admin-order-details-page.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/order-details/admin-order-details-page.tsx
@@ -12,6 +12,9 @@ import {
 	formatServiceType,
 } from '@/shared/format/orders';
 import { OrderRankRoute } from '@/shared/orders/order-rank-route';
+import { getOrderRatings } from '@/shared/ratings/rating-actions';
+import { RatingStars } from '@/shared/ratings/rating-card';
+import type { RatingOutput } from '@/shared/ratings/rating-contracts';
 import {
 	Card,
 	CardContent,
@@ -37,12 +40,14 @@ type AdminOrderDetailsViewProps = {
 	currentUserId: string;
 	messages: ChatMessage[];
 	order: AdminOrderOutput;
+	ratings: RatingOutput[];
 };
 
 export const AdminOrderDetailsView = ({
 	currentUserId,
 	messages,
 	order,
+	ratings,
 }: AdminOrderDetailsViewProps) => {
 	const isForceCancelDisabled = order.status === 'cancelled';
 	const { boosterPayment } = order;
@@ -97,6 +102,38 @@ export const AdminOrderDetailsView = ({
 
 			<div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_420px]">
 				<div className="space-y-8">
+					<Card className="border-hextech-gold/15">
+						<CardHeader>
+							<CardTitle>Avaliações</CardTitle>
+						</CardHeader>
+						<CardContent className="space-y-5">
+							{ratings.length ? (
+								ratings.map((rating) => (
+									<div key={rating.id} className="space-y-2">
+										<p className="text-[10px] font-black uppercase tracking-widest text-white/40">
+											{rating.fromUserId === order.clientId
+												? 'Cliente → Booster'
+												: 'Booster → Cliente'}
+										</p>
+										<RatingStars score={rating.score} />
+										{rating.comment ? (
+											<p className="text-sm leading-relaxed text-white/70">
+												{rating.comment}
+											</p>
+										) : null}
+										<p className="text-[10px] text-white/30">
+											{formatDateTime(rating.createdAt)}
+										</p>
+									</div>
+								))
+							) : (
+								<p className="text-xs text-white/35">
+									Nenhuma avaliação registrada.
+								</p>
+							)}
+						</CardContent>
+					</Card>
+
 					<Card className="border-white/10">
 						<CardHeader>
 							<CardTitle className="flex items-center gap-2">
@@ -291,10 +328,11 @@ export const AdminOrderDetailsView = ({
 export const AdminOrderDetailsPage = async ({
 	orderId,
 }: AdminOrderDetailsPageProps) => {
-	const [order, chat, currentUserId] = await Promise.all([
+	const [order, chat, currentUserId, ratings] = await Promise.all([
 		getAdminOrder(orderId),
 		getAdminOrderChatMessages(orderId),
 		getAdminUserId(),
+		getOrderRatings(orderId),
 	]);
 	if (!order) notFound();
 
@@ -303,6 +341,7 @@ export const AdminOrderDetailsPage = async ({
 			order={order}
 			messages={chat.items}
 			currentUserId={currentUserId}
+			ratings={ratings}
 		/>
 	);
 };

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx
@@ -9,6 +9,11 @@ import {
 	AdminUsersPage,
 } from './admin-dashboard-page';
 
+jest.mock('@/shared/ratings/rating-actions', () => ({
+	getOrderRatings: jest.fn(),
+	submitRatingAction: jest.fn(),
+}));
+
 jest.mock('@/shared/dashboard/dashboard-entrance', () => ({
 	DashboardEntrance: ({ children }: PropsWithChildren) => <div>{children}</div>,
 }));
@@ -137,6 +142,7 @@ describe('admin dashboard pages', () => {
 		render(
 			<AdminOrderDetailsView
 				currentUserId="admin-1"
+				ratings={[]}
 				messages={[
 					{
 						id: 'message-1',
@@ -187,6 +193,7 @@ describe('admin dashboard pages', () => {
 		render(
 			<AdminOrderDetailsView
 				currentUserId="admin-1"
+				ratings={[]}
 				messages={[]}
 				order={{
 					id: 'order-1',

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.spec.tsx
@@ -29,7 +29,7 @@ jest.mock('../../actions/admin-actions', () => ({
 }));
 
 describe('admin dashboard pages', () => {
-	it('renders only overview metrics on the main admin page', () => {
+	it('renders overview metrics and withdrawal requests on the main admin page', () => {
 		render(
 			<AdminDashboardPage
 				metrics={{
@@ -38,6 +38,16 @@ describe('admin dashboard pages', () => {
 					activeOrders: 2,
 					activeUsers: 3,
 				}}
+				withdrawals={[
+					{
+						id: 'withdrawal-1',
+						boosterId: 'booster-1',
+						boosterUsername: 'Booster One',
+						amount: 2500,
+						payoutPixKey: 'booster@example.com',
+						createdAt: '2026-08-08T12:00:00.000Z',
+					},
+				]}
 			/>,
 		);
 
@@ -45,6 +55,9 @@ describe('admin dashboard pages', () => {
 		expect(screen.getByText('Receita')).toBeInTheDocument();
 		expect(screen.getByText('Pedidos ativos')).toBeInTheDocument();
 		expect(screen.getByText('Usuários ativos')).toBeInTheDocument();
+		expect(screen.getByText('Solicitações de saque')).toBeInTheDocument();
+		expect(screen.getByText('Booster One')).toBeInTheDocument();
+		expect(screen.getByText('booster@example.com')).toBeInTheDocument();
 		expect(screen.queryByText('dev-client')).not.toBeInTheDocument();
 		expect(screen.queryByText('Preciso de ajuda')).not.toBeInTheDocument();
 	});

--- a/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.tsx
+++ b/apps/web/src/modules/admin-dashboard/presentation/overview/admin-dashboard-page.tsx
@@ -11,6 +11,7 @@ import {
 	ShieldCheck,
 	Ticket,
 	Users,
+	WalletCards,
 } from 'lucide-react';
 import Link from 'next/link';
 import { DashboardEmptyState } from '@/shared/dashboard/dashboard-empty-state';
@@ -43,6 +44,7 @@ import type {
 	AdminOrderOutput,
 	AdminSupportTicketOutput,
 	AdminUserOutput,
+	AdminWithdrawalRequestOutput,
 } from '../../server/admin-contracts';
 import { roleLabels } from '../users/admin-user-metadata';
 import {
@@ -55,6 +57,7 @@ type AdminDashboardPageProps = {
 	orders?: AdminOrderOutput[];
 	tickets?: AdminSupportTicketOutput[];
 	users?: AdminUserOutput[];
+	withdrawals?: AdminWithdrawalRequestOutput[];
 };
 
 type AdminUsersPageProps = {
@@ -202,6 +205,7 @@ export const AdminDashboardPage = ({
 	orders = [],
 	tickets = [],
 	users = [],
+	withdrawals = [],
 }: AdminDashboardPageProps) => {
 	const orderSummary = summarizeOrders(orders);
 
@@ -247,6 +251,57 @@ export const AdminDashboardPage = ({
 					/>
 				</div>
 			</section>
+
+			<Card className="dashboard-animate flex-none overflow-hidden border-white/10">
+				<div className="flex items-center justify-between border-b border-white/5 px-5 py-4">
+					<div className="flex items-center gap-3">
+						<WalletCards className="h-4 w-4 text-hextech-cyan" />
+						<h3 className="text-xs font-black uppercase tracking-[0.3em] text-white">
+							Solicitações de saque
+						</h3>
+					</div>
+					<Badge variant="outline">{withdrawals.length}</Badge>
+				</div>
+				<div className="divide-y divide-white/5">
+					{withdrawals.map((withdrawal) => (
+						<div
+							key={withdrawal.id}
+							className="grid gap-3 px-5 py-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_120px_160px] md:items-center"
+						>
+							<div className="min-w-0">
+								<p className="truncate text-sm font-black text-white">
+									{withdrawal.boosterUsername}
+								</p>
+								<p className="truncate font-mono text-[10px] text-white/35">
+									{withdrawal.boosterId}
+								</p>
+							</div>
+							<div className="min-w-0">
+								<p className="text-[9px] font-black uppercase tracking-widest text-white/35">
+									Chave PIX
+								</p>
+								<p className="break-all font-mono text-xs text-white/70">
+									{withdrawal.payoutPixKey ??
+										'Não informada (solicitação antiga)'}
+								</p>
+							</div>
+							<p className="font-black text-hextech-gold">
+								{formatCurrency(withdrawal.amount)}
+							</p>
+							<p className="text-xs text-white/40 md:text-right">
+								{formatDateTime(withdrawal.createdAt)}
+							</p>
+						</div>
+					))}
+					{withdrawals.length === 0 ? (
+						<DashboardEmptyState
+							icon={WalletCards}
+							title="Nenhuma solicitação de saque"
+							description="Novas solicitações aparecerão aqui com a chave PIX informada pelo booster."
+						/>
+					) : null}
+				</div>
+			</Card>
 
 			<div className="dashboard-animate flex min-h-0 flex-1 flex-col gap-6 xl:grid xl:grid-cols-[1fr_380px]">
 				<Card className="flex min-h-0 flex-1 flex-col overflow-hidden border-white/10">

--- a/apps/web/src/modules/admin-dashboard/server/admin-contracts.ts
+++ b/apps/web/src/modules/admin-dashboard/server/admin-contracts.ts
@@ -126,11 +126,21 @@ export const adminSupportTicketSchema = z.object({
 	latestMessageAt: z.string().nullable(),
 });
 
+export const adminWithdrawalRequestSchema = z.object({
+	id: z.string(),
+	boosterId: z.string(),
+	boosterUsername: z.string(),
+	amount: z.number().int().positive(),
+	payoutPixKey: z.string().min(1).nullable(),
+	createdAt: z.string(),
+});
+
 export const adminDashboardSchema = z.object({
 	metrics: adminMetricsSchema,
 	users: z.array(adminUserSchema),
 	orders: z.array(adminOrderSchema),
 	tickets: z.array(adminSupportTicketSchema),
+	withdrawals: z.array(adminWithdrawalRequestSchema),
 });
 
 export type AdminMetricsOutput = z.infer<typeof adminMetricsSchema>;
@@ -142,5 +152,8 @@ export type AdminChangeUserRoleInput = z.infer<
 export type AdminUserOutput = z.infer<typeof adminUserSchema>;
 export type AdminOrderOutput = z.infer<typeof adminOrderSchema>;
 export type AdminSupportTicketOutput = z.infer<typeof adminSupportTicketSchema>;
+export type AdminWithdrawalRequestOutput = z.infer<
+	typeof adminWithdrawalRequestSchema
+>;
 export type AdminScheduledJobsOutput = z.infer<typeof adminScheduledJobsSchema>;
 export type AdminDashboardOutput = z.infer<typeof adminDashboardSchema>;

--- a/apps/web/src/modules/admin-dashboard/server/admin-service.spec.ts
+++ b/apps/web/src/modules/admin-dashboard/server/admin-service.spec.ts
@@ -62,6 +62,18 @@ describe('admin service', () => {
 					},
 				] as T;
 			}
+			if (path === '/admin/withdrawals?limit=25') {
+				return [
+					{
+						id: 'withdrawal-1',
+						boosterId: 'booster-1',
+						boosterUsername: 'Booster One',
+						amount: 2500,
+						payoutPixKey: 'booster@example.com',
+						createdAt: '2026-04-10T10:06:00.000Z',
+					},
+				] as T;
+			}
 			throw new Error(`Unexpected path: ${path}`);
 		});
 
@@ -77,6 +89,7 @@ describe('admin service', () => {
 			users: [expect.objectContaining({ id: 'user-1' })],
 			orders: [expect.objectContaining({ id: 'order-1' })],
 			tickets: [expect.objectContaining({ id: 'ticket-1' })],
+			withdrawals: [expect.objectContaining({ id: 'withdrawal-1' })],
 		});
 	});
 

--- a/apps/web/src/modules/admin-dashboard/server/admin-service.ts
+++ b/apps/web/src/modules/admin-dashboard/server/admin-service.ts
@@ -8,6 +8,7 @@ import {
 	type AdminScheduledJobsOutput,
 	type AdminSupportTicketOutput,
 	type AdminUserOutput,
+	type AdminWithdrawalRequestOutput,
 	adminChangeUserRoleInputSchema,
 	adminCreateUserInputSchema,
 	adminDashboardSchema,
@@ -18,6 +19,7 @@ import {
 	adminScheduledJobsSchema,
 	adminSupportTicketSchema,
 	adminUserSchema,
+	adminWithdrawalRequestSchema,
 } from './admin-contracts';
 
 export type AuthenticatedApiRequest = <T>(
@@ -161,17 +163,38 @@ export const getAdminSupportTickets = async (
 	);
 };
 
+export const getAdminWithdrawalRequests = async (
+	apiRequest: AuthenticatedApiRequest,
+): Promise<AdminWithdrawalRequestOutput[]> => {
+	const path = '/admin/withdrawals?limit=25';
+	return await withAdminReadErrorContext(
+		'Admin withdrawals request',
+		path,
+		async () => {
+			const response = await apiRequest<unknown>(path, { auth: true });
+			return adminWithdrawalRequestSchema.array().parse(response);
+		},
+	);
+};
+
 export const getAdminDashboard = async (
 	apiRequest: AuthenticatedApiRequest,
 ): Promise<AdminDashboardOutput> => {
-	const [metrics, users, orders, tickets] = await Promise.all([
+	const [metrics, users, orders, tickets, withdrawals] = await Promise.all([
 		getAdminMetrics(apiRequest),
 		getAdminUsers(apiRequest),
 		getAdminOrders(apiRequest),
 		getAdminSupportTickets(apiRequest),
+		getAdminWithdrawalRequests(apiRequest),
 	]);
 
-	return adminDashboardSchema.parse({ metrics, users, orders, tickets });
+	return adminDashboardSchema.parse({
+		metrics,
+		users,
+		orders,
+		tickets,
+		withdrawals,
+	});
 };
 
 export const createAdminUser = async (

--- a/apps/web/src/modules/booster-dashboard/actions/booster-actions.ts
+++ b/apps/web/src/modules/booster-dashboard/actions/booster-actions.ts
@@ -186,11 +186,16 @@ export const requestBoosterWithdrawalAction = async (
 	const amount = Number.isFinite(amountInReais)
 		? Money.fromDecimal(amountInReais).cents
 		: Number.NaN;
+	const payoutPixKey = formData.get('payoutPixKey');
 
 	try {
 		await assertSameOriginRequest();
 		const session = await getBoosterSessionOrRedirect();
-		await requestBoosterWithdrawal(session.userId, { amount }, api.request);
+		await requestBoosterWithdrawal(
+			session.userId,
+			{ amount, payoutPixKey },
+			api.request,
+		);
 		revalidatePath('/booster');
 		return { success: true };
 	} catch (error) {

--- a/apps/web/src/modules/booster-dashboard/actions/booster-actions.ts
+++ b/apps/web/src/modules/booster-dashboard/actions/booster-actions.ts
@@ -9,15 +9,8 @@ import { getCheckoutErrorMessage } from '@/shared/api-client-management/user-mes
 import { redirectOnAuthError } from '@/shared/auth/redirect-on-auth-error';
 import type { AuthSession } from '@/shared/auth/session';
 import { getAuthSession } from '@/shared/auth/session';
-import {
-	type ChatMessageOutput,
-	type ListChatMessagesResponseOutput,
-	sendChatMessageInputSchema,
-} from '@/shared/chat/chat-contracts';
-import {
-	listOrderChatMessages,
-	sendOrderChatMessage,
-} from '@/shared/chat/chat-service';
+import { type ListChatMessagesResponseOutput } from '@/shared/chat/chat-contracts';
+import { listOrderChatMessages } from '@/shared/chat/chat-service';
 import { assertSameOriginRequest } from '@/shared/security/origin';
 import type {
 	BoosterOrderOutput,
@@ -25,6 +18,7 @@ import type {
 	BoosterWalletOutput,
 	BoosterWalletTransactionsOutput,
 	BoosterWorkOutput,
+	OrderCredentialsOutput,
 } from '../server/booster-contracts';
 import { acceptBoosterOrderSchema } from '../server/booster-contracts';
 import {
@@ -36,6 +30,7 @@ import {
 	getBoosterWork as getBoosterWorkFromApi,
 	rejectBoosterOrder,
 	requestBoosterWithdrawal,
+	revealBoosterOrderCredentials,
 } from '../server/booster-service';
 
 export type BoosterActionState = {
@@ -43,15 +38,9 @@ export type BoosterActionState = {
 	success?: boolean;
 };
 
-export type SendBoosterChatMessageActionState =
-	| {
-			message: ChatMessageOutput;
-			error?: never;
-	  }
-	| {
-			error: string;
-			message?: never;
-	  };
+export type RevealCredentialsActionState =
+	| { credentials: OrderCredentialsOutput; error?: never }
+	| { error: string; credentials?: never };
 
 const getBoosterSessionOrRedirect = async () => {
 	const session = await getAuthSession();
@@ -136,38 +125,21 @@ export const getBoosterOrderChatMessages = async (
 	}
 };
 
-export const sendBoosterOrderChatMessageAction = async (
+export const revealBoosterOrderCredentialsAction = async (
 	orderId: string,
-	content: string,
-): Promise<SendBoosterChatMessageActionState> => {
-	const parsed = sendChatMessageInputSchema.safeParse({ content });
-	if (!parsed.success) {
-		return { error: parsed.error.issues[0]?.message ?? 'Mensagem inválida.' };
-	}
-
+): Promise<RevealCredentialsActionState> => {
 	try {
 		await assertSameOriginRequest();
 		await getBoosterSessionOrRedirect();
-
 		return {
-			message: await sendOrderChatMessage(orderId, parsed.data, api.request),
+			credentials: await revealBoosterOrderCredentials(orderId, api.request),
 		};
 	} catch (error) {
-		if (
-			error instanceof ApiRequestError &&
-			(error.status === 401 || error.status === 403)
-		) {
-			return { error: 'Entre novamente para continuar.' };
-		}
-
-		if (error instanceof ApiRequestError && error.status === 409) {
-			return {
-				error:
-					'Este chat não está disponível para envio de mensagens neste status.',
-			};
-		}
-
-		return { error: 'Não foi possível enviar a mensagem.' };
+		if (error instanceof ApiRequestError && error.status === 429)
+			return { error: error.message };
+		if (error instanceof ApiRequestError && error.status === 404)
+			return { error: 'Credenciais indisponíveis para este pedido.' };
+		return { error: 'Não foi possível revelar as credenciais.' };
 	}
 };
 

--- a/apps/web/src/modules/booster-dashboard/model/booster-orders.ts
+++ b/apps/web/src/modules/booster-dashboard/model/booster-orders.ts
@@ -1,3 +1,4 @@
+import { formatDate } from '@/shared/format/date';
 import type {
 	BoosterOrderOutput,
 	BoosterQueueOutput,
@@ -26,9 +27,10 @@ export const formatTransactionReason = (
 export const formatTransactionRelease = (
 	transaction: Pick<
 		BoosterWalletTransactionOutput,
-		'releasedAt' | 'releasedBy'
+		'availableAt' | 'releasedAt' | 'releasedBy'
 	>,
 ) => {
-	if (!transaction.releasedAt) return 'Bloqueado';
+	if (!transaction.releasedAt)
+		return `Disponível em ${formatDate(transaction.availableAt)}`;
 	return transaction.releasedBy === 'admin' ? 'Liberado por admin' : 'Liberado';
 };

--- a/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.spec.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.spec.tsx
@@ -5,10 +5,12 @@ import {
 	getBoosterOrder,
 	getBoosterOrderChatMessages,
 	getBoosterUserId,
+	revealBoosterOrderCredentialsAction,
 } from '../../actions/booster-actions';
 import { BoosterOrderDetailsPage } from './booster-order-details-page';
 
 jest.mock('next/navigation', () => ({
+	useRouter: () => ({ refresh: jest.fn() }),
 	notFound: jest.fn(() => {
 		throw new Error('NEXT_NOT_FOUND');
 	}),
@@ -57,7 +59,13 @@ jest.mock('../../actions/booster-actions', () => ({
 		nextCursor: null,
 	}),
 	getBoosterUserId: jest.fn().mockResolvedValue('booster-1'),
-	sendBoosterOrderChatMessageAction: jest.fn(),
+	revealBoosterOrderCredentialsAction: jest.fn().mockResolvedValue({
+		credentials: {
+			login: 'client-login',
+			summonerName: 'Summoner BR',
+			password: 'secret-password',
+		},
+	}),
 }));
 
 jest.mock('lucide-react', () => ({
@@ -95,6 +103,22 @@ describe('BoosterOrderDetailsPage', () => {
 		expect(getBoosterOrder).toHaveBeenCalledWith('order-active-1');
 		expect(getBoosterOrderChatMessages).toHaveBeenCalledWith('order-active-1');
 		expect(getBoosterUserId).toHaveBeenCalledTimes(1);
+	});
+
+	it('reveals accepted-order credentials only after an explicit click', async () => {
+		render(await BoosterOrderDetailsPage({ orderId: 'order-active-1' }));
+
+		expect(screen.queryByText('client-login')).not.toBeInTheDocument();
+		await userEvent.click(
+			screen.getByRole('button', { name: /Revelar credenciais/i }),
+		);
+
+		expect(revealBoosterOrderCredentialsAction).toHaveBeenCalledWith(
+			'order-active-1',
+		);
+		expect(screen.getByText('client-login')).toBeInTheDocument();
+		expect(screen.getByText('Summoner BR')).toBeInTheDocument();
+		expect(screen.getByText('secret-password')).toBeInTheDocument();
 	});
 
 	it('renders completed orders as read-only chat', async () => {

--- a/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.spec.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.spec.tsx
@@ -119,6 +119,28 @@ describe('BoosterOrderDetailsPage', () => {
 		expect(screen.getByText('client-login')).toBeInTheDocument();
 		expect(screen.getByText('Summoner BR')).toBeInTheDocument();
 		expect(screen.getByText('secret-password')).toBeInTheDocument();
+
+		await userEvent.click(
+			screen.getByRole('button', { name: /Ocultar credenciais/i }),
+		);
+		expect(screen.queryByText('client-login')).not.toBeInTheDocument();
+	});
+
+	it.each([
+		'Credenciais indisponíveis para este pedido.',
+		'Muitas tentativas. Aguarde antes de tentar novamente.',
+	])('shows credential reveal failures without exposing fields: %s', async (error) => {
+		jest
+			.mocked(revealBoosterOrderCredentialsAction)
+			.mockResolvedValueOnce({ error });
+
+		render(await BoosterOrderDetailsPage({ orderId: 'order-active-1' }));
+		await userEvent.click(
+			screen.getByRole('button', { name: /Revelar credenciais/i }),
+		);
+
+		expect(screen.getByText(error)).toBeInTheDocument();
+		expect(screen.queryByText('client-login')).not.toBeInTheDocument();
 	});
 
 	it('renders completed orders as read-only chat', async () => {

--- a/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/order-details/booster-order-details-page.tsx
@@ -17,6 +17,7 @@ import { toBoosterWork } from '../../model/booster-orders';
 import type { BoosterOrderOutput } from '../../server/booster-contracts';
 import { CompleteBoosterOrderButton } from '../booster-order-action-buttons';
 import { BoosterChatPanel } from '../overview/booster-chat-panel';
+import { OrderCredentialsCard } from './order-credentials-card';
 
 type BoosterOrderDetailsPageProps = {
 	orderId: string;
@@ -86,6 +87,16 @@ export const BoosterOrderDetailsPage = async ({
 				/>
 
 				<section className="grid content-start gap-4 sm:grid-cols-3 xl:grid-cols-1">
+					{order.status === 'completed' ? (
+						<RatingCard
+							orderId={order.id}
+							currentUserId={currentUserId}
+							initialRatings={ratings}
+						/>
+					) : null}
+					{order.status === 'in_progress' ? (
+						<OrderCredentialsCard orderId={order.id} />
+					) : null}
 					<div className="rounded-sm border border-white/10 bg-white/[0.03] p-5">
 						<p className="text-[9px] font-black uppercase tracking-widest text-white/35">
 							Status
@@ -122,13 +133,6 @@ export const BoosterOrderDetailsPage = async ({
 							{formatCurrency(order.boosterAmount)}
 						</p>
 					</div>
-					{order.status === 'completed' ? (
-						<RatingCard
-							orderId={order.id}
-							currentUserId={currentUserId}
-							initialRatings={ratings}
-						/>
-					) : null}
 				</section>
 			</div>
 		</div>

--- a/apps/web/src/modules/booster-dashboard/presentation/order-details/order-credentials-card.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/order-details/order-credentials-card.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Button } from '@/shared/ui/components/button';
+import {
+	type RevealCredentialsActionState,
+	revealBoosterOrderCredentialsAction,
+} from '../../actions/booster-actions';
+import type { OrderCredentialsOutput } from '../../server/booster-contracts';
+
+const fields: Array<[keyof OrderCredentialsOutput, string]> = [
+	['login', 'Login'],
+	['summonerName', 'Invocador'],
+	['password', 'Senha'],
+];
+
+export const OrderCredentialsCard = ({ orderId }: { orderId: string }) => {
+	const [credentials, setCredentials] = useState<OrderCredentialsOutput | null>(
+		null,
+	);
+	const [error, setError] = useState<string | null>(null);
+	const [isPending, startTransition] = useTransition();
+
+	const reveal = () => {
+		setError(null);
+		startTransition(async () => {
+			const result: RevealCredentialsActionState =
+				await revealBoosterOrderCredentialsAction(orderId);
+			if (!result.credentials)
+				return setError(result.error ?? 'Credenciais indisponíveis.');
+			setCredentials(result.credentials);
+		});
+	};
+
+	return (
+		<div className="rounded-sm border border-hextech-cyan/25 bg-hextech-cyan/[0.04] p-5 sm:col-span-3 xl:col-span-1">
+			<div className="flex items-center justify-between gap-3">
+				<p className="text-[9px] font-black uppercase tracking-widest text-hextech-cyan">
+					Credenciais da conta
+				</p>
+				<Button
+					size="sm"
+					variant="outline"
+					disabled={isPending}
+					onClick={credentials ? () => setCredentials(null) : reveal}
+				>
+					{credentials
+						? 'Ocultar credenciais'
+						: isPending
+							? 'Revelando...'
+							: 'Revelar credenciais'}
+				</Button>
+			</div>
+			{credentials ? (
+				<dl className="mt-4 space-y-3">
+					{fields.map(([key, label]) => (
+						<div key={key} className="min-w-0">
+							<dt className="text-[9px] font-bold uppercase tracking-wider text-white/35">
+								{label}
+							</dt>
+							<dd className="mt-1 flex items-center gap-2">
+								<code className="min-w-0 flex-1 break-all text-xs text-white">
+									{credentials[key]}
+								</code>
+								<button
+									type="button"
+									className="text-[9px] font-black uppercase tracking-wider text-hextech-cyan hover:text-white"
+									onClick={() =>
+										navigator.clipboard.writeText(credentials[key])
+									}
+								>
+									Copiar {label.toLowerCase()}
+								</button>
+							</dd>
+						</div>
+					))}
+				</dl>
+			) : (
+				<p className="mt-3 text-xs leading-relaxed text-white/45">
+					Ocultas por segurança. Cada revelação é auditada.
+				</p>
+			)}
+			{error ? <p className="mt-3 text-xs text-red-400">{error}</p> : null}
+		</div>
+	);
+};

--- a/apps/web/src/modules/booster-dashboard/presentation/overview/booster-chat-panel.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/overview/booster-chat-panel.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useCallback, useState, useTransition } from 'react';
 import type { ChatMessage } from '@/shared/chat/chat.types';
 import { ChatPanel } from '@/shared/chat/chat-panel';
-import { sendBoosterOrderChatMessageAction } from '../../actions/booster-actions';
+import { useLiveOrderChat } from '@/shared/chat/use-live-order-chat';
 
 type BoosterChatPanelProps = {
 	orderId: string;
@@ -22,39 +21,20 @@ export const BoosterChatPanel = ({
 	isReadOnly,
 	statusText = 'Ativo',
 }: BoosterChatPanelProps) => {
-	const [messages, setMessages] = useState(initialMessages);
-	const [error, setError] = useState<string | null>(null);
-	const [isPending, startTransition] = useTransition();
-
-	const handleSendMessage = useCallback(
-		(content: string) => {
-			setError(null);
-			startTransition(async () => {
-				const result = await sendBoosterOrderChatMessageAction(
-					orderId,
-					content,
-				);
-				if (result.error) {
-					setError(result.error);
-					return;
-				}
-				const nextMessage = result.message;
-				if (!nextMessage) return;
-
-				setMessages((currentMessages) => [...currentMessages, nextMessage]);
-			});
-		},
-		[orderId],
-	);
+	const { isSending, liveError, messages, sendMessage } = useLiveOrderChat({
+		orderId,
+		initialMessages,
+		enabled: !isReadOnly,
+	});
 
 	return (
 		<div className="space-y-2">
 			<ChatPanel
 				messages={messages}
 				currentUserId={currentUserId}
-				onSendMessage={handleSendMessage}
-				isSending={isPending}
-				isDisabled={isPending || isReadOnly}
+				onSendMessage={sendMessage}
+				isSending={isSending}
+				isDisabled={isSending || isReadOnly}
 				isReadOnly={isReadOnly}
 				title={orderLabel}
 				statusText={statusText}
@@ -62,9 +42,9 @@ export const BoosterChatPanel = ({
 				emptyDescription="Envie a primeira mensagem para alinhar este pedido com o cliente."
 				className="h-[min(720px,calc(100dvh-15rem))] min-h-130 max-w-none"
 			/>
-			{error ? (
+			{liveError ? (
 				<p className="text-[10px] font-bold uppercase tracking-wider text-red-400">
-					{error}
+					{liveError}
 				</p>
 			) : null}
 		</div>

--- a/apps/web/src/modules/booster-dashboard/presentation/overview/booster-dashboard-live-refresh.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/overview/booster-dashboard-live-refresh.tsx
@@ -2,16 +2,8 @@
 
 import { useDashboardEvents } from '@/shared/dashboard/use-dashboard-events';
 
-const boosterDashboardEvents = [
-	'order.paid',
-	'order.accepted',
-	'order.rejected',
-	'order.completed',
-	'order.cancelled',
-] as const;
-
 export const BoosterDashboardLiveRefresh = () => {
-	useDashboardEvents({ events: boosterDashboardEvents });
+	useDashboardEvents();
 
 	return null;
 };

--- a/apps/web/src/modules/booster-dashboard/presentation/overview/booster-dashboard-page.spec.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/overview/booster-dashboard-page.spec.tsx
@@ -28,6 +28,10 @@ jest.mock('../../actions/booster-actions', () => ({
 				deadline: '2026-05-01T00:00:00.000Z',
 				totalAmount: 12000,
 				boosterAmount: 8400,
+				extras: [
+					{ type: 'specific_champions', price: 100 },
+					{ type: 'specific_routes', price: 100 },
+				],
 				createdAt: '2026-04-01T00:00:00.000Z',
 			},
 		],
@@ -63,8 +67,9 @@ jest.mock('../../actions/booster-actions', () => ({
 				amount: 8400,
 				type: 'credit',
 				reason: 'order_completion',
-				availableAt: '2026-05-01T00:00:00.000Z',
-				releasedAt: '2026-05-02T00:00:00.000Z',
+				availableAt: '2026-05-04T00:00:00.000Z',
+				releasedAt: null,
+				releasedBy: null,
 				createdAt: '2026-05-01T00:00:00.000Z',
 			},
 		],
@@ -73,7 +78,6 @@ jest.mock('../../actions/booster-actions', () => ({
 	rejectBoosterOrderAction: jest.fn(),
 	completeBoosterOrderAction: jest.fn(),
 	requestBoosterWithdrawalAction: jest.fn(),
-	sendBoosterOrderChatMessageAction: jest.fn(),
 }));
 
 jest.mock('@/shared/dashboard/dashboard-entrance', () => ({
@@ -85,6 +89,7 @@ jest.mock('./booster-dashboard-live-refresh', () => ({
 }));
 
 jest.mock('lucide-react', () => ({
+	ArrowRight: () => <svg data-testid="arrow-right-icon" />,
 	BadgeDollarSign: () => <svg data-testid="money-icon" />,
 	BriefcaseBusiness: () => <svg data-testid="briefcase-icon" />,
 	CheckCircle2: () => <svg data-testid="check-icon" />,
@@ -113,13 +118,19 @@ describe('BoosterDashboardPage', () => {
 		expect(screen.getByText('Pedidos disponíveis')).toBeInTheDocument();
 		expect(screen.queryByText('Pedidos em execução')).not.toBeInTheDocument();
 		expect(screen.getAllByText('Elo Boost')).toHaveLength(2);
-		expect(screen.getAllByText('Gold II → Platinum IV')).toHaveLength(2);
+		expect(screen.getAllByAltText('Ouro')).toHaveLength(2);
+		expect(screen.getAllByAltText('Platina')).toHaveLength(2);
 		expect(screen.getAllByText(/R\$\s*84,00/).length).toBeGreaterThan(0);
 		expect(screen.getByText('Carteira')).toBeInTheDocument();
-		expect(screen.queryByText('Movimentações')).not.toBeInTheDocument();
+		expect(screen.getByText('Movimentações')).toBeInTheDocument();
+		expect(screen.getByText(/Disponível em 04\/05\/2026/)).toBeInTheDocument();
+		expect(screen.getByText(/Sem valor mínimo/i)).toBeInTheDocument();
 		expect(getBoosterQueue).toHaveBeenCalledTimes(1);
 		expect(getBoosterWork).not.toHaveBeenCalled();
-		expect(getBoosterWalletTransactions).not.toHaveBeenCalled();
+		expect(getBoosterWalletTransactions).toHaveBeenCalledTimes(1);
+		expect(screen.getAllByText(/Extras:/)[1].closest('td')).not.toHaveClass(
+			'whitespace-nowrap',
+		);
 
 		await userEvent.click(
 			screen.getAllByRole('button', { name: /^Aceitar$/i })[0],

--- a/apps/web/src/modules/booster-dashboard/presentation/overview/booster-dashboard-page.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/overview/booster-dashboard-page.tsx
@@ -5,6 +5,7 @@ import { formatCurrency } from '@/shared/format/currency';
 import {
 	getBoosterQueue,
 	getBoosterWallet,
+	getBoosterWalletTransactions,
 	getBoosterWork,
 } from '../../actions/booster-actions';
 import {
@@ -17,7 +18,10 @@ import {
 	type BoosterDashboardTab,
 	DEFAULT_BOOSTER_DASHBOARD_TAB,
 } from '../../model/booster-tabs';
-import type { BoosterWalletOutput } from '../../server/booster-contracts';
+import type {
+	BoosterWalletOutput,
+	BoosterWalletTransactionsOutput,
+} from '../../server/booster-contracts';
 import { BoosterDashboardLiveRefresh } from './booster-dashboard-live-refresh';
 import { BoosterOrderList } from './booster-order-list';
 import { WalletPanel } from './wallet-panel';
@@ -38,6 +42,7 @@ type BoosterDashboardSummaryProps =
 
 type BoosterQueueViewModel = BoosterQueue & {
 	wallet: BoosterWalletOutput;
+	transactions: BoosterWalletTransactionsOutput['transactions'];
 };
 
 const BoosterDashboardSummary = ({
@@ -112,7 +117,7 @@ const BoosterQueueView = ({ queue }: { queue: BoosterQueueViewModel }) => (
 				mode="available"
 				orders={queue.availableOrders}
 			/>
-			<WalletPanel wallet={queue.wallet} />
+			<WalletPanel wallet={queue.wallet} transactions={queue.transactions} />
 		</div>
 	</div>
 );
@@ -152,16 +157,19 @@ export const BoosterDashboardPage = async ({
 		);
 	}
 
-	const [queueOutput, wallet] = await Promise.all([
+	const [queueOutput, wallet, transactions] = await Promise.all([
 		getBoosterQueue(),
 		getBoosterWallet(),
+		getBoosterWalletTransactions(),
 	]);
 	const queue = toBoosterQueue(queueOutput);
 
 	return (
 		<DashboardEntrance>
 			<BoosterDashboardLiveRefresh />
-			<BoosterQueueView queue={{ ...queue, wallet }} />
+			<BoosterQueueView
+				queue={{ ...queue, wallet, transactions: transactions.transactions }}
+			/>
 		</DashboardEntrance>
 	);
 };

--- a/apps/web/src/modules/booster-dashboard/presentation/overview/booster-order-list.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/overview/booster-order-list.tsx
@@ -137,7 +137,7 @@ const BoosterOrderSummary = ({
 			desiredLeague={order.desiredLeague}
 			desiredDivision={order.desiredDivision}
 		/>
-		<p className="text-white/55">
+		<p className="break-words text-white/55">
 			{order.summonerName ?? 'Invocador não informado'} ·{' '}
 			{order.server ?? 'Servidor não informado'} ·{' '}
 			{order.desiredQueue ?? 'Fila não informada'}
@@ -146,7 +146,7 @@ const BoosterOrderSummary = ({
 			{order.currentLp ?? '—'} PDL · ganho estimado de {order.lpGain ?? '—'} PDL
 		</p>
 		{order.extras?.length ? (
-			<p className="text-white/45">
+			<p className="break-words text-white/45">
 				Extras:{' '}
 				{order.extras.map((extra) => getExtraLabel(extra.type)).join(', ')}
 			</p>
@@ -222,7 +222,7 @@ const BoosterOrderRow = ({
 				</div>
 			</div>
 		</TableCell>
-		<TableCell className="font-bold text-white/70 whitespace-nowrap">
+		<TableCell className="font-bold text-white/70">
 			{mode === 'available' ? (
 				<BoosterOrderSummary order={order} />
 			) : (

--- a/apps/web/src/modules/booster-dashboard/presentation/overview/withdrawal-form.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/overview/withdrawal-form.tsx
@@ -36,6 +36,19 @@ export const WithdrawalForm = ({ maxAmount }: WithdrawalFormProps) => {
 					disabled={maxAmount <= 0 || isPending}
 				/>
 			</div>
+			<div className="space-y-2">
+				<Label htmlFor="withdrawal-pix-key">Chave PIX para recebimento</Label>
+				<Input
+					id="withdrawal-pix-key"
+					name="payoutPixKey"
+					type="text"
+					maxLength={255}
+					autoComplete="off"
+					required
+					placeholder="CPF, e-mail, telefone ou chave aleatória"
+					disabled={maxAmount <= 0 || isPending}
+				/>
+			</div>
 			<Button
 				type="submit"
 				variant="secondary"

--- a/apps/web/src/modules/booster-dashboard/presentation/overview/withdrawal-form.tsx
+++ b/apps/web/src/modules/booster-dashboard/presentation/overview/withdrawal-form.tsx
@@ -19,6 +19,10 @@ export const WithdrawalForm = ({ maxAmount }: WithdrawalFormProps) => {
 
 	return (
 		<form action={formAction} className="space-y-3">
+			<p className="text-[10px] leading-relaxed text-white/40">
+				Sem valor mínimo. Saques usam apenas o saldo disponível; valores
+				bloqueados são liberados na data indicada abaixo.
+			</p>
 			<div className="space-y-2">
 				<Label htmlFor="withdrawal-amount">Valor do saque</Label>
 				<Input

--- a/apps/web/src/modules/booster-dashboard/server/booster-contracts.ts
+++ b/apps/web/src/modules/booster-dashboard/server/booster-contracts.ts
@@ -43,6 +43,12 @@ export const acceptBoosterOrderSchema = z.object({
 	deadline: z.string().datetime({ offset: true }),
 });
 
+export const orderCredentialsSchema = z.object({
+	login: z.string(),
+	summonerName: z.string(),
+	password: z.string(),
+});
+
 export const boosterWalletSchema = z.object({
 	boosterId: z.string(),
 	balanceLocked: z.number().nonnegative(),
@@ -72,6 +78,7 @@ export const withdrawalRequestSchema = z.object({
 export type BoosterQueueOutput = z.infer<typeof boosterQueueSchema>;
 export type BoosterWorkOutput = z.infer<typeof boosterWorkSchema>;
 export type BoosterOrderOutput = z.infer<typeof boosterOrderSchema>;
+export type OrderCredentialsOutput = z.infer<typeof orderCredentialsSchema>;
 export type BoosterWalletOutput = z.infer<typeof boosterWalletSchema>;
 export type BoosterWalletTransactionOutput = z.infer<
 	typeof boosterWalletTransactionSchema

--- a/apps/web/src/modules/booster-dashboard/server/booster-contracts.ts
+++ b/apps/web/src/modules/booster-dashboard/server/booster-contracts.ts
@@ -73,6 +73,7 @@ export const boosterWalletTransactionsSchema = z.object({
 
 export const withdrawalRequestSchema = z.object({
 	amount: z.number().positive(),
+	payoutPixKey: z.string().trim().min(1).max(255),
 });
 
 export type BoosterQueueOutput = z.infer<typeof boosterQueueSchema>;

--- a/apps/web/src/modules/booster-dashboard/server/booster-service.ts
+++ b/apps/web/src/modules/booster-dashboard/server/booster-service.ts
@@ -140,7 +140,7 @@ export const requestBoosterWithdrawal = async (
 		method: 'POST',
 		body: JSON.stringify({
 			amount: body.amount,
-			requestedAt: new Date().toISOString(),
+			payoutPixKey: body.payoutPixKey,
 		}),
 	});
 };

--- a/apps/web/src/modules/booster-dashboard/server/booster-service.ts
+++ b/apps/web/src/modules/booster-dashboard/server/booster-service.ts
@@ -1,4 +1,5 @@
 import { ApiRequestError } from '@/shared/api-client-management/http';
+import type { OrderCredentialsOutput } from './booster-contracts';
 import {
 	acceptBoosterOrderSchema,
 	type BoosterQueueOutput,
@@ -9,6 +10,7 @@ import {
 	boosterWalletSchema,
 	boosterWalletTransactionsSchema,
 	boosterWorkSchema,
+	orderCredentialsSchema,
 	withdrawalRequestSchema,
 } from './booster-contracts';
 
@@ -112,6 +114,18 @@ export const completeBoosterOrder = async (
 		auth: true,
 		method: 'POST',
 	});
+};
+
+export const revealBoosterOrderCredentials = async (
+	orderId: string,
+	apiRequest: AuthenticatedApiRequest,
+): Promise<OrderCredentialsOutput> => {
+	const response = await apiRequest<unknown>(
+		`/orders/${encodeURIComponent(orderId)}/credentials/reveal`,
+		{ auth: true },
+	);
+
+	return orderCredentialsSchema.parse(response);
 };
 
 export const requestBoosterWithdrawal = async (

--- a/apps/web/src/modules/client-dashboard/actions/order-actions.ts
+++ b/apps/web/src/modules/client-dashboard/actions/order-actions.ts
@@ -7,15 +7,8 @@ import { ApiRequestError } from '@/shared/api-client-management/http';
 import { getCheckoutErrorMessage } from '@/shared/api-client-management/user-messages';
 import { redirectOnAuthError } from '@/shared/auth/redirect-on-auth-error';
 import { getAuthSession } from '@/shared/auth/session';
-import {
-	type ChatMessageOutput,
-	type ListChatMessagesResponseOutput,
-	sendChatMessageInputSchema,
-} from '@/shared/chat/chat-contracts';
-import {
-	listOrderChatMessages,
-	sendOrderChatMessage,
-} from '@/shared/chat/chat-service';
+import type { ListChatMessagesResponseOutput } from '@/shared/chat/chat-contracts';
+import { listOrderChatMessages } from '@/shared/chat/chat-service';
 import { assertSameOriginRequest } from '@/shared/security/origin';
 import {
 	getClientDashboardOrders as getClientDashboardOrdersFromApi,
@@ -246,52 +239,6 @@ export const getOrderChatMessages = async (
 			return { items: [], nextCursor: null };
 
 		return redirectOnAuthError(error);
-	}
-};
-
-export type SendOrderChatMessageActionState =
-	| {
-			message: ChatMessageOutput;
-			error?: never;
-	  }
-	| {
-			error: string;
-			message?: never;
-	  };
-
-export const sendOrderChatMessageAction = async (
-	orderId: string,
-	content: string,
-): Promise<SendOrderChatMessageActionState> => {
-	const parsed = sendChatMessageInputSchema.safeParse({ content });
-	if (!parsed.success) {
-		return { error: parsed.error.issues[0]?.message ?? 'Mensagem inválida.' };
-	}
-
-	try {
-		const session = await getAuthSession();
-		if (!session) return { error: 'Sessão expirada. Entre novamente.' };
-
-		await assertSameOriginRequest();
-		return {
-			message: await sendOrderChatMessage(orderId, parsed.data, api.request),
-		};
-	} catch (error) {
-		if (
-			error instanceof ApiRequestError &&
-			(error.status === 401 || error.status === 403)
-		) {
-			return { error: 'Entre novamente para continuar.' };
-		}
-
-		if (error instanceof ApiRequestError && error.status === 409) {
-			return {
-				error:
-					'Este chat não está disponível para envio de mensagens neste status.',
-			};
-		}
-
-		return { error: 'Não foi possível enviar a mensagem.' };
 	}
 };
 

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-live.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-live.spec.tsx
@@ -1,0 +1,119 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OrderChatPanel } from './order-chat-panel';
+
+type Listener = (payload?: unknown) => void;
+
+class SocketStub {
+	readonly listeners = new Map<string, Listener>();
+	readonly emitted: Array<[string, unknown]> = [];
+	connected = true;
+
+	on(event: string, listener: Listener) {
+		this.listeners.set(event, listener);
+		return this;
+	}
+
+	off(event: string) {
+		this.listeners.delete(event);
+		return this;
+	}
+
+	emit(event: string, payload: unknown) {
+		this.emitted.push([event, payload]);
+		return this;
+	}
+
+	close() {}
+
+	trigger(event: string, payload?: unknown) {
+		this.listeners.get(event)?.(payload);
+	}
+}
+
+const socket = new SocketStub();
+const refresh = jest.fn();
+
+jest.mock('next/navigation', () => ({
+	useRouter: () => ({ refresh }),
+}));
+
+jest.mock('socket.io-client', () => ({
+	io: jest.fn(() => socket),
+}));
+
+describe('OrderChatPanel live updates', () => {
+	beforeEach(() => {
+		refresh.mockClear();
+		socket.emitted.length = 0;
+		socket.listeners.clear();
+	});
+
+	it('shows a message broadcast by the order chat socket without a refresh', () => {
+		render(
+			<OrderChatPanel
+				currentUserId="client-1"
+				initialMessages={[]}
+				orderId="order-1"
+				orderStatus="in_progress"
+			/>,
+		);
+
+		act(() => {
+			socket.trigger('chat:message.created', {
+				id: 'message-1',
+				orderId: 'order-1',
+				chatId: 'chat-1',
+				content: 'Mensagem ao vivo',
+				sender: {
+					id: 'booster-1',
+					username: 'Booster',
+					role: 'BOOSTER',
+				},
+				createdAt: '2026-08-04T01:25:43.000Z',
+			});
+		});
+
+		expect(screen.getByText('Mensagem ao vivo')).toBeInTheDocument();
+	});
+
+	it('sends messages through the order chat socket', async () => {
+		render(
+			<OrderChatPanel
+				currentUserId="client-1"
+				initialMessages={[]}
+				orderId="order-1"
+				orderStatus="in_progress"
+			/>,
+		);
+
+		await userEvent.type(
+			screen.getByRole('textbox', { name: 'Mensagem do chat' }),
+			'Olá booster',
+		);
+		await userEvent.click(
+			screen.getByRole('button', { name: 'Enviar mensagem' }),
+		);
+
+		expect(socket.emitted).toContainEqual([
+			'chat:send',
+			{ orderId: 'order-1', content: 'Olá booster' },
+		]);
+	});
+
+	it('refreshes missed history after reconnecting', () => {
+		render(
+			<OrderChatPanel
+				currentUserId="client-1"
+				initialMessages={[]}
+				orderId="order-1"
+				orderStatus="in_progress"
+			/>,
+		);
+
+		act(() => socket.trigger('connect'));
+		act(() => socket.trigger('connect'));
+
+		expect(refresh).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-live.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-live.spec.tsx
@@ -47,6 +47,7 @@ describe('OrderChatPanel live updates', () => {
 		refresh.mockClear();
 		socket.emitted.length = 0;
 		socket.listeners.clear();
+		socket.connected = true;
 	});
 
 	it('shows a message broadcast by the order chat socket without a refresh', () => {
@@ -99,6 +100,40 @@ describe('OrderChatPanel live updates', () => {
 			'chat:send',
 			{ orderId: 'order-1', content: 'Olá booster' },
 		]);
+	});
+
+	it('re-enables sending when the socket disconnects before confirmation', async () => {
+		render(
+			<OrderChatPanel
+				currentUserId="client-1"
+				initialMessages={[]}
+				orderId="order-1"
+				orderStatus="in_progress"
+			/>,
+		);
+
+		await userEvent.type(
+			screen.getByRole('textbox', { name: 'Mensagem do chat' }),
+			'Mensagem interrompida',
+		);
+		await userEvent.click(
+			screen.getByRole('button', { name: 'Enviar mensagem' }),
+		);
+		expect(
+			screen.getByRole('button', { name: 'Enviar mensagem' }),
+		).toBeDisabled();
+
+		act(() => {
+			socket.connected = false;
+			socket.trigger('disconnect');
+		});
+
+		expect(
+			screen.getByRole('textbox', { name: 'Mensagem do chat' }),
+		).toBeEnabled();
+		expect(
+			screen.getByText('A conexão caiu antes da confirmação da mensagem.'),
+		).toBeInTheDocument();
 	});
 
 	it('refreshes missed history after reconnecting', () => {

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-panel.spec.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-panel.spec.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { OrderChatPanel } from './order-chat-panel';
 
+jest.mock('next/navigation', () => ({
+	useRouter: () => ({ refresh: jest.fn() }),
+}));
+
 jest.mock('@/shared/chat/chat-panel', () => ({
 	ChatPanel: ({
 		isDisabled,
@@ -19,10 +23,6 @@ jest.mock('@/shared/chat/chat-panel', () => ({
 			{statusText}
 		</div>
 	),
-}));
-
-jest.mock('../../actions/order-actions', () => ({
-	sendOrderChatMessageAction: jest.fn(),
 }));
 
 const renderPanel = (orderStatus: string) =>

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-panel.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-chat-panel.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useCallback, useState, useTransition } from 'react';
 import type { ChatMessage } from '@/shared/chat/chat.types';
 import { ChatPanel } from '@/shared/chat/chat-panel';
-import { sendOrderChatMessageAction } from '../../actions/order-actions';
+import { useLiveOrderChat } from '@/shared/chat/use-live-order-chat';
 import { orderDetailsLayout } from './order-details-layout';
 import { getOrderStageCopy, isReadOnlyOrderStatus } from './order-stage-copy';
 
@@ -32,39 +31,22 @@ export const OrderChatPanel = ({
 	currentUserId,
 	initialMessages,
 }: OrderChatPanelProps) => {
-	const [messages, setMessages] = useState(initialMessages);
-	const [error, setError] = useState<string | null>(null);
-	const [isPending, startTransition] = useTransition();
 	const isReadOnly = isReadOnlyOrderStatus(orderStatus);
-	const isDisabled = orderStatus !== 'in_progress' || isPending;
 	const copy = getOrderStageCopy(orderStatus);
-
-	const handleSendMessage = useCallback(
-		(content: string) => {
-			setError(null);
-			startTransition(async () => {
-				const result = await sendOrderChatMessageAction(orderId, content);
-				if (result.error) {
-					setError(result.error);
-					return;
-				}
-				const nextMessage = result.message;
-				if (!nextMessage) return;
-
-				setMessages((currentMessages) => [...currentMessages, nextMessage]);
-			});
-		},
-		[orderId],
-	);
+	const { isSending, liveError, messages, sendMessage } = useLiveOrderChat({
+		orderId,
+		initialMessages,
+		enabled: orderStatus === 'in_progress',
+	});
 
 	return (
 		<div className="space-y-2">
 			<ChatPanel
 				messages={messages}
 				currentUserId={currentUserId}
-				onSendMessage={handleSendMessage}
-				isSending={isPending}
-				isDisabled={isDisabled}
+				onSendMessage={sendMessage}
+				isSending={isSending}
+				isDisabled={orderStatus !== 'in_progress' || isSending}
 				isReadOnly={isReadOnly}
 				title="Chat do pedido"
 				statusText={copy.chatStatus}
@@ -72,9 +54,9 @@ export const OrderChatPanel = ({
 				emptyDescription={getEmptyDescription(orderStatus)}
 				className={orderDetailsLayout.chat}
 			/>
-			{error ? (
+			{liveError ? (
 				<p className="text-[10px] font-bold uppercase tracking-wider text-red-400">
-					{error}
+					{liveError}
 				</p>
 			) : null}
 		</div>

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-live-refresh.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-live-refresh.tsx
@@ -2,16 +2,8 @@
 
 import { useDashboardEvents } from '@/shared/dashboard/use-dashboard-events';
 
-const orderDetailsEvents = [
-	'order.paid',
-	'order.accepted',
-	'order.rejected',
-	'order.completed',
-	'order.cancelled',
-] as const;
-
 export const OrderDetailsLiveRefresh = () => {
-	useDashboardEvents({ events: orderDetailsEvents });
+	useDashboardEvents();
 
 	return null;
 };

--- a/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/order-details/order-details-page.tsx
@@ -99,11 +99,11 @@ export const OrderDetailsPage = async ({ orderId }: OrderDetailsPageProps) => {
 				{chatPanel}
 
 				<div className={orderDetailsLayout.rail}>
+					{ratingCard}
 					<OrderServiceCard order={order} />
 					<OrderBoosterCard booster={order.booster} />
 					<OrderActivityCard />
 					<OrderSupportCard orderId={order.id} />
-					{ratingCard}
 				</div>
 			</div>
 		</div>

--- a/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-live-refresh.tsx
+++ b/apps/web/src/modules/client-dashboard/presentation/overview/client-dashboard-live-refresh.tsx
@@ -2,16 +2,8 @@
 
 import { useDashboardEvents } from '@/shared/dashboard/use-dashboard-events';
 
-const clientDashboardEvents = [
-	'order.paid',
-	'order.accepted',
-	'order.rejected',
-	'order.completed',
-	'order.cancelled',
-] as const;
-
 export const ClientDashboardLiveRefresh = () => {
-	useDashboardEvents({ events: clientDashboardEvents });
+	useDashboardEvents();
 
 	return null;
 };

--- a/apps/web/src/shared/chat/chat-service.ts
+++ b/apps/web/src/shared/chat/chat-service.ts
@@ -1,10 +1,6 @@
 import {
-	type ChatMessageOutput,
-	chatMessageSchema,
 	type ListChatMessagesResponseOutput,
 	listChatMessagesResponseSchema,
-	type SendChatMessageInput,
-	sendChatMessageInputSchema,
 } from './chat-contracts';
 
 export type AuthenticatedApiRequest = <T>(
@@ -40,22 +36,4 @@ export const listAdminOrderChatMessages = async (
 	);
 
 	return listChatMessagesResponseSchema.parse(response);
-};
-
-export const sendOrderChatMessage = async (
-	orderId: string,
-	input: SendChatMessageInput,
-	apiRequest: AuthenticatedApiRequest,
-): Promise<ChatMessageOutput> => {
-	const body = sendChatMessageInputSchema.parse(input);
-	const response = await apiRequest<unknown>(
-		getOrderChatMessagesPath(orderId),
-		{
-			auth: true,
-			method: 'POST',
-			body: JSON.stringify(body),
-		},
-	);
-
-	return chatMessageSchema.parse(response);
 };

--- a/apps/web/src/shared/chat/use-live-order-chat.ts
+++ b/apps/web/src/shared/chat/use-live-order-chat.ts
@@ -26,6 +26,7 @@ export const useLiveOrderChat = ({
 	const [messages, setMessages] = useState(initialMessages);
 	const [liveError, setLiveError] = useState<string | null>(null);
 	const [isSending, setIsSending] = useState(false);
+	const isSendingRef = useRef(false);
 	const socketRef = useRef<Socket | null>(null);
 	const hasConnected = useRef(false);
 	const router = useRouter();
@@ -64,22 +65,32 @@ export const useLiveOrderChat = ({
 			const parsed = chatMessageSchema.safeParse(payload);
 			if (!parsed.success || parsed.data.orderId !== orderId) return;
 			appendMessage(parsed.data);
+			isSendingRef.current = false;
 			setIsSending(false);
 		};
 		const handleError = () => {
+			isSendingRef.current = false;
 			setIsSending(false);
 			setLiveError('Não foi possível atualizar o chat em tempo real.');
+		};
+		const handleDisconnect = () => {
+			if (!isSendingRef.current) return;
+			isSendingRef.current = false;
+			setIsSending(false);
+			setLiveError('A conexão caiu antes da confirmação da mensagem.');
 		};
 
 		socket.on('connect', join);
 		socket.on('chat:message.created', receive);
 		socket.on('chat:error', handleError);
+		socket.on('disconnect', handleDisconnect);
 
 		return () => {
 			socketRef.current = null;
 			socket.off('connect', join);
 			socket.off('chat:message.created', receive);
 			socket.off('chat:error', handleError);
+			socket.off('disconnect', handleDisconnect);
 			socket.close();
 		};
 	}, [appendMessage, enabled, orderId, router]);
@@ -93,6 +104,7 @@ export const useLiveOrderChat = ({
 			}
 
 			setLiveError(null);
+			isSendingRef.current = true;
 			setIsSending(true);
 			socketRef.current.emit('chat:send', { orderId, ...parsed.data });
 		},

--- a/apps/web/src/shared/chat/use-live-order-chat.ts
+++ b/apps/web/src/shared/chat/use-live-order-chat.ts
@@ -1,0 +1,103 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { io, type Socket } from 'socket.io-client';
+import { getPublicApiBaseUrl } from '@/shared/env/public-env';
+import type { ChatMessage } from './chat.types';
+import {
+	chatMessageSchema,
+	sendChatMessageInputSchema,
+} from './chat-contracts';
+
+const CHAT_NAMESPACE = '/chat';
+
+type UseLiveOrderChatInput = {
+	orderId: string;
+	initialMessages: ChatMessage[];
+	enabled: boolean;
+};
+
+export const useLiveOrderChat = ({
+	orderId,
+	initialMessages,
+	enabled,
+}: UseLiveOrderChatInput) => {
+	const [messages, setMessages] = useState(initialMessages);
+	const [liveError, setLiveError] = useState<string | null>(null);
+	const [isSending, setIsSending] = useState(false);
+	const socketRef = useRef<Socket | null>(null);
+	const hasConnected = useRef(false);
+	const router = useRouter();
+
+	const appendMessage = useCallback((message: ChatMessage) => {
+		setMessages((current) =>
+			current.some(({ id }) => id === message.id)
+				? current
+				: [...current, message],
+		);
+	}, []);
+
+	useEffect(() => {
+		setMessages((current) => [
+			...current,
+			...initialMessages.filter(
+				(message) => !current.some(({ id }) => id === message.id),
+			),
+		]);
+	}, [initialMessages]);
+
+	useEffect(() => {
+		if (!enabled) return;
+
+		const socket = io(`${getPublicApiBaseUrl()}${CHAT_NAMESPACE}`, {
+			withCredentials: true,
+			transports: ['websocket', 'polling'],
+		});
+		socketRef.current = socket;
+		const join = () => {
+			socket.emit('chat:join', { orderId });
+			if (hasConnected.current) router.refresh();
+			hasConnected.current = true;
+		};
+		const receive = (payload: unknown) => {
+			const parsed = chatMessageSchema.safeParse(payload);
+			if (!parsed.success || parsed.data.orderId !== orderId) return;
+			appendMessage(parsed.data);
+			setIsSending(false);
+		};
+		const handleError = () => {
+			setIsSending(false);
+			setLiveError('Não foi possível atualizar o chat em tempo real.');
+		};
+
+		socket.on('connect', join);
+		socket.on('chat:message.created', receive);
+		socket.on('chat:error', handleError);
+
+		return () => {
+			socketRef.current = null;
+			socket.off('connect', join);
+			socket.off('chat:message.created', receive);
+			socket.off('chat:error', handleError);
+			socket.close();
+		};
+	}, [appendMessage, enabled, orderId, router]);
+
+	const sendMessage = useCallback(
+		(content: string) => {
+			const parsed = sendChatMessageInputSchema.safeParse({ content });
+			if (!parsed.success || !socketRef.current?.connected) {
+				setLiveError('Não foi possível enviar a mensagem.');
+				return;
+			}
+
+			setLiveError(null);
+			setIsSending(true);
+			socketRef.current.emit('chat:send', { orderId, ...parsed.data });
+		},
+		[orderId],
+	);
+
+	return { isSending, liveError, messages, sendMessage };
+};

--- a/apps/web/src/shared/dashboard/use-dashboard-events.spec.tsx
+++ b/apps/web/src/shared/dashboard/use-dashboard-events.spec.tsx
@@ -41,7 +41,7 @@ class EventSourceStub {
 }
 
 const TestDashboardEvents = () => {
-	useDashboardEvents({ events: ['order.paid'] });
+	useDashboardEvents();
 
 	return null;
 };
@@ -72,6 +72,16 @@ describe('useDashboardEvents', () => {
 
 		expect(refresh).toHaveBeenCalledTimes(1);
 		expect(eventSource?.url).toBe('/api/orders/events');
+	});
+
+	it('refreshes when saved credentials make an order available', () => {
+		render(<TestDashboardEvents />);
+		const eventSource = EventSourceStub.instances[0];
+
+		eventSource?.emit('order.credentials_saved');
+		jest.advanceTimersByTime(500);
+
+		expect(refresh).toHaveBeenCalledTimes(1);
 	});
 
 	it('closes the stream on unmount', () => {

--- a/apps/web/src/shared/dashboard/use-dashboard-events.ts
+++ b/apps/web/src/shared/dashboard/use-dashboard-events.ts
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react';
 
 const ORDER_EVENT_TYPES = [
 	'order.paid',
+	'order.credentials_saved',
 	'order.accepted',
 	'order.rejected',
 	'order.completed',

--- a/apps/web/src/shared/ratings/rating-card.tsx
+++ b/apps/web/src/shared/ratings/rating-card.tsx
@@ -23,7 +23,7 @@ type RatingCardProps = {
 	className?: string;
 };
 
-const Stars = ({ score }: { score: number }) => (
+export const RatingStars = ({ score }: { score: number }) => (
 	<div className="flex gap-1.5" role="img" aria-label={`${score} de 5`}>
 		{[1, 2, 3, 4, 5].map((value) => (
 			<Star
@@ -64,7 +64,7 @@ export const RatingCard = ({
 						<p className="text-[10px] uppercase tracking-widest text-white/40">
 							Você avaliou este pedido
 						</p>
-						<Stars score={submitted.score} />
+						<RatingStars score={submitted.score} />
 						{submitted.comment ? (
 							<p className="text-sm leading-relaxed text-white/70">
 								{submitted.comment}

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -5,6 +5,8 @@
 - Order chat and messages
 - Support tickets and messages
 - Notification metadata referencing user activity
+- Withdrawal payout PIX keys, which may contain a CPF, CNPJ, phone number,
+  email address, or random EVP key
 
 Order credentials follow the product credential lifecycle in
 `docs/requirements.md`.
@@ -22,6 +24,10 @@ destroyed.
 - Attachments are not supported.
 - Clients and boosters access only their own records.
 - Admin access exists for support, moderation, and governance.
+- Withdrawal PIX keys remain attached to financial ledger records, are visible
+  only to admins for payout operations, and are not returned in the booster's
+  general transaction history.
+- No automatic withdrawal PIX-key retention or erasure window is implemented.
 - Authorization is enforced by the API.
 
 ## Forbidden handling

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -48,6 +48,8 @@ Web platform for operating League of Legends boosting services with a marketplac
 - FR-032: `Account Credentials` are stored only after payment confirmation.
 - FR-033: `Account Credentials` are deleted when payment is not confirmed.
 - FR-034: `Account Credentials` are permanently deleted after service finalization.
+- FR-080: The booster wallet shows each locked credit's release date and makes
+  clear that withdrawals have no minimum but use only the available balance.
 
 ### 6. Service extras
 Priced extras:
@@ -69,6 +71,8 @@ Zero-cost extras:
 - FR-048: `Campeões Específicos`
 - FR-049: `Stream Online`
 - FR-050: Pricing modifiers are applied deterministically.
+- FR-081: Long extras lists remain readable without forcing the dashboard page
+  to scroll horizontally.
 
 ### 7. Coupons
 - FR-051: Admin can create coupons.
@@ -80,6 +84,8 @@ Zero-cost extras:
 - FR-055: Chat history is persisted.
 - FR-056: Notifications are in-platform only.
 - FR-057: Discord integration is currently out of scope.
+- FR-082: New chat messages appear for both participants without a manual page
+  refresh, and reconnecting recovers persisted messages missed while offline.
 
 ### 9. Support tickets
 - FR-058: Ticketing system for user issues.
@@ -90,6 +96,8 @@ Zero-cost extras:
 - FR-061: Clients can rate boosters.
 - FR-062: Boosters can rate clients.
 - FR-063: Admin-defined reputation/achievement rules are supported, including booster scoring and badge/medal milestones.
+- FR-083: Completed-order details place the rating action first, and admins can
+  inspect both participants' submitted ratings from every order detail page.
 
 ### 11. Admin control
 - FR-064: Admin financial dashboard.
@@ -105,6 +113,11 @@ Zero-cost extras:
   admin cannot change their own account type.
 - FR-079: The booster defines the delivery deadline when accepting an order.
   The deadline currently has no maximum duration.
+- FR-084: Saving credentials after payment immediately makes an otherwise
+  eligible order appear in the booster queue without a manual refresh.
+- FR-085: Full account credentials are never included in order listings or
+  details; only the assigned booster of an accepted, in-progress order can
+  explicitly reveal them on demand through the audited reveal path.
 
 ### 12. Chargebacks
 - FR-068: Chargeback-associated users are blocked.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -50,6 +50,9 @@ Web platform for operating League of Legends boosting services with a marketplac
 - FR-034: `Account Credentials` are permanently deleted after service finalization.
 - FR-080: The booster wallet shows each locked credit's release date and makes
   clear that withdrawals have no minimum but use only the available balance.
+- FR-081: A new withdrawal requires the booster's payout PIX key, and admins
+  can see the 25 most recent requests with their booster, amount, timestamp,
+  and PIX key when one was collected.
 
 ### 6. Service extras
 Priced extras:

--- a/packages/database/prisma/migrations/20260808043301_add_withdrawal_pix_key/migration.sql
+++ b/packages/database/prisma/migrations/20260808043301_add_withdrawal_pix_key/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "wallet_transactions" ADD COLUMN     "payout_pix_key" TEXT;

--- a/packages/database/prisma/migrations/20260808050458_index_withdrawal_requests/migration.sql
+++ b/packages/database/prisma/migrations/20260808050458_index_withdrawal_requests/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "wallet_transactions_reason_createdAt_idx" ON "wallet_transactions"("reason", "createdAt");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -336,12 +336,14 @@ model WalletTransaction {
   amount      Int
   type        WalletTransactionType
   reason      String
+  payoutPixKey String?               @map("payout_pix_key")
   availableAt DateTime
   releasedAt  DateTime?
   releasedBy  WalletTransactionReleaseSource?
   createdAt   DateTime              @default(now())
 
   @@index([walletId, createdAt])
+  @@index([reason, createdAt])
   @@map("wallet_transactions")
 }
 


### PR DESCRIPTION
## Summary
- refresh booster/client dashboards when saved credentials change order eligibility
- use the existing Socket.IO chat gateway for live send/receive and reconnect recovery
- add audited on-demand credential reveal, wrap long extras, and surface wallet unlock dates
- place ratings first on completed orders and expose read-only ratings to admins

## Verification
- `pnpm biome:check:all`
- API and web TypeScript checks
- API unit: 89 suites / 412 tests
- web unit: 46 suites / 152 tests
- API integration: 10 suites / 37 tests
- API orders E2E: 41 tests
- database integration: orders/ratings passed; full run had one users timeout that passed alone on rerun
- ratings database E2E: 3 tests
- API and web production builds
- Playwright dashboard E2E skipped at operator request

Closes #121
Addresses #118

Follow-ups remain tracked in #107 and #76.